### PR TITLE
Fix parsing of PackageHomePage (was probably a copy and past error),

### DIFF
--- a/data/SPDXTagExample.tag
+++ b/data/SPDXTagExample.tag
@@ -33,6 +33,7 @@ PackageName: SPDX Translator
 SPDXID: SPDXRef-Package
 PackageVersion: Version 0.9.2
 PackageDownloadLocation: http://www.spdx.org/tools
+PackageHomePage: http://www.spdx.org/tools
 PackageSummary: <text>SPDX Translator utility</text>
 PackageSourceInfo: <text>Version 1.0 of the SPDX Translator application</text>
 PackageFileName: spdxtranslator-1.0.zip

--- a/spdx/parsers/tagvalue.py
+++ b/spdx/parsers/tagvalue.py
@@ -963,7 +963,7 @@ class Parser(object):
     def p_pkg_home_1(self, p):
         """pkg_home : PKG_HOME pkg_home_value"""
         try:
-            self.builder.set_pkg_down_location(self.document, p[2])
+            self.builder.set_pkg_home(self.document, p[2])
         except OrderError:
             self.order_error('PackageHomePage', 'PackageName', p.lineno(1))
         except CardinalityError:


### PR DESCRIPTION
add PackageHomePage tag to SPDXTagExample.tag

Signed-off-by: Andreas Kleber <andreas@drosselweg7a.de>