### PR TITLE
Fix #102 by using Version method from_str in config.py file.

### DIFF
--- a/spdx/config.py
+++ b/spdx/config.py
@@ -34,7 +34,7 @@ def load_license_list(file_name):
     licenses_map = {}
     with codecs.open(file_name, 'rb', encoding='utf-8') as lics:
         licenses = json.load(lics)
-        version = licenses['licenseListVersion'].split('.')
+        version = licenses['licenseListVersion']
         for lic in licenses['licenses']:
             if lic.get('isDeprecatedLicenseId'):
                 continue
@@ -45,28 +45,5 @@ def load_license_list(file_name):
     return version, licenses_map
 
 
-def load_exception_list(file_name):
-    """
-    Return the exceptions list version tuple and a mapping of exceptions
-    name->id and id->name loaded from a JSON file
-    from https://github.com/spdx/license-list-data
-    """
-    exceptions_map = {}
-    with codecs.open(file_name, 'rb', encoding='utf-8') as excs:
-        exceptions = json.load(excs)
-        version = exceptions['licenseListVersion'].split('.')
-        for exc in exceptions['exceptions']:
-            if exc.get('isDeprecatedLicenseId'):
-                continue
-            name = exc['name']
-            identifier = exc['licenseExceptionId']
-            exceptions_map[name] = identifier
-            exceptions_map[identifier] = name
-    return version, exceptions_map
-
-
-(_major, _minor), LICENSE_MAP = load_license_list(_licenses)
-LICENSE_LIST_VERSION = Version(major=_major, minor=_minor)
-
-(_major, _minor), EXCEPTION_MAP = load_exception_list(_exceptions)
-EXCEPTION_LIST_VERSION = Version(major=_major, minor=_minor)
+_version, LICENSE_MAP = load_license_list(_licenses)
+LICENSE_LIST_VERSION = Version.from_str(_version)

--- a/spdx/config.py
+++ b/spdx/config.py
@@ -34,7 +34,7 @@ def load_license_list(file_name):
     licenses_map = {}
     with codecs.open(file_name, 'rb', encoding='utf-8') as lics:
         licenses = json.load(lics)
-        version = licenses['licenseListVersion']
+        version, _, _ = licenses['licenseListVersion'].split('-')
         for lic in licenses['licenses']:
             if lic.get('isDeprecatedLicenseId'):
                 continue
@@ -45,5 +45,28 @@ def load_license_list(file_name):
     return version, licenses_map
 
 
+def load_exception_list(file_name):
+    """
+    Return the exceptions list version tuple and a mapping of exceptions
+    name->id and id->name loaded from a JSON file
+    from https://github.com/spdx/license-list-data
+    """
+    exceptions_map = {}
+    with codecs.open(file_name, 'rb', encoding='utf-8') as excs:
+        exceptions = json.load(excs)
+        version, _, _  = exceptions['licenseListVersion'].split('-')
+        for exc in exceptions['exceptions']:
+            if exc.get('isDeprecatedLicenseId'):
+                continue
+            name = exc['name']
+            identifier = exc['licenseExceptionId']
+            exceptions_map[name] = identifier
+            exceptions_map[identifier] = name
+    return version, exceptions_map
+
+
 _version, LICENSE_MAP = load_license_list(_licenses)
 LICENSE_LIST_VERSION = Version.from_str(_version)
+
+_version, EXCEPTION_MAP = load_exception_list(_exceptions)
+EXCEPTION_LIST_VERSION = Version.from_str(_version)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -12,17 +12,31 @@ class TestLicenseList(TestCase):
 
     def test_load_license_list(self):
         version, licenses_map = config.load_license_list(config._licenses)
-        assert version == '2.6'
+        assert version == '3.5'
         # Test some instances in licenses_map
         assert licenses_map['MIT License'] == 'MIT'
         assert licenses_map['MIT'] == 'MIT License'
         assert licenses_map['Apache License 2.0'] == 'Apache-2.0'
         assert licenses_map['Apache-2.0'] == 'Apache License 2.0'
-        assert licenses_map['GNU General Public License v3.0 only'] == 'GPL-3.0'
-        assert licenses_map['GPL-3.0'] == 'GNU General Public License v3.0 only'
+        assert licenses_map['GNU General Public License v3.0 only'] == 'GPL-3.0-only'
+        assert licenses_map['GPL-3.0-only'] == 'GNU General Public License v3.0 only'
     
     def test_config_license_list_version_constant(self):
-        assert config.LICENSE_LIST_VERSION == Version(major=2, minor=6)
+        assert config.LICENSE_LIST_VERSION == Version(major=3, minor=5)
+
+    def test_load_exception_list(self):
+        version, exception_map = config.load_exception_list(config._exceptions)
+        assert version == '3.5'
+        # Test some instances in exception_map
+        assert exception_map['Bison exception 2.2'] == 'Bison-exception-2.2'
+        assert exception_map['Bison-exception-2.2'] == 'Bison exception 2.2'
+        assert exception_map['OpenVPN OpenSSL Exception'] == 'openvpn-openssl-exception'
+        assert exception_map['openvpn-openssl-exception'] == 'OpenVPN OpenSSL Exception'
+        assert exception_map['Qt GPL exception 1.0'] == 'Qt-GPL-exception-1.0'
+        assert exception_map['Qt-GPL-exception-1.0'] == 'Qt GPL exception 1.0'
+    
+    def test_config_exception_list_version_constant(self):
+        assert config.EXCEPTION_LIST_VERSION == Version(major=3, minor=5)
 
 
 if __name__ == '__main__':

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,29 @@
+from __future__ import absolute_import
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import unittest
+from unittest import TestCase
+
+from spdx import config
+from spdx.version import Version
+
+class TestLicenseList(TestCase):
+
+    def test_load_license_list(self):
+        version, licenses_map = config.load_license_list(config._licenses)
+        assert version == '2.6'
+        # Test some instances in licenses_map
+        assert licenses_map['MIT License'] == 'MIT'
+        assert licenses_map['MIT'] == 'MIT License'
+        assert licenses_map['Apache License 2.0'] == 'Apache-2.0'
+        assert licenses_map['Apache-2.0'] == 'Apache License 2.0'
+        assert licenses_map['GNU General Public License v3.0 only'] == 'GPL-3.0'
+        assert licenses_map['GPL-3.0'] == 'GNU General Public License v3.0 only'
+    
+    def test_config_license_list_version_constant(self):
+        assert config.LICENSE_LIST_VERSION == Version(major=2, minor=6)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Fix #102 
This PR modifies config.py file to use the method `from_str` in `Version` instead of creating the object directly with string values.

Signed-off-by: Xavier Figueroa <xavierfigueroav@gmail.com>