### PR TITLE
Add 'Snippet' class as a part of the SPDX 2.1 specification

### DIFF
--- a/data/SPDXRdfExample.rdf
+++ b/data/SPDXRdfExample.rdf
@@ -4,10 +4,15 @@
     xmlns="http://spdx.org/rdf/terms#"
     xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">
   <Snippet rdf:about="http://spdx.org/spdxdocs/spdx-example-444504E0-4F89-41D3-9A0C-0305E82C3301#SPDXRef-Snippet">
+    <snippetFromFile>
+      <File rdf:about="http://spdx.org/spdxdocs/spdx-example-444504E0-4F89-41D3-9A0C-0305E82C3301#SPDXRef-DoapSource"/>
+    </snippetFromFile>
     <name>from linux kernel</name>
     <copyrightText>Copyright 2008-2010 John Smith</copyrightText>
     <licenseComments>The concluded license was taken from package xyz, from which the snippet was copied into the current file. The concluded license information was found in the COPYING.txt file in package xyz.</licenseComments>
     <rdfs:comment>This snippet was identified as significant and highlighted in this Apache-2.0 file, when a commercial scanner identified it as being derived from file foo.c in package xyz which is licensed under GPL-2.0-or-later.</rdfs:comment>
+    <licenseConcluded rdf:resource="http://spdx.org/licenses/Apache-2.0"/>
+    <licenseInfoInSnippet rdf:resource="http://spdx.org/licenses/Apache-2.0"/>
   </Snippet>
   <SpdxDocument rdf:about="http://www.spdx.org/tools#SPDXANALYSIS">
     <creationInfo>

--- a/data/SPDXRdfExample.rdf
+++ b/data/SPDXRdfExample.rdf
@@ -3,6 +3,12 @@
     xmlns:j.0="http://usefulinc.com/ns/doap#"
     xmlns="http://spdx.org/rdf/terms#"
     xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">
+  <Snippet rdf:about="http://spdx.org/spdxdocs/spdx-example-444504E0-4F89-41D3-9A0C-0305E82C3301#SPDXRef-Snippet">
+    <name>from linux kernel</name>
+    <copyrightText>Copyright 2008-2010 John Smith</copyrightText>
+    <licenseComments>The concluded license was taken from package xyz, from which the snippet was copied into the current file. The concluded license information was found in the COPYING.txt file in package xyz.</licenseComments>
+    <rdfs:comment>This snippet was identified as significant and highlighted in this Apache-2.0 file, when a commercial scanner identified it as being derived from file foo.c in package xyz which is licensed under GPL-2.0-or-later.</rdfs:comment>
+  </Snippet>
   <SpdxDocument rdf:about="http://www.spdx.org/tools#SPDXANALYSIS">
     <creationInfo>
       <CreationInfo>

--- a/data/SPDXTagExample.tag
+++ b/data/SPDXTagExample.tag
@@ -65,6 +65,12 @@ ArtifactOfProjectHomePage: http://www.openjena.org/
 ArtifactOfProjectURI: UNKNOWN
 FileComment: <text>This file belongs to Jena</text>
 
+## Snippet Information
+SnippetSPDXID: SPDXRef-Snippet
+SnippetLicenseComments: <text>The concluded license was taken from package xyz, from which the snippet was copied into the current file. The concluded license information was found in the COPYING.txt file in package xyz.</text>
+SnippetCopyrightText: <text> Copyright 2008-2010 John Smith </text>
+SnippetComment: <text>This snippet was identified as significant and highlighted in this Apache-2.0 file, when a commercial scanner identified it as being derived from file foo.c in package xyz which is licensed under GPL-2.0-or-later.</text>
+SnippetName: from linux kernel
 
 ## License Information
 LicenseID: LicenseRef-3

--- a/data/SPDXTagExample.tag
+++ b/data/SPDXTagExample.tag
@@ -67,10 +67,13 @@ FileComment: <text>This file belongs to Jena</text>
 
 ## Snippet Information
 SnippetSPDXID: SPDXRef-Snippet
+SnippetFromFileSPDXID: SPDXRef-DoapSource
 SnippetLicenseComments: <text>The concluded license was taken from package xyz, from which the snippet was copied into the current file. The concluded license information was found in the COPYING.txt file in package xyz.</text>
 SnippetCopyrightText: <text> Copyright 2008-2010 John Smith </text>
 SnippetComment: <text>This snippet was identified as significant and highlighted in this Apache-2.0 file, when a commercial scanner identified it as being derived from file foo.c in package xyz which is licensed under GPL-2.0-or-later.</text>
 SnippetName: from linux kernel
+SnippetLicenseConcluded: Apache-2.0
+LicenseInfoInSnippet: Apache-2.0
 
 ## License Information
 LicenseID: LicenseRef-3

