### PR TITLE
 Fix #91 by passing all rdflib types in six.text_type function

### DIFF
--- a/data/SPDXRdfExample.rdf
+++ b/data/SPDXRdfExample.rdf
@@ -118,7 +118,6 @@
     <referencesFile>
       <File rdf:about="https://spdx.org/spdxdocs/spdx-example-444504E0-4F89-41D3-9A0C-0305E82C3301#SPDXRef-File2">
         <copyrightText>Copyright 2010, 2011 Source Auditor Inc.</copyrightText>
-        <licenseComments></licenseComments>
         <licenseInfoInFile rdf:resource="http://spdx.org/licenses/Apache-2.0"/>
         <licenseConcluded rdf:resource="http://spdx.org/licenses/Apache-2.0"/>
         <fileType rdf:resource="http://spdx.org/rdf/terms#fileType_source"/>

--- a/spdx/parsers/rdf.py
+++ b/spdx/parsers/rdf.py
@@ -106,7 +106,7 @@ class BaseParser(object):
         elif value == self.spdx_namespace.unknown:
             return utils.UnKnown()
         else:
-            return value
+            return six.text_type(value)
 
 
 class LicenseParser(BaseParser):
@@ -135,7 +135,7 @@ class LicenseParser(BaseParser):
             if special == lics:
                 if self.LICS_REF_REGEX.match(lics):
                     # Is a license ref i.e LicenseRef-1
-                    return document.License.from_identifier(lics)
+                    return document.License.from_identifier(six.text_type(lics))
                 else:
                     # Not a known license form
                     raise SPDXValueError('License')
@@ -164,7 +164,7 @@ class LicenseParser(BaseParser):
 
         identifier_tripple = identifier_tripples[0]
         _s, _p, identifier = identifier_tripple
-        return identifier
+        return six.text_type(identifier)
 
     def get_extr_license_text(self, extr_lic):
         """
@@ -183,7 +183,7 @@ class LicenseParser(BaseParser):
 
         text_tripple = text_tripples[0]
         _s, _p, text = text_tripple
-        return text
+        return six.text_type(text)
 
     def get_extr_lic_name(self, extr_lic):
         """
@@ -195,14 +195,14 @@ class LicenseParser(BaseParser):
             return
         elif len(extr_name_list) == 0:
             return
-        return self.to_special_value(extr_name_list[0][2])
+        return six.text_type(self.to_special_value(extr_name_list[0][2]))
 
     def get_extr_lics_xref(self, extr_lic):
         """
         Return a list of cross references.
         """
         xrefs = list(self.graph.triples((extr_lic, RDFS.seeAlso, None)))
