### PR TITLE
Report correct line no.s while showing errors #77

### DIFF
--- a/spdx/parsers/lexers/tagvalue.py
+++ b/spdx/parsers/lexers/tagvalue.py
@@ -94,8 +94,9 @@ class Lexer(object):
         r'</text>\s*'
         t.type = 'TEXT'
         t.value = t.lexer.lexdata[
-            t.lexer.text_start:t.lexer.lexpos].strip()
+            t.lexer.text_start:t.lexer.lexpos]
         t.lexer.lineno += t.value.count('\n')
+        t.value = t.value.strip()
         t.lexer.begin('INITIAL')
         return t
 

--- a/tests/test_tag_value_parser.py
+++ b/tests/test_tag_value_parser.py
@@ -34,16 +34,17 @@ class TestLexer(TestCase):
         data = '''
         SPDXVersion: SPDX-2.1
         # Comment.
-        DataLicense: CC0-1.0
         DocumentComment: <text>This is a sample spreadsheet</text>
+        DataLicense: CC0-1.0
         '''
         self.l.input(data)
         self.token_assert_helper(self.l.token(), 'DOC_VERSION', 'SPDXVersion', 2)
         self.token_assert_helper(self.l.token(), 'LINE', 'SPDX-2.1', 2)
-        self.token_assert_helper(self.l.token(), 'DOC_LICENSE', 'DataLicense', 4)
-        self.token_assert_helper(self.l.token(), 'LINE', 'CC0-1.0', 4)
-        self.token_assert_helper(self.l.token(), 'DOC_COMMENT', 'DocumentComment', 5)
-        self.token_assert_helper(self.l.token(), 'TEXT', '<text>This is a sample spreadsheet</text>', 5)
+        self.token_assert_helper(self.l.token(), 'DOC_COMMENT', 'DocumentComment', 4)
+        self.token_assert_helper(self.l.token(), 'TEXT', '<text>This is a sample spreadsheet</text>', 4)
+        self.token_assert_helper(self.l.token(), 'DOC_LICENSE', 'DataLicense',
+                                 5)
+        self.token_assert_helper(self.l.token(), 'LINE', 'CC0-1.0', 5)
 
     def test_creation_info(self):
         data = '''


### PR DESCRIPTION
This occurs due to the method `t_text_end` in the
file `lexers\tagvalue.py`. The line `t.value.count('\n')`
doesn't detect newlines because the earlier line is stripped
of whitespaces and newlines. This issue is resolved by first
counting the no. of newline chars and then stripping
whitespaces and newlines so information is preserved.

Signed-off-by: Yash Nisar <yash.nisar@somaiya.edu>

Closes https://github.com/spdx/tools-python/issues/77