### PR TITLE
Add transparent pytest support

### DIFF
--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -16,7 +16,7 @@ from __future__ import print_function
 import unittest
 from unittest import TestCase
 
-import testing_utils
+import tests.testing_utils as testing_utils
 
 from spdx.document import Document, License
 import spdx.parsers.tagvaluebuilders as builders


### PR DESCRIPTION
Before:

```
./configure
source ./bin/activate
pip install pytest pytest-cov pytest-xdist
pytest --cov=spdx tests
```

Results in `spdx` not found, then `test_utils` not found

After:

The command sequence above runs fine and reports coverage

Signed-off-by: Aleksandr Lisianoi <all3fox@gmail.com>