### PR TITLE
Fix build failure for Travis and Appveyor #36

### DIFF
--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -188,7 +188,7 @@ class TestWriters(TestCase):
         try:
             temp_dir = tempfile.mkdtemp(prefix='test_spdx')
             result_file = os.path.join(temp_dir, 'spdx-simple.tv')
-            with open(result_file, 'wb') as output:
+            with open(result_file, 'w') as output:
                 write_document(doc, output, validate=True)
 
             expected_file = utils_test.get_test_loc(
@@ -211,7 +211,7 @@ class TestWriters(TestCase):
             result_file = os.path.join(temp_dir, 'spdx-simple-plus.tv')
 
             # test proper!
-            with open(result_file, 'wb') as output:
+            with open(result_file, 'w') as output:
                 write_document(doc, output, validate=True)
 
             expected_file = utils_test.get_test_loc(


### PR DESCRIPTION
Python3 returns 'bytes' and not 'str' when reading/writing
to/from a binary stream. So, the files need to be opened in
text mode for `str` related operations.

Signed-off-by: Yash Nisar <yash.nisar@somaiya.edu>

Closes https://github.com/spdx/tools-python/issues/36