-        return map(lambda xref_triple: xref_triple[2], xrefs)
+        return map(lambda xref_triple: six.text_type(xref_triple[2]), xrefs)
 
     def get_extr_lics_comment(self, extr_lics):
         """
@@ -214,7 +214,7 @@ class LicenseParser(BaseParser):
             self.more_than_one_error('extracted license comment')
             return
         elif len(comment_list) == 1:
-            return comment_list[0][2]
+            return six.text_type(comment_list[0][2])
         else:
             return
 
@@ -244,7 +244,7 @@ class LicenseParser(BaseParser):
             lic.full_name = name
         if comment is not None:
             lic.comment = comment
-        lic.cross_ref = map(lambda x: six.text_type(x), xrefs)
+        lic.cross_ref = xrefs
         return lic
 
     def handle_extracted_license(self, extr_lic):
@@ -341,7 +341,7 @@ class PackageParser(LicenseParser):
     def p_pkg_cr_text(self, p_term, predicate):
         try:
             for _, _, text in self.graph.triples((p_term, predicate, None)):
-                self.builder.set_pkg_cr_text(self.doc, self.to_special_value(six.text_type(text)))
+                self.builder.set_pkg_cr_text(self.doc, six.text_type(self.to_special_value(text)))
         except CardinalityError:
             self.more_than_one_error('package copyright text')
 
@@ -626,7 +626,7 @@ class FileParser(LicenseParser):
     def p_file_spdx_id(self, f_term, predicate):
         try:
             try:
-                self.builder.set_file_spdx_id(self.doc, f_term)
+                self.builder.set_file_spdx_id(self.doc, six.text_type(f_term))
             except SPDXValueError:
                 self.value_error('FILE_SPDX_ID_VALUE', f_term)
         except CardinalityError:
@@ -851,7 +851,7 @@ class AnnotationParser(BaseParser):
             annotation_type = self.get_annotation_type(r_term)
             self.builder.add_annotation_type(self.doc, annotation_type)
             try:
-                self.builder.set_annotation_spdx_id(self.doc, r_term)
+                self.builder.set_annotation_spdx_id(self.doc, six.text_type(r_term))
             except CardinalityError:
                 self.more_than_one_error('SPDX Identifier Reference')
 
@@ -861,7 +861,7 @@ class AnnotationParser(BaseParser):
         for _, _, typ in self.graph.triples((
                 r_term, self.spdx_namespace['annotationType'], None)):
             if typ is not None:
-                return typ
+                return six.text_type(typ)
             else:
                 self.error = True
                 msg = 'Annotation must have exactly one annotation type.'
@@ -1001,7 +1001,7 @@ class Parser(PackageParser, FileParser, SnippetParser, ReviewParser, AnnotationP
         """Parses the version, data license, name, SPDX Identifier, namespace,
         and comment."""
         try:
-            self.builder.set_doc_spdx_id(self.doc, doc_term)
+            self.builder.set_doc_spdx_id(self.doc, six.text_type(doc_term))
         except SPDXValueError:
             self.value_error('DOC_SPDX_ID_VALUE', doc_term)
         try:

--- a/tests/data/doc_parse/spdx-expected.json
+++ b/tests/data/doc_parse/spdx-expected.json
@@ -1,0 +1,255 @@
+{
+    "id": "https://spdx.org/spdxdocs/spdx-example-444504E0-4F89-41D3-9A0C-0305E82C3301#SPDXRef-DOCUMENT", 
+    "specVersion": {
+        "major": 2,
+        "minor": 1
+    }, 
+    "namespace": "https://spdx.org/spdxdocs/spdx-example-444504E0-4F89-41D3-9A0C-0305E82C3301", 
+    "name": "Sample_Document-V2.1", 
+    "comment": "This is a sample spreadsheet", 
+    "dataLicense": {
+        "identifier": "CC0-1.0", 
+        "name": "Creative Commons Zero v1.0 Universal", 
+        "type": "Single"
+    },
+    "licenseListVersion": {
+        "major": 2,
+        "minor": 6
+    }, 
+    "creators": [
+        {
+            "type": "Person",
+            "name": "Gary O'Neall",
+            "email": null
+        }, 
+        {
+            "type": "Organization",
+            "name": "Source Auditor Inc.",
+            "email": null
+        }, 
+        {
+            "type": "Tool",
+            "name": "SourceAuditor-V1.2"
+        }
+    ], 
+    "created": "2010-02-03T00:00:00Z", 
+    "creatorComment": "This is an example of an SPDX spreadsheet format", 
+    "package": {
+        "name": "SPDX Translator", 
+        "packageFileName": "spdxtranslator-1.0.zip", 
+        "summary": "SPDX Translator utility", 
+        "description": "This utility translates and SPDX RDF XML document to a spreadsheet, translates a spreadsheet to an SPDX RDF XML document and translates an SPDX RDFa document to an SPDX RDF XML document.", 
+        "versionInfo": "Version 0.9.2", 
+        "sourceInfo": "Version 1.0 of the SPDX Translator application", 
+        "downloadLocation": "http://www.spdx.org/tools", 
+        "homepage": null, 
+        "originator": {
+            "type": "Organization", 
+            "name": "SPDX", 
+            "email": null
+        }, 
+        "supplier": {
+            "type": "Organization",
+            "name": "Linux Foundation", 
+            "email": null
+        }, 
+        "licenseConcluded": {
+            "identifier": ["Apache-1.0", "Apache-2.0", "LicenseRef-1", "LicenseRef-2", "LicenseRef-3", "LicenseRef-4", "MPL-1.1"], 
+            "name": ["Apache License 1.0", "Apache License 2.0", "CyberNeko License", "Mozilla Public License 1.1", "None", "None", "None"], 
+            "type": "Conjunction"
+        }, 
+        "licenseDeclared": {
+            "identifier": ["Apache-2.0", "LicenseRef-1", "LicenseRef-2", "LicenseRef-3", "LicenseRef-4", "MPL-1.1"], 
+            "name": ["Apache License 2.0", "CyberNeko License", "Mozilla Public License 1.1", "None", "None", "None"], 
+            "type": "Conjunction"
+        }, 
+        "copyrightText": " Copyright 2010, 2011 Source Auditor Inc.", 
+        "licenseComment": "The declared license information can be found in the NOTICE file at the root of the archive file", 
+        "checksum": {
+            "identifier": "SHA1", 
+            "value": "2fd4e1c67a2d28fced849ee1bb76e7391b93eb12"
+        }, 
+        "files": [
+            {
+                "id": "https://spdx.org/spdxdocs/spdx-example-444504E0-4F89-41D3-9A0C-0305E82C3301#SPDXRef-File1", 
+                "name": "Jenna-2.6.3/jena-2.6.3-sources.jar", 
+                "type": 3, 
+                "comment": "This file belongs to Jena",  
+                "licenseConcluded": {
+                    "identifier": "LicenseRef-1", 
+                    "name": null, 
+                    "type": "Single"
+                }, 
+                "copyrightText": "(c) Copyright 2000, 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009 Hewlett-Packard Development Company, LP", 
+                "licenseComment": "This license is used by Jena", 
+                "notice": null, 
+                "checksum": {
+                    "identifier": "SHA1", 
+                    "value": "3ab4e1c67a2d28fced849ee1bb76e7391b93f125"
+                }, 
+                "licenseInfoFromFiles": [
+                    {
+                        "identifier": "LicenseRef-1", 
+                        "name": null, 
+                        "type": "Single"
+                    }
+                ], 
+                "contributors": [], 
+                "dependencies": [], 
+                "artifactOfProjectName": ["Jena"], 
+                "artifactOfProjectHome": ["http://www.openjena.org/"], 
+                "artifactOfProjectURI": []
+            }, 
+            {
+                "id": "https://spdx.org/spdxdocs/spdx-example-444504E0-4F89-41D3-9A0C-0305E82C3301#SPDXRef-File2", 
+                "name": "src/org/spdx/parser/DOAPProject.java", 
+                "type": 1, 
+                "comment": null, 
+                "licenseConcluded": {
+                    "identifier": "Apache-2.0", 
+                    "name": "Apache License 2.0", 
+                    "type": "Single"
+                }, 
+                "copyrightText": "Copyright 2010, 2011 Source Auditor Inc.", 
+                "licenseComment": null, 
+                "notice": null, 
+                "checksum": {
+                    "identifier": "SHA1", 
+                    "value": "2fd4e1c67a2d28fced849ee1bb76e7391b93eb12"
+                }, 
+                "licenseInfoFromFiles": [
+                    {
+                        "identifier": "Apache-2.0", 
+                        "name": "Apache License 2.0", 
+                        "type": "Single"
+                    }
+                ], 
+                "contributors": [], 
+                "dependencies": [], 
+                "artifactOfProjectName": [], 
+                "artifactOfProjectHome": [], 
+                "artifactOfProjectURI": []
+            }
+        ], 
+        "licenseInfoFromFiles": [
+            {
+                "identifier": "Apache-1.0", 
+                "name": "Apache License 1.0", 
+                "type": "Single"
+            }, 
+            {
+                "identifier": "Apache-2.0", 
+                "name": "Apache License 2.0", 
+                "type": "Single"
+            }, 
+            {
+                "identifier": "LicenseRef-1", 
+                "name": null, 
+                "type": "Single"
+            }, 
+            {
+                "identifier": "LicenseRef-2", 
+                "name": null, 
+                "type": "Single"
+            }, 
+            {
+                "identifier": "LicenseRef-3", 
+                "name": "CyberNeko License", 
+                "type": "Single"
+            }, 
+            {
+                "identifier": "LicenseRef-4", 
+                "name": null, 
+                "type": "Single"
+            }, 
+            {
+                "identifier": "MPL-1.1", 
+                "name": "Mozilla Public License 1.1", 
+                "type": "Single"
+            }
+        ], 
+        "verificationCode": {
+            "value": "4e3211c67a2d28fced849ee1bb76e7391b93feba", 
+            "excludedFilesNames": [
+                "SpdxTranslatorSpdx.rdf", 
+                "SpdxTranslatorSpdx.txt"
+            ]
+        }
+    },
+    "externalDocumentRefs": [
+        {
+            "externalDocumentId": "DocumentRef-spdx-tool-2.1",
+            "spdxDocumentNamespace": "https://spdx.org/spdxdocs/spdx-tools-v2.1-3F2504E0-4F89-41D3-9A0C-0305E82C3301", 
+            "checksum": {
+                "identifier": "SHA1", 
+                "value": "d6a770ba38583ed4bb4525bd96e50461655d2759"
+            }
+        }
+    ],
+    "extractedLicenses": [
+        {
+            "name": null,
+            "identifier": "LicenseRef-1",
+            "text": "/*\n * (c) Copyright 2000, 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009 Hewlett-Packard Development Company, LP\n * All rights reserved.\n *\n * Redistribution and use in source and binary forms, with or without\n * modification, are permitted provided that the following conditions\n * are met:\n * 1. Redistributions of source code must retain the above copyright\n *    notice, this list of conditions and the following disclaimer.\n * 2. Redistributions in binary form must reproduce the above copyright\n *    notice, this list of conditions and the following disclaimer in the\n *    documentation and/or other materials provided with the distribution.\n * 3. The name of the author may not be used to endorse or promote products\n *    derived from this software without specific prior written permission.\n *\n * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR\n * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES\n * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.\n * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,\n * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT\n * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,\n * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY\n * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT\n * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF\n * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.\n */", 
+            "comment": null,
+            "cross_refs": []
+        }, 
+        {
+            "name": null,
+            "identifier": "LicenseRef-2",
+            "text": "This package includes the GRDDL parser developed by Hewlett Packard under the following license:\n\u00a9 Copyright 2007 Hewlett-Packard Development Company, LP\n\nRedistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met: \n\nRedistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer. \nRedistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution. \nThe name of the author may not be used to endorse or promote products derived from this software without specific prior written permission. \nTHIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. ", 
+            "comment": null,
+            "cross_refs": []
+        }, 
+        {
+            "name": "CyberNeko License",
+            "identifier": "LicenseRef-3",
+            "text": "The CyberNeko Software License, Version 1.0\n\n \n(C) Copyright 2002-2005, Andy Clark.  All rights reserved.\n \nRedistribution and use in source and binary forms, with or without\nmodification, are permitted provided that the following conditions\nare met:\n\n1. Redistributions of source code must retain the above copyright\n   notice, this list of conditions and the following disclaimer. \n\n2. Redistributions in binary form must reproduce the above copyright\n   notice, this list of conditions and the following disclaimer in\n   the documentation and/or other materials provided with the\n   distribution.\n\n3. The end-user documentation included with the redistribution,\n   if any, must include the following acknowledgment:  \n     \"This product includes software developed by Andy Clark.\"\n   Alternately, this acknowledgment may appear in the software itself,\n   if and wherever such third-party acknowledgments normally appear.\n\n4. The names \"CyberNeko\" and \"NekoHTML\" must not be used to endorse\n   or promote products derived from this software without prior \n   written permission. For written permission, please contact \n   andyc@cyberneko.net.\n\n5. Products derived from this software may not be called \"CyberNeko\",\n   nor may \"CyberNeko\" appear in their name, without prior written\n   permission of the author.\n\nTHIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESSED OR IMPLIED\nWARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES\nOF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE\nDISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR OTHER CONTRIBUTORS\nBE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, \nOR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT \nOF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR \nBUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, \nWHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE \nOR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, \nEVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.", 
+            "comment": "This is tye CyperNeko License",
+            "cross_refs": [
+                "http://justasample.url.com", 
+                "http://people.apache.org/~andyc/neko/LICENSE"
+            ]
+        }, 
+        {
+            "name": null,
+            "identifier": "LicenseRef-4",
+            "text": "/*\n * (c) Copyright 2009 University of Bristol\n * All rights reserved.\n *\n * Redistribution and use in source and binary forms, with or without\n * modification, are permitted provided that the following conditions\n * are met:\n * 1. Redistributions of source code must retain the above copyright\n *    notice, this list of conditions and the following disclaimer.\n * 2. Redistributions in binary form must reproduce the above copyright\n *    notice, this list of conditions and the following disclaimer in the\n *    documentation and/or other materials provided with the distribution.\n * 3. The name of the author may not be used to endorse or promote products\n *    derived from this software without specific prior written permission.\n *\n * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR\n * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES\n * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.\n * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,\n * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT\n * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,\n * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY\n * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT\n * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF\n * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.\n */  ", 
+            "comment": null,
+            "cross_refs": []
+        }
+    ],
+    "annotations": [
+        {
+            "id": "https://spdx.org/spdxdocs/spdx-example-444504E0-4F89-41D3-9A0C-0305E82C3301#SPDXRef-45", 
+            "comment": "This is just an example. Some of the non-standard licenses look like they are actually BSD 3 clause licenses", 
+            "type": "REVIEW", 
+            "annotator": {
+               "type": "Person", 
+               "name": "Jim Reviewer", 
+               "email": null
+            }, 
+            "date": "2012-06-13T00:00:00Z"
+        }
+    ],
+    "reviews": [
+        {
+            "comment": "This is just an example.  Some of the non-standard licenses look like they are actually BSD 3 clause licenses", 
+            "reviewer": {
+                "type": "Person",
+                "name": "Joe Reviewer", 
+                "email": null
+            }, 
+            "date": "2010-02-10T00:00:00Z"
+        }, 
+        {
+            "comment": "Another example reviewer.", 
+            "reviewer": {
+                "type": "Person",
+                "name": "Suzanne Reviewer", 
+                "email": null
+            }, 
+            "date": "2011-03-13T00:00:00Z"
+        }
+    ]
+}

--- a/tests/test_rdf_parser.py
+++ b/tests/test_rdf_parser.py
@@ -1,0 +1,62 @@
+from __future__ import absolute_import
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import unittest
+import json
+from unittest import TestCase
+from tests import utils_test
+from tests.utils_test import TestParserUtils
+from spdx.parsers import rdf
+from spdx.parsers.rdfbuilders import Builder as RDFBuilder
+from spdx.parsers.loggers import StandardLogger
+
+
+class TestParser(TestCase):
+
+    def test_rdf_parser(self):
+        parser = rdf.Parser(RDFBuilder(), StandardLogger())
+        test_file = utils_test.get_test_loc('../../data/SPDXRdfExample.rdf', test_data_dir=utils_test.test_data_dir)
+        with open(test_file, 'r') as file:
+            document, _ = parser.parse(file)
+        expected_loc = utils_test.get_test_loc('doc_parse/spdx-expected.json', test_data_dir=utils_test.test_data_dir)
+        self.check_document(document, expected_loc)
+    
+    def check_document(self, document, expected_loc, regen=False):
+        result = TestParserUtils.to_dict(document)
+
+        if regen:
+            with open(expected_loc, 'w', encoding='utf-8') as o:
+                o.write(result)
+
+        with open(expected_loc, 'r') as ex:
+            expected = json.load(ex, encoding='utf-8')
+
+        self.check_fields(result, expected)
+        assert result == expected
+        
+    def check_fields(self, result, expected):
+        """
+        Test result and expected objects field by field 
+        to provide more specific error messages when failing
+        """
+        assert result['id'] == expected['id']
+        assert result['specVersion'] == expected['specVersion']
+        assert result['namespace'] == expected['namespace']
+        assert result['name'] == expected['name']
+        assert result['comment'] == expected['comment']
+        assert result['dataLicense'] == expected['dataLicense']
+        assert result['licenseListVersion'] == expected['licenseListVersion']
+        assert result['creators'] == expected['creators']
+        assert result['created'] == expected['created']
+        assert result['creatorComment'] == expected['creatorComment']
+        assert result['package']['files'] == expected['package']['files']
+        assert result['package'] == expected['package']
+        assert result['externalDocumentRefs'] == expected['externalDocumentRefs']
+        assert result['extractedLicenses'] == expected['extractedLicenses']
+        assert result['annotations'] == expected['annotations']
+        assert result['reviews'] == expected['reviews']
+        
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
1. About fixing:
 - Pass all rdflib types in RDF parsers into six.text_type function before passing them into RDF builders.
2. About tests:
 - Add test utilities that build a Python dictionary representation of the information stored in models.
 - Add a JSON file with expected info after parsing a test file.
 - Add tests that open a test file, open the expected file and compare them.

Signed-off-by: Xavier Figueroa <xavierfigueroav@gmail.com>