### PR TITLE
Report an error when `UNKNOWN_TAG` is found #55

### DIFF
--- a/spdx/parsers/tagvalue.py
+++ b/spdx/parsers/tagvalue.py
@@ -266,7 +266,7 @@ class Parser(object):
         self.logger.log(msg)
 
     def p_uknown_tag(self, p):
-        """unknown_tag : UNKNOWN_TAG"""
+        """unknown_tag : UNKNOWN_TAG LINE"""
         self.error = True
         msg = ERROR_MESSAGES['UNKNOWN_TAG'].format(p[1], p.lineno(1))
         self.logger.log(msg)


### PR DESCRIPTION
The cause of the error was the method ​`p_unknown_tag`
in `parsers/tagvalue.py`. Due to the incorrect context-free grammar specification defined in the method, the line after the `unknown_tag` was not taken into consideration. The
context-free grammar specification was rectified and tests
were corresponding tests were added.

Signed-off-by: Yash Nisar <yash.nisar@somaiya.edu>