### PR TITLE
change docstring of method set_pkg_cr_text

### DIFF
--- a/spdx/parsers/tagvaluebuilders.py
+++ b/spdx/parsers/tagvaluebuilders.py
@@ -751,7 +751,7 @@ class PackageBuilder(object):
             raise CardinalityError('Package::LicenseComment')
 
     def set_pkg_cr_text(self, doc, text):
-        """Sets the package's license comment.
+        """Sets the package's copyright text.
         Raises OrderError if no package previously defined.
         Raises CardinalityError if already set.
         Raises value error if text is not one of [None, NOASSERT, TEXT].


### PR DESCRIPTION
Made the following change in parsers/tagvaluebuilders.py:

Replaced the string `Sets the package's license comment` by `Sets the package's copyright text` for the method set_pkg_cr_text.