### PR TITLE
added an authors file

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,0 +1,29 @@
+# This is the list of [Project Name] authors for copyright purposes. This does
+# not necessarily list everyone who has contributed code, since in some cases,
+# their employer may be the copyright holder. To see the full list of
+# contributors, see the revision history in source control.
+
+Ahmed H. Ismail <ahm3d.hisham@gmail.com>
+Philippe Ombredanne <pombredanne@nexb.com>
+Sebastian Schuberth <sschuberth@users.noreply.github.com>
+Xavier Figueroa <xavierfigueroav@gmail.com>
+yash-nisar <yash.nisar@somaiya.edu>
+Carmen Bianca Bakker <carmen@carmenbianca.eu>
+Clemens Lang <clemens.lang@bmw-carit.de>
+Hugo Jacob <Hugo.Jacob@bmw.de>
+Tushar Mittal <chiragmittal.mittal@gmail.com>
+Macrovve <macrovve@gmail.com>
+Kyle Altendorf <sda@fstab.net>
+rtgdk <rohit.lodhartg@gmail.com>
+Steven Kalt <kalt.steven@gmail.com>
+Peter Williams <pezra@barelyenough.org>
+Ahmed Hisham Ismail <ahm3d.hisham@gmail.com>
+Alexander Lisianoi <all3fox@gmail.com>
+Thomas Hafner <thomas.hafner@harman.com>
+Rohit Lodha <sschuberth@gmail.com>
+aviral1701 <aviral1701@gmail.com>
+Vignesh <vettyvignesh@gmail.com>
+Krys Nuvadga <tetechris20@gmail.com>
+abhishekspeer <abhishek.abhishekgaur.gaur@gmail.com>
+Omkar <omkar108591@gmail.com>
+Andreas Kleber <andreas@drosselweg7a.de>


### PR DESCRIPTION
Adressesses #113.  Authors are added in order of the number of commits contributed from most to least, with recency breaking ties. I used each contributor's most recent email address.

<details><summary>Code used to generate authors list</summary>

```python
from subprocess import run, PIPE
from collections import Counter, OrderedDict


def get_authors():
    return run(
        "git log --use-mailmap --format=format:'%aN#<%aE>'".split(" "),
        stdout=PIPE,
    ).stdout.decode()


def get_authors_list():
    return [auth.split("#") for auth in get_authors().split("\n")]


def by_recency(authors):
    order = OrderedDict()
    for name, email in authors:
        result = order.get(name, [])
        result.append(email)
        order[name] = result
    return "\n".join([f"{i} {order[i][0]}" for i in order])


def by_commit_count(authors):
    count = Counter()
    name_emails = {}
    for name, email in authors:
        count[name] += 1
        if name not in name_emails:
            name_emails[name] = email
    by_count = [*count.items()]
    by_count.sort(key=lambda x: x[1])
    by_count = by_count[::-1]
    return "\n".join(
        " ".join((name, name_emails[name])) for name, count in by_count
    )


if __name__ == "__main__":
    with open("AUTHORS", "w") as target:
        target.write(by_commit_count(get_authors_list()))

```
</details>

Signed-off-by: Steven Kalt <kalt.steven@gmail.com>