### PR TITLE
Allow to create a file with pre-calculated SHA1

### DIFF
--- a/spdx/file.py
+++ b/spdx/file.py
@@ -49,12 +49,12 @@ class File(object):
     artifact_of_project_uri - list of project uris, possibly empty.
     """
 
-    def __init__(self, name):
+    def __init__(self, name, chk_sum = None):
         super(File, self).__init__()
         self.name = name
         self.comment = None
         self.type = None
-        self.chk_sum = None
+        self.chk_sum = chk_sum
         self.conc_lics = None
         self.licenses_in_file = []
         self.license_comment = None

--- a/spdx/package.py
+++ b/spdx/package.py
@@ -192,7 +192,12 @@ class Package(object):
         hashes = []
 
         for file_entry in self.files:
-            hashes.append(file_entry.calc_chksum())
+            if isinstance(file_entry.chk_sum, checksum.Algorithm) and
+               file_entry.chk_sum.identifier == 'SHA1':
+                sha1 = file_entry.chk_sum.value
+            else:
+                sha1 = file_entry.calc_chksum()
+            hashes.append(sha1)
 
         hashes.sort()
 


### PR DESCRIPTION
And use a file's SHA1, if present, in package verification code
calculation.