--- a/spdx/document.py
+++ b/spdx/document.py
@@ -196,9 +196,11 @@ class Document(object):
       SPDX license list. Optional, many. Type: ExtractedLicense.
     - reviews: SPDX document review information, Optional zero or more.
       Type: Review.
+    - snippet: Snippet information. Optional zero or more. Type: Snippet.
     """
 
-    def __init__(self, version=None, data_license=None, comment=None, package=None):
+    def __init__(self, version=None, data_license=None, comment=None,
+                 package=None, snippet=None):
         # avoid recursive impor
         from spdx.creationinfo import CreationInfo
         self.version = version
@@ -208,12 +210,16 @@ class Document(object):
         self.package = package
         self.extracted_licenses = []
         self.reviews = []
+        self.snippet = []
 
     def add_review(self, review):
         self.reviews.append(review)
 
     def add_extr_lic(self, lic):
         self.extracted_licenses.append(lic)
+
+    def add_snippet(self, snip):
+        self.snippet.append(snip)
 
     @property
     def files(self):
@@ -241,6 +247,7 @@ class Document(object):
             and self.validate_package(messages)
             and self.validate_extracted_licenses(messages)
             and self.validate_reviews(messages)
+            and self.validate_snippet(messages)
         )
 
     def validate_version(self, messages=None):
@@ -275,6 +282,15 @@ class Document(object):
         valid = True
         for review in self.reviews:
             valid = review.validate(messages) and valid
+        return valid
+
+    def validate_snippet(self, messages=None):
+        # FIXME: messages should be returned
+        messages = messages if messages is not None else []
+
+        valid = True
+        for snippet in self.snippet:
+            valid = snippet.validate(messages) and valid
         return valid
 
     def validate_creation_info(self, messages=None):

--- a/spdx/parsers/lexers/tagvalue.py
+++ b/spdx/parsers/lexers/tagvalue.py
@@ -70,6 +70,12 @@ class Lexer(object):
         'LicenseName': 'LICS_NAME',
         'LicenseCrossReference': 'LICS_CRS_REF',
         'LicenseComment': 'LICS_COMMENT',
+        # Snippet
+        'SnippetSPDXID': 'SNIPPET_SPDX_ID',
+        'SnippetName': 'SNIPPET_NAME',
+        'SnippetComment': 'SNIPPET_COMMENT',
+        'SnippetCopyrightText': 'SNIPPET_CR_TEXT',
+        'SnippetLicenseComments': 'SNIPPET_LICS_COMMENT',
         # Common
         'NOASSERTION': 'NO_ASSERT',
         'UNKNOWN': 'UN_KNOWN',
@@ -94,8 +100,9 @@ class Lexer(object):
         r'</text>\s*'
         t.type = 'TEXT'
         t.value = t.lexer.lexdata[
-            t.lexer.text_start:t.lexer.lexpos].strip()
+                  t.lexer.text_start:t.lexer.lexpos]
         t.lexer.lineno += t.value.count('\n')
+        t.value = t.value.strip()
         t.lexer.begin('INITIAL')
         return t
 

--- a/spdx/parsers/lexers/tagvalue.py
+++ b/spdx/parsers/lexers/tagvalue.py
@@ -76,6 +76,9 @@ class Lexer(object):
         'SnippetComment': 'SNIPPET_COMMENT',
         'SnippetCopyrightText': 'SNIPPET_CR_TEXT',
         'SnippetLicenseComments': 'SNIPPET_LICS_COMMENT',
+        'SnippetFromFileSPDXID': 'SNIPPET_FILE_SPDXID',
+        'SnippetLicenseConcluded': 'SNIPPET_LICS_CONC',
+        'LicenseInfoInSnippet': 'SNIPPET_LICS_INFO',
         # Common
         'NOASSERTION': 'NO_ASSERT',
         'UNKNOWN': 'UN_KNOWN',

--- a/spdx/parsers/rdf.py
+++ b/spdx/parsers/rdf.py
@@ -49,6 +49,9 @@ ERROR_MESSAGES = {
     'REVIEW_DATE' : 'Invalid review date value \'{0}\' must be date in ISO 8601 format.',
     'SNIPPET_SPDX_ID_VALUE' : 'SPDXID must be "SPDXRef-[idstring]" where [idstring] is a unique string '
                               'containing letters, numbers, ".", "-".',
+    'SNIPPET_SINGLE_LICS' : 'Snippet Concluded License must be a license url or spdx:noassertion or spdx:none.',
+    'SNIPPET_LIC_INFO' : 'License Information in Snippet must be a license url or a reference '
+                         'to the license, denoted by LicenseRef-[idstring] or spdx:noassertion or spdx:none.',
 }
 
 
@@ -700,6 +703,44 @@ class SnippetParser(LicenseParser):
                 self.builder.set_snippet_copyright(self.doc, self.to_special_value(six.text_type(o)))
             except CardinalityError:
                 self.more_than_one_error('copyrightText')
+                break
+
+        try:
+            for _, _, licenses in self.graph.triples(
+                    (snippet_term, self.spdx_namespace['licenseConcluded'], None)):
+                if (licenses, RDF.type, self.spdx_namespace['ConjunctiveLicenseSet']) in self.graph:
+                    lics = self.handle_conjunctive_list(licenses)
+                    self.builder.set_snip_concluded_license(self.doc, lics)
+
+                elif (licenses, RDF.type, self.spdx_namespace['DisjunctiveLicenseSet']) in self.graph:
+                    lics = self.handle_disjunctive_list(licenses)
+                    self.builder.set_snip_concluded_license(self.doc, lics)
+
+                else:
+                    try:
+                        lics = self.handle_lics(licenses)
+                        self.builder.set_snip_concluded_license(self.doc, lics)
+                    except SPDXValueError:
+                        self.value_error('SNIPPET_SINGLE_LICS', licenses)
+        except CardinalityError:
+            self.more_than_one_error('package {0}'.format(
+                self.spdx_namespace['licenseConcluded']))
+
+        for _, _, info in self.graph.triples(
+                (snippet_term, self.spdx_namespace['licenseInfoInSnippet'], None)):
+            lic = self.handle_lics(info)
+            if lic is not None:
+                try:
+                    self.builder.set_snippet_lics_info(self.doc, lic)
+                except SPDXValueError:
+                    self.value_error('SNIPPET_LIC_INFO', lic)
+
+        for _s, _p, o in self.graph.triples(
+                (snippet_term, self.spdx_namespace['snippetFromFile'], None)):
+            try:
+                self.builder.set_snip_from_file_spdxid(self.doc, six.text_type(o))
+            except CardinalityError:
+                self.more_than_one_error('snippetFromFile')
                 break
 
 

--- a/spdx/parsers/rdfbuilders.py
+++ b/spdx/parsers/rdfbuilders.py
@@ -305,6 +305,50 @@ class FileBuilder(tagvaluebuilders.FileBuilder):
             raise OrderError('File::Notice')
 
 
+class SnippetBuilder(tagvaluebuilders.SnippetBuilder):
+
+    def __init__(self):
+        super(SnippetBuilder, self).__init__()
+
+    def set_snippet_lic_comment(self, doc, lic_comment):
+        """Sets the snippet's license comment.
+        Raises OrderError if no snippet previously defined.
+        Raises CardinalityError if already set.
+        """
+        self.assert_snippet_exists()
+        if not self.snippet_lic_comment_set:
+            self.snippet_lic_comment_set = True
+            doc.snippet[-1].license_comment = lic_comment
+        else:
+            CardinalityError('Snippet::licenseComments')
+
+    def set_snippet_comment(self, doc, comment):
+        """
+        Sets general comments about the snippet.
+        Raises OrderError if no snippet previously defined.
+        Raises CardinalityError if comment already set.
+        """
+        self.assert_snippet_exists()
+        if not self.snippet_comment_set:
+            self.snippet_comment_set = True
+            doc.snippet[-1].comment = comment
+            return True
+        else:
+            raise CardinalityError('Snippet::comment')
+
+    def set_snippet_copyright(self, doc, copyright):
+        """Sets the snippet's copyright text.
+        Raises OrderError if no snippet previously defined.
+        Raises CardinalityError if already set.
+        """
+        self.assert_snippet_exists()
+        if not self.snippet_copyright_set:
+            self.snippet_copyright_set = True
+            doc.snippet[-1].copyright = copyright
+        else:
+            raise CardinalityError('Snippet::copyrightText')
+
+
 class ReviewBuilder(tagvaluebuilders.ReviewBuilder):
 
     def __init__(self):
@@ -325,7 +369,8 @@ class ReviewBuilder(tagvaluebuilders.ReviewBuilder):
             raise OrderError('ReviewComment')
 
 
-class Builder(DocBuilder, EntityBuilder, CreationInfoBuilder, PackageBuilder, FileBuilder, ReviewBuilder):
+class Builder(DocBuilder, EntityBuilder, CreationInfoBuilder, PackageBuilder, FileBuilder,
+              SnippetBuilder, ReviewBuilder):
 
     def __init__(self):
         super(Builder, self).__init__()

--- a/spdx/parsers/tagvaluebuilders.py
+++ b/spdx/parsers/tagvaluebuilders.py
@@ -1031,6 +1031,53 @@ class SnippetBuilder(object):
         else:
             raise CardinalityError('Snippet::SnippetLicenseComments')
 
+    def set_snip_from_file_spdxid(self, doc, snip_from_file_spdxid):
+        """Sets the snippet's 'Snippet from File SPDX Identifier'.
+        Raises OrderError if no snippet previously defined.
+        Raises CardinalityError if already set.
+        Raises SPDXValueError if the data is a malformed value.
+        """
+        self.assert_snippet_exists()
+        snip_from_file_spdxid = snip_from_file_spdxid.split('#')[-1]
+        if not self.snip_file_spdxid_set:
+            self.snip_file_spdxid_set = True
+            if validations.validate_snip_file_spdxid(snip_from_file_spdxid):
+                doc.snippet[-1].snip_from_file_spdxid = snip_from_file_spdxid
+                return True
+            else:
+                raise SPDXValueError('Snippet::SnippetFromFileSPDXID')
+        else:
+            raise CardinalityError('Snippet::SnippetFromFileSPDXID')
+
+    def set_snip_concluded_license(self, doc, conc_lics):
+        """
+        Raises OrderError if no snippet previously defined.
+        Raises CardinalityError if already set.
+        Raises SPDXValueError if the data is a malformed value.
+        """
+        self.assert_snippet_exists()
+        if not self.snippet_conc_lics_set:
+            self.snippet_conc_lics_set = True
+            if validations.validate_lics_conc(conc_lics):
+                doc.snippet[-1].conc_lics = conc_lics
+                return True
+            else:
+                raise SPDXValueError('Snippet::SnippetLicenseConcluded')
+        else:
+            raise CardinalityError('Snippet::SnippetLicenseConcluded')
+
+    def set_snippet_lics_info(self, doc, lics_info):
+        """
+        Raises OrderError if no snippet previously defined.
+        Raises SPDXValueError if the data is a malformed value.
+        """
+        self.assert_snippet_exists()
+        if validations.validate_snip_lics_info(lics_info):
+            doc.snippet[-1].add_lics(lics_info)
+            return True
+        else:
+            raise SPDXValueError('Snippet::LicenseInfoInSnippet')
+
     def reset_snippet(self):
         # FIXME: this state does not make sense
         self.snippet_spdx_id_set = False
@@ -1038,6 +1085,8 @@ class SnippetBuilder(object):
         self.snippet_comment_set = False
         self.snippet_copyright_set = False
         self.snippet_lic_comment_set = False
+        self.snip_file_spdxid_set = False
+        self.snippet_conc_lics_set = False
 
     def assert_snippet_exists(self):
         if not self.snippet_spdx_id_set:

--- a/spdx/parsers/validations.py
+++ b/spdx/parsers/validations.py
@@ -186,3 +186,30 @@ def validate_extr_lic_name(value, optional=False):
         return optional
     else:
         return isinstance(value, (six.string_types, utils.NoAssert, rdflib.Literal))
+
+
+def validate_snippet_spdx_id(value, optional=False):
+    value = value.split('#')[-1]
+    if re.match(r'^SPDXRef[A-Za-z0-9.\-]+$', value) is not None:
+        return True
+    else:
+        return False
+
+
+def validate_snip_comment(value, optional=False):
+    return validate_is_free_form_text(value, optional)
+
+
+def validate_snippet_copyright(value, optional=False):
+    if validate_is_free_form_text(value, optional):
+        return True
+    elif isinstance(value, (utils.NoAssert, utils.SPDXNone)):
+        return True
+    elif value is None:
+        return optional
+    else:
+        return False
+
+
+def validate_snip_lic_comment(value, optional=False):
+    return validate_is_free_form_text(value, optional)

--- a/spdx/parsers/validations.py
+++ b/spdx/parsers/validations.py
@@ -213,3 +213,20 @@ def validate_snippet_copyright(value, optional=False):
 
 def validate_snip_lic_comment(value, optional=False):
     return validate_is_free_form_text(value, optional)
+
+
+def validate_snip_file_spdxid(value, optional=False):
+    if re.match(
+            r'(DocumentRef[A-Za-z0-9.\-]+:){0,1}SPDXRef[A-Za-z0-9.\-]+', value) is not None:
+        return True
+    else:
+        return False
+
+
+def validate_snip_lics_info(value, optional=False):
+    if value is None:
+        return optional
+    elif isinstance(value, (utils.NoAssert, utils.SPDXNone, document.License)):
+        return True
+    else:
+        return False

--- a/spdx/snippet.py
+++ b/spdx/snippet.py
@@ -1,0 +1,76 @@
+# Copyright (c) 2018 Yash M. Nisar
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import six
+
+from spdx import utils
+
+
+class Snippet(object):
+    """
+    Represents an analyzed snippet.
+    Fields:
+     - spdx_id: Uniquely identify any element in an SPDX document which may be
+     referenced  by other elements. Mandatory, one per snippet if the snippet
+     is present.
+     - name: Name of the snippet. Optional, one. Type: str.
+     - comment: General comments about the snippet. Optional, one. Type: str.
+     - copyright: Copyright text. Mandatory, one. Type: str.
+     - license_comment: Relevant background references or analysis that went
+     in to arriving at the Concluded License for a snippet. Optional, one.
+     Type: str.
+    """
+
+    def __init__(self, spdx_id=None, copyright=None):
+        self.spdx_id = spdx_id
+        self.name = None
+        self.comment = None
+        self.copyright = copyright
+        self.license_comment = None
+
+    def validate(self, messages=None):
+        """
+        Validate fields of the snippet and update the messages list with user
+        friendly error messages for display.
+        """
+        # FIXME: we should return messages instead
+        messages = messages if messages is not None else []
+
+        return (self.validate_spdx_id(messages) and
+                self.validate_copyright_text(messages))
+
+    def validate_spdx_id(self, messages=None):
+        # FIXME: messages should be returned
+        messages = messages if messages is not None else []
+
+        if self.spdx_id is None:
+            messages.append('Snippet has no SPDX Identifier.')
+            return False
+
+        else:
+            return True
+
+    def validate_copyright_text(self, messages=None):
+        # FIXME: we should return messages instead
+        messages = messages if messages is not None else []
+
+        if isinstance(
+            self.copyright,
+                (six.string_types, six.text_type, utils.NoAssert,
+                 utils.SPDXNone)):
+            return True
+        else:
+            messages.append('Snippet copyright must be str or unicode or '
+                            'utils.NoAssert or utils.SPDXNone')
+            return False
+
+    def has_optional_field(self, field):
+        return getattr(self, field, None) is not None

--- a/spdx/writers/rdf.py
+++ b/spdx/writers/rdf.py
@@ -287,6 +287,41 @@ class FileWriter(LicenseWriter):
             self.add_file_dependencies_helper(doc_file)
 
 
+class SnippetWriter(LicenseWriter):
+
+    """
+    Write spdx.snippet.Snippet
+    """
+
+    def __init__(self, document, out):
+        super(SnippetWriter, self).__init__(document, out)
+
+    def create_snippet_node(self, snippet):
+        """
+        Return a snippet node.
+        """
+        snippet_node = URIRef('http://spdx.org/rdf/terms/Snippet' + str(snippet.spdx_id))
+        type_triple = (snippet_node, RDF.type, self.spdx_namespace.Snippet)
+        self.graph.add(type_triple)
+
+        if snippet.has_optional_field('comment'):
+            comment_triple = (snippet_node, RDFS.comment, Literal(snippet.comment))
+            self.graph.add(comment_triple)
+
+        if snippet.has_optional_field('name'):
+            name_triple = (snippet_node, self.spdx_namespace.name, snippet.name)
+            self.graph.add(name_triple)
+
+        if snippet.has_optional_field('license_comment'):
+            lic_comment_triple = (snippet_node, self.spdx_namespace.licenseComments,
+                                  snippet.license_comment)
+            self.graph.add(lic_comment_triple)
+
+        cr_text_node = self.to_special_value(snippet.copyright)
+        cr_text_triple = (snippet_node, self.spdx_namespace.copyrightText, cr_text_node)
+        self.graph.add(cr_text_triple)
+
+
 class ReviewInfoWriter(BaseWriter):
 
     """
@@ -495,7 +530,8 @@ class PackageWriter(LicenseWriter):
             self.graph.add(triple)
 
 
-class Writer(CreationInfoWriter, ReviewInfoWriter, FileWriter, PackageWriter):
+class Writer(CreationInfoWriter, ReviewInfoWriter, FileWriter, SnippetWriter,
+             PackageWriter):
     """
     Warpper for other writers to write all fields of spdx.document.Document
     Call `write()` to start writing.

--- a/spdx/writers/rdf.py
+++ b/spdx/writers/rdf.py
@@ -300,7 +300,7 @@ class SnippetWriter(LicenseWriter):
         """
         Return a snippet node.
         """
-        snippet_node = URIRef('http://spdx.org/rdf/terms/Snippet' + str(snippet.spdx_id))
+        snippet_node = URIRef('http://spdx.org/rdf/terms/Snippet#' + snippet.spdx_id)
         type_triple = (snippet_node, RDF.type, self.spdx_namespace.Snippet)
         self.graph.add(type_triple)
 
@@ -309,17 +309,41 @@ class SnippetWriter(LicenseWriter):
             self.graph.add(comment_triple)
 
         if snippet.has_optional_field('name'):
-            name_triple = (snippet_node, self.spdx_namespace.name, snippet.name)
+            name_triple = (snippet_node, self.spdx_namespace.name, Literal(snippet.name))
             self.graph.add(name_triple)
 
         if snippet.has_optional_field('license_comment'):
             lic_comment_triple = (snippet_node, self.spdx_namespace.licenseComments,
-                                  snippet.license_comment)
+                                  Literal(snippet.license_comment))
             self.graph.add(lic_comment_triple)
 
         cr_text_node = self.to_special_value(snippet.copyright)
         cr_text_triple = (snippet_node, self.spdx_namespace.copyrightText, cr_text_node)
         self.graph.add(cr_text_triple)
+
+        snip_from_file_triple = (snippet_node, self.spdx_namespace.snippetFromFile,
+                                 Literal(snippet.snip_from_file_spdxid))
+        self.graph.add(snip_from_file_triple)
+
+        conc_lic_node = self.license_or_special(snippet.conc_lics)
+        conc_lic_triple = (
+            snippet_node, self.spdx_namespace.licenseConcluded, conc_lic_node)
+        self.graph.add(conc_lic_triple)
+
+        license_info_nodes = map(self.license_or_special,
+                                 snippet.licenses_in_snippet)
+        for lic in license_info_nodes:
+            triple = (
+            snippet_node, self.spdx_namespace.licenseInfoInSnippet, lic)
+            self.graph.add(triple)
+
+        return snippet_node
+
+    def snippets(self):
+        """
+        Return list of snippet nodes.
+        """
+        return map(self.create_snippet_node, self.document.snippet)
 
 
 class ReviewInfoWriter(BaseWriter):
@@ -583,6 +607,10 @@ class Writer(CreationInfoWriter, ReviewInfoWriter, FileWriter, SnippetWriter,
         package_node = self.packages()
         package_triple = (doc_node, self.spdx_namespace.describesPackage, package_node)
         self.graph.add(package_triple)
+        # Add snippet
+        snippet_nodes = self.snippets()
+        for snippet in snippet_nodes:
+            self.graph.add((doc_node, self.spdx_namespace.Snippet, snippet))
 
         # normalize the graph to ensure that the sort order is stable
         self.graph = to_isomorphic(self.graph)

--- a/spdx/writers/tagvalue.py
+++ b/spdx/writers/tagvalue.py
@@ -135,6 +135,21 @@ def write_file(spdx_file, out):
             write_value('ArtifactOfProjectURI', uri, out)
 
 
+def write_snippet(snippet, out):
+    """
+    Write snippet fields to out.
+    """
+    out.write('# Snippet\n\n')
+    write_value('SnippetSPDXID', snippet.spdx_id, out)
+    write_text_value('SnippetCopyrightText', snippet.copyright, out)
+    if snippet.has_optional_field('name'):
+        write_value('SnippetName', snippet.name, out)
+    if snippet.has_optional_field('comment'):
+        write_text_value('SnippetComment', snippet.comment, out)
+    if snippet.has_optional_field('license_comment'):
+        write_text_value('SnippetLicenseComments', snippet.license_comment, out)
+
+
 def write_package(package, out):
     """
     Write a package fields to out.
@@ -251,6 +266,11 @@ def write_document(document, out, validate=True):
     # Write out package info
     write_package(document.package, out)
     write_separators(out)
+
+    # Write out snippet info
+    for snippet in document.snippet:
+        write_snippet(snippet, out)
+        write_separators(out)
 
     out.write('# Extracted Licenses\n\n')
     for lic in sorted(document.extracted_licenses):

--- a/spdx/writers/tagvalue.py
+++ b/spdx/writers/tagvalue.py
@@ -141,6 +141,7 @@ def write_snippet(snippet, out):
     """
     out.write('# Snippet\n\n')
     write_value('SnippetSPDXID', snippet.spdx_id, out)
+    write_value('SnippetFromFileSPDXID', snippet.snip_from_file_spdxid, out)
     write_text_value('SnippetCopyrightText', snippet.copyright, out)
     if snippet.has_optional_field('name'):
         write_value('SnippetName', snippet.name, out)
@@ -148,6 +149,15 @@ def write_snippet(snippet, out):
         write_text_value('SnippetComment', snippet.comment, out)
     if snippet.has_optional_field('license_comment'):
         write_text_value('SnippetLicenseComments', snippet.license_comment, out)
+    if isinstance(snippet.conc_lics,
+                  (document.LicenseConjunction, document.LicenseDisjunction)):
+        write_value('SnippetLicenseConcluded', u'({0})'.format(
+            snippet.conc_lics), out)
+    else:
+        write_value('SnippetLicenseConcluded', snippet.conc_lics, out)
+    # Write sorted list
+    for lics in sorted(snippet.licenses_in_snippet):
+        write_value('LicenseInfoInSnippet', lics, out)
 
 
 def write_package(package, out):

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -407,6 +407,77 @@ class TestSnippetBuilder(TestCase):
         self.builder.set_snippet_lic_comment(self.document,
                                              '<text>Lic comment</text>')
 
+    def test_snippet_from_file_spdxid(self):
+        self.builder.create_snippet(self.document, 'SPDXRef-Snippet')
+        self.builder.set_snip_from_file_spdxid(self.document,
+                                               'SPDXRef-DoapSource')
+
+    @testing_utils.raises(builders.SPDXValueError)
+    def test_snippet_from_file_spdxid_value(self):
+        self.builder.create_snippet(self.document, 'SPDXRef-Snippet')
+        self.builder.set_snip_from_file_spdxid(self.document,
+                                               '#_$random_chars')
+
+    @testing_utils.raises(builders.OrderError)
+    def test_snippet_from_file_spdxid_order(self):
+        self.builder.set_snip_from_file_spdxid(self.document,
+                                               'SPDXRef-DoapSource')
+
+    @testing_utils.raises(builders.CardinalityError)
+    def test_snippet_from_file_spdxid_cardinality(self):
+        self.builder.create_snippet(self.document, 'SPDXRef-Snippet')
+        self.builder.set_snip_from_file_spdxid(self.document,
+                                               'SPDXRef-DoapSource')
+        self.builder.set_snip_from_file_spdxid(self.document,
+                                               'SPDXRef-somevalue')
+
+    def test_snippet_conc_lics(self):
+        self.builder.create_snippet(self.document, 'SPDXRef-Snippet')
+        self.builder.set_snip_concluded_license(self.document,
+                                                License.from_identifier(
+                                                    'Apache-2.0'))
+
+    @testing_utils.raises(builders.SPDXValueError)
+    def test_snippet_conc_lics_value(self):
+        self.builder.create_snippet(self.document, 'SPDXRef-Snippet')
+        self.builder.set_snip_concluded_license(self.document, 'Apache-2.0')
+
+    @testing_utils.raises(builders.OrderError)
+    def test_snippet_conc_lics_order(self):
+        self.builder.set_snip_concluded_license(self.document,
+                                                License.from_identifier(
+                                                    'Apache-2.0'))
+
+    @testing_utils.raises(builders.CardinalityError)
+    def test_snippet_conc_lics_cardinality(self):
+        self.builder.create_snippet(self.document, 'SPDXRef-Snippet')
+        self.builder.set_snip_concluded_license(self.document,
+                                                License.from_identifier(
+                                                    'Apache-2.0'))
+        self.builder.set_snip_concluded_license(self.document,
+                                                License.from_identifier(
+                                                    'Apache-2.0'))
+
+    def test_snippet_lics_info(self):
+        self.builder.create_snippet(self.document, 'SPDXRef-Snippet')
+        self.builder.set_snippet_lics_info(self.document,
+                                           License.from_identifier(
+                                               'Apache-2.0'))
+        self.builder.set_snippet_lics_info(self.document,
+                                           License.from_identifier(
+                                               'GPL-2.0-or-later'))
+
+    @testing_utils.raises(builders.SPDXValueError)
+    def test_snippet_lics_info_value(self):
+        self.builder.create_snippet(self.document, 'SPDXRef-Snippet')
+        self.builder.set_snippet_lics_info(self.document, 'Apache-2.0')
+
+    @testing_utils.raises(builders.OrderError)
+    def test_snippet_lics_info_order(self):
+        self.builder.set_snippet_lics_info(self.document,
+                                           License.from_identifier(
+                                               'Apache-2.0'))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -341,5 +341,72 @@ class TestPackageBuilder(TestCase):
         self.builder.set_pkg_desc(self.document, '<text>something</text>')
 
 
+class TestSnippetBuilder(TestCase):
+
+    def setUp(self):
+        self.entity_builder = builders.EntityBuilder()
+        self.builder = builders.SnippetBuilder()
+        self.document = Document()
+
+    def test_create_snippet(self):
+        assert self.builder.create_snippet(self.document, 'SPDXRef-Snippet')
+
+    @testing_utils.raises(builders.SPDXValueError)
+    def test_incorrect_snippet_spdx_id(self):
+        self.builder.create_snippet(self.document, 'Some_value_with_$%')
+
+    def test_snippet_name(self):
+        self.builder.create_snippet(self.document, 'SPDXRef-Snippet')
+        self.builder.set_snippet_name(self.document, 'Name_of_snippet')
+
+    @testing_utils.raises(builders.OrderError)
+    def test_snippet_name_order(self):
+        self.builder.set_snippet_name(self.document, 'Name_of_snippet')
+
+    def test_snippet_comment(self):
+        self.builder.create_snippet(self.document, 'SPDXRef-Snippet')
+        self.builder.set_snippet_comment(self.document, '<text>Comment</text>')
+
+    @testing_utils.raises(builders.OrderError)
+    def test_snippet_comment_order(self):
+        self.builder.set_snippet_comment(self.document, '<text>Comment</text>')
+
+    @testing_utils.raises(builders.SPDXValueError)
+    def test_snippet_comment_text_value(self):
+        self.builder.create_snippet(self.document, 'SPDXRef-Snippet')
+        self.builder.set_snippet_comment(self.document, 'Comment.')
+
+    def test_snippet_copyright(self):
+        self.builder.create_snippet(self.document, 'SPDXRef-Snippet')
+        self.builder.set_snippet_copyright(self.document, '<text>Copyright 2008-2010 John Smith</text>')
+
+    @testing_utils.raises(builders.SPDXValueError)
+    def test_snippet_copyright_text_value(self):
+        self.builder.create_snippet(self.document, 'SPDXRef-Snippet')
+        self.builder.set_snippet_copyright(self.document,
+                                           'Copyright 2008-2010 John Smith')
+
+    @testing_utils.raises(builders.OrderError)
+    def test_snippet_copyright_order(self):
+        self.builder.set_snippet_copyright(self.document,
+                                           '<text>Copyright 2008-2010 John Smith</text>')
+
+    def test_snippet_lic_comment(self):
+        self.builder.create_snippet(self.document, 'SPDXRef-Snippet')
+        self.builder.set_snippet_lic_comment(self.document,
+                                             '<text>Lic comment</text>')
+
+    @testing_utils.raises(builders.SPDXValueError)
+    def test_snippet_lic_comment_text_value(self):
+        self.builder.create_snippet(self.document, 'SPDXRef-Snippet')
+        self.builder.set_snippet_lic_comment(self.document,
+                                             'Lic comment')
+
+    @testing_utils.raises(builders.OrderError)
+    def test_snippet_lic_comment_order(self):
+        self.builder.set_snippet_lic_comment(self.document,
+                                             '<text>Lic comment</text>')
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_tag_value_parser.py
+++ b/tests/test_tag_value_parser.py
@@ -101,6 +101,9 @@ class TestLexer(TestCase):
         SnippetCopyrightText: <text>Some cr text.</text>
         SnippetComment: <text>Some snippet comment.</text>
         SnippetName: from linux kernel
+        SnippetFromFileSPDXID: SPDXRef-DoapSource
+        SnippetLicenseConcluded: Apache-2.0
+        LicenseInfoInSnippet: Apache-2.0
         '''
         self.l.input(data)
         self.token_assert_helper(self.l.token(), 'SNIPPET_SPDX_ID', 'SnippetSPDXID', 2)
@@ -113,6 +116,15 @@ class TestLexer(TestCase):
         self.token_assert_helper(self.l.token(), 'TEXT', '<text>Some snippet comment.</text>', 5)
         self.token_assert_helper(self.l.token(), 'SNIPPET_NAME', 'SnippetName', 6)
         self.token_assert_helper(self.l.token(), 'LINE', 'from linux kernel', 6)
+        self.token_assert_helper(self.l.token(), 'SNIPPET_FILE_SPDXID',
+                                 'SnippetFromFileSPDXID', 7)
+        self.token_assert_helper(self.l.token(), 'LINE', 'SPDXRef-DoapSource', 7)
+        self.token_assert_helper(self.l.token(), 'SNIPPET_LICS_CONC',
+                                 'SnippetLicenseConcluded', 8)
+        self.token_assert_helper(self.l.token(), 'LINE', 'Apache-2.0', 8)
+        self.token_assert_helper(self.l.token(), 'SNIPPET_LICS_INFO',
+                                 'LicenseInfoInSnippet', 9)
+        self.token_assert_helper(self.l.token(), 'LINE', 'Apache-2.0', 9)
 
     def token_assert_helper(self, token, ttype, value, line):
         assert token.type == ttype
@@ -183,6 +195,9 @@ class TestParser(TestCase):
         'SnippetCopyrightText: <text> Copyright 2008-2010 John Smith </text>',
         'SnippetComment: <text>Some snippet comment.</text>',
         'SnippetName: from linux kernel',
+        'SnippetFromFileSPDXID: SPDXRef-DoapSource',
+        'SnippetLicenseConcluded: Apache-2.0',
+        'LicenseInfoInSnippet: Apache-2.0',
     ])
 
     complete_str = '{0}\n{1}\n{2}\n{3}\n{4}\n{5}'.format(document_str, creation_str, review_str, package_str, file_str, snippet_str)
@@ -244,6 +259,9 @@ class TestParser(TestCase):
         assert document.snippet[-1].comment == 'Some snippet comment.'
         assert document.snippet[-1].copyright == ' Copyright 2008-2010 John Smith '
         assert document.snippet[-1].license_comment == 'Some lic comment.'
+        assert document.snippet[-1].snip_from_file_spdxid == 'SPDXRef-DoapSource'
+        assert document.snippet[-1].conc_lics.identifier == 'Apache-2.0'
+        assert document.snippet[-1].licenses_in_snippet[-1].identifier == 'Apache-2.0'
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Add 'spdx_id', 'name', 'comment', 'copyright', and
'license_comment' to the 'snippet' class.

Signed-off-by: Yash Nisar <yash.nisar@somaiya.edu>