### PR TITLE
Remove Redundant Assignments and Few other Fixes

### DIFF
--- a/spdx/annotation.py
+++ b/spdx/annotation.py
@@ -76,35 +76,30 @@ class Annotation(object):
         """Returns True if all the fields are valid.
         Appends any error messages to messages parameter.
         """
-        messages = self.validate_annotator(messages)
-        messages = self.validate_annotation_date(messages)
-        messages = self.validate_annotation_type(messages)
-        messages = self.validate_spdx_id(messages)
-
+        self.validate_annotator(messages)
+        self.validate_annotation_date(messages)
+        self.validate_annotation_type(messages)
+        self.validate_spdx_id(messages)
         return messages
 
     def validate_annotator(self, messages):
         if self.annotator is None:
-            messages = messages + ['Annotation missing annotator.']
-
+            messages.append('Annotation missing annotator.')
         return messages
 
     def validate_annotation_date(self, messages):
         if self.annotation_date is None:
-            messages = messages + ['Annotation missing annotation date.']
-
+            messages.append('Annotation missing annotation date.')
         return messages
 
     def validate_annotation_type(self, messages):
         if self.annotation_type is None:
-            messages = messages + ['Annotation missing annotation type.']
-
+            messages.append('Annotation missing annotation type.')
         return messages
 
     def validate_spdx_id(self, messages):
         if self.spdx_id is None:
-            messages = messages + [
+            messages.append(
                 'Annotation missing SPDX Identifier Reference.'
-            ]
-
+            )
         return messages

--- a/spdx/creationinfo.py
+++ b/spdx/creationinfo.py
@@ -156,20 +156,18 @@ class CreationInfo(object):
         """Returns True if the fields are valid according to the SPDX standard.
         Appends user friendly messages to the messages parameter.
         """
-        messages = self.validate_creators(messages)
-        messages = self.validate_created(messages)
-
+        self.validate_creators(messages)
+        self.validate_created(messages)
         return messages
 
     def validate_creators(self, messages):
         if len(self.creators) == 0:
-            messages = messages + [
-                'No creators defined, must have at least one.']
-
+            messages.append(
+                'No creators defined, must have at least one.'
+            )
         return messages
 
     def validate_created(self, messages):
         if self.created is None:
-            messages = messages + ['Creation info missing created date.']
-
+            messages.append('Creation info missing created date.')
         return messages

--- a/spdx/document.py
+++ b/spdx/document.py
@@ -56,32 +56,29 @@ class ExternalDocumentRef(object):
         Validate all fields of the ExternalDocumentRef class and update the
         messages list with user friendly error messages for display.
         """
-        messages = self.validate_ext_doc_id(messages)
-        messages = self.validate_spdx_doc_uri(messages)
-        messages = self.validate_checksum(messages)
-
+        self.validate_ext_doc_id(messages)
+        self.validate_spdx_doc_uri(messages)
+        self.validate_checksum(messages)
         return messages
 
     def validate_ext_doc_id(self, messages):
         if not self.external_document_id:
-            messages = messages + [
+            messages.append(
                 'ExternalDocumentRef has no External Document ID.'
-            ]
-
+            )
         return messages
 
     def validate_spdx_doc_uri(self, messages):
         if not self.spdx_document_uri:
-            messages = messages + [
+            messages.append(
                 'ExternalDocumentRef has no SPDX Document URI.'
-            ]
+            )
 
         return messages
 
     def validate_checksum(self, messages):
         if not self.check_sum:
-            messages = messages + ['ExternalDocumentRef has no Checksum.']
-
+            messages.append('ExternalDocumentRef has no Checksum.')
         return messages
 
 
@@ -319,56 +316,51 @@ class Document(object):
         Validate all fields of the document and update the
         messages list with user friendly error messages for display.
         """
-        messages = self.validate_version(messages)
-        messages = self.validate_data_lics(messages)
-        messages = self.validate_name(messages)
-        messages = self.validate_spdx_id(messages)
-        messages = self.validate_namespace(messages)
-        messages = self.validate_ext_document_references(messages)
-        messages = self.validate_creation_info(messages)
-        messages = self.validate_package(messages)
-        messages = self.validate_extracted_licenses(messages)
-        messages = self.validate_reviews(messages)
-        messages = self.validate_snippet(messages)
-
+        self.validate_version(messages)
+        self.validate_data_lics(messages)
+        self.validate_name(messages)
+        self.validate_spdx_id(messages)
+        self.validate_namespace(messages)
+        self.validate_ext_document_references(messages)
+        self.validate_creation_info(messages)
+        self.validate_package(messages)
+        self.validate_extracted_licenses(messages)
+        self.validate_reviews(messages)
+        self.validate_snippet(messages)
         return messages
 
     def validate_version(self, messages):
         if self.version is None:
-            messages = messages + ['Document has no version.']
-
+            messages.append('Document has no version.')
         return messages
 
     def validate_data_lics(self, messages):
         if self.data_license is None:
-            messages = messages + ['Document has no data license.']
+            messages.append('Document has no data license.')
         else:
         # FIXME: REALLY? what if someone wants to use something else?
             if self.data_license.identifier != 'CC0-1.0':
-                messages = messages + ['Document data license must be CC0-1.0.']
-
+                messages.append('Document data license must be CC0-1.0.')
         return messages
 
     def validate_name(self, messages):
         if self.name is None:
-            messages = messages + ['Document has no name.']
-
+            messages.append('Document has no name.')
         return messages
 
     def validate_namespace(self, messages):
         if self.namespace is None:
-            messages = messages + ['Document has no namespace.']
-
+            messages.append('Document has no namespace.')
         return messages
 
     def validate_spdx_id(self, messages):
         if self.spdx_id is None:
-            messages = messages + ['Document has no SPDX Identifier.']
+            messages.append('Document has no SPDX Identifier.')
         else:
             if not self.spdx_id.endswith('SPDXRef-DOCUMENT'):
-                messages = messages + [
+                messages.append(
                     'Invalid Document SPDX Identifier value.'
-                ]
+                )
 
         return messages
 
@@ -381,6 +373,7 @@ class Document(object):
                     'External document references must be of the type '
                     'spdx.document.ExternalDocumentRef and not ' + str(type(doc))
                 ]
+
         return messages
 
     def validate_reviews(self, messages):
@@ -405,16 +398,14 @@ class Document(object):
         if self.creation_info is not None:
             messages = self.creation_info.validate(messages)
         else:
-            messages = messages + ['Document has no creation information.']
-
+            messages.append('Document has no creation information.')
         return messages
 
     def validate_package(self, messages):
         if self.package is not None:
             messages = self.package.validate(messages)
         else:
-            messages = messages + ['Document has no package.']
-
+            messages.append('Document has no package.')
         return messages
 
     def validate_extracted_licenses(self, messages):

--- a/spdx/file.py
+++ b/spdx/file.py
@@ -100,19 +100,19 @@ class File(object):
         """Validates the fields and appends user friendly messages
         to messages parameter if there are errors.
         """
-        messages = self.validate_concluded_license(messages)
-        messages = self.validate_type(messages)
-        messages = self.validate_checksum(messages)
-        messages = self.validate_licenses_in_file(messages)
-        messages = self.validate_copyright(messages)
-        messages = self.validate_artifacts(messages)
-        messages = self.validate_spdx_id(messages)
+        self.validate_concluded_license(messages)
+        self.validate_type(messages)
+        self.validate_checksum(messages)
+        self.validate_licenses_in_file(messages)
+        self.validate_copyright(messages)
+        self.validate_artifacts(messages)
+        self.validate_spdx_id(messages)
 
         return messages
 
     def validate_spdx_id(self, messages):
         if self.spdx_id is None:
-            messages = messages + ['File has no SPDX Identifier.']
+            messages.append('File has no SPDX Identifier.')
 
         return messages
 
@@ -121,10 +121,10 @@ class File(object):
             self.copyright,
             (six.string_types, six.text_type, utils.NoAssert, utils.SPDXNone)
         ):
-            messages = messages + [
+            messages.append(
                 'File copyright must be str or unicode or '
                 'utils.NoAssert or utils.SPDXNone'
-            ]
+            )
 
         return messages
 
@@ -132,17 +132,18 @@ class File(object):
         if (len(self.artifact_of_project_home) <
             max(len(self.artifact_of_project_uri),
                 len(self.artifact_of_project_name))):
-            messages = messages + [
-                'File must have as much artifact of project as uri or homepage']
+            messages.append(
+                'File must have as much artifact of project as uri or homepage'
+            )
 
         return messages
 
     def validate_licenses_in_file(self, messages):
         # FIXME: what are we testing the length of a list? or?
         if len(self.licenses_in_file) == 0:
-            messages = messages + [
+            messages.append(
                 'File must have at least one license in file.'
-            ]
+            )
 
         return messages
 
@@ -150,10 +151,10 @@ class File(object):
         # FIXME: use isinstance instead??
         if not isinstance(self.conc_lics, (document.License, utils.NoAssert,
                                            utils.SPDXNone)):
-            messages = messages + [
+            messages.append(
                 'File concluded license must be one of '
                 'document.License, utils.NoAssert or utils.SPDXNone'
-            ]
+            )
 
         return messages
 
@@ -162,21 +163,21 @@ class File(object):
             None, FileType.SOURCE, FileType.OTHER, FileType.BINARY,
             FileType.ARCHIVE
         ]:
-            messages = messages + [
+            messages.append(
                 'File type must be one of the constants defined in '
                 'class spdx.file.FileType'
-            ]
+            )
 
         return messages
 
     def validate_checksum(self, messages):
         if not isinstance(self.chk_sum, checksum.Algorithm):
-            messages = messages + [
+            messages.append(
                 'File checksum must be instance of spdx.checksum.Algorithm'
-            ]
+            )
         else:
             if not self.chk_sum.identifier == 'SHA1':
-                messages = messages + ['File checksum algorithm must be SHA1']
+                messages.append('File checksum algorithm must be SHA1')
 
         return messages
 

--- a/spdx/package.py
+++ b/spdx/package.py
@@ -107,28 +107,28 @@ class Package(object):
         Validate the package fields.
         Append user friendly error messages to the `messages` list.
         """
-        messages = self.validate_checksum(messages)
-        messages = self.validate_optional_str_fields(messages)
-        messages = self.validate_mandatory_str_fields(messages)
-        messages = self.validate_files(messages)
-        messages = self.validate_pkg_ext_refs(messages)
-        messages = self.validate_mandatory_fields(messages)
-        messages = self.validate_optional_fields(messages)
+        self.validate_checksum(messages)
+        self.validate_optional_str_fields(messages)
+        self.validate_mandatory_str_fields(messages)
+        self.validate_files(messages)
+        self.validate_pkg_ext_refs(messages)
+        self.validate_mandatory_fields(messages)
+        self.validate_optional_fields(messages)
 
         return messages
 
     def validate_optional_fields(self, messages):
         if self.originator and not isinstance(self.originator, (utils.NoAssert, creationinfo.Creator)):
-            messages = messages + [
+            messages.append(
                 'Package originator must be instance of '
                 'spdx.utils.NoAssert or spdx.creationinfo.Creator'
-            ]
+            )
 
         if self.supplier and not isinstance(self.supplier, (utils.NoAssert, creationinfo.Creator)):
-            messages = messages + [
+            messages.append(
                 'Package supplier must be instance of '
                 'spdx.utils.NoAssert or spdx.creationinfo.Creator'
-            ]
+            )
 
         return messages
 
@@ -137,49 +137,49 @@ class Package(object):
             if isinstance(ref, ExternalPackageRef):
                 messages = ref.validate(messages)
             else:
-                messages = messages + [
+                messages.append(
                     'External package references must be of the type '
                     'spdx.package.ExternalPackageRef and not ' + str(type(ref))
-                ]
+                )
 
         return messages
 
     def validate_mandatory_fields(self, messages):
         if not isinstance(self.conc_lics, (utils.SPDXNone, utils.NoAssert, document.License)):
-            messages = messages + [
+            messages.append(
                 'Package concluded license must be instance of '
                 'spdx.utils.SPDXNone or spdx.utils.NoAssert or '
                 'spdx.document.License'
-            ]
+            )
 
         if not isinstance(self.license_declared, (utils.SPDXNone, utils.NoAssert, document.License)):
-            messages = messages + [
+            messages.append(
                 'Package declared license must be instance of '
                 'spdx.utils.SPDXNone or spdx.utils.NoAssert or '
                 'spdx.document.License'
-            ]
+            )
 
-        # FIXME: this is obscure and unreadable
-        license_from_file_check = lambda prev, el: prev and isinstance(el, (document.License, utils.SPDXNone, utils.NoAssert))
-        if not reduce(license_from_file_check, self.licenses_from_files, True):
-            messages = messages + [
+        # expected_data_types.
+        exp_dtypes = (document.License, utils.SPDXNone, utils.NoAssert)
+        if not all(isinstance(el, exp_dtypes) for el in self.licenses_from_files):
+            messages.append(
                 'Each element in licenses_from_files must be instance of '
                 'spdx.utils.SPDXNone or spdx.utils.NoAssert or '
                 'spdx.document.License'
-            ]
+            )
 
         if not self.licenses_from_files:
-            messages = messages + [
+            messages.append(
                 'Package licenses_from_files can not be empty'
-            ]
+            )
 
         return messages
 
     def validate_files(self, messages):
         if not self.files:
-            messages = messages + [
+            messages.append(
                 'Package must have at least one file.'
-            ]
+            )
         else:
             for f in self.files:
                 messages = f.validate(messages)
@@ -221,25 +221,25 @@ class Package(object):
                 # FIXME: this does not make sense???
                 attr = getattr(field, '__str__', None)
                 if not callable(attr):
-                    messages = messages + [
+                    messages.append(
                         '{0} must provide __str__ method.'.format(field)
-                    ]
+                    )
                     # Continue checking.
             elif not optional:
-                messages = messages + [
+                messages.append(
                     'Package {0} can not be None.'.format(field_str)
-                ]
+                )
 
         return messages
 
     def validate_checksum(self, messages):
         if not isinstance(self.check_sum, checksum.Algorithm):
-            messages = messages + [
+            messages.append(
                 'Package checksum must be instance of spdx.checksum.Algorithm'
-            ]
+            )
         else:
             if self.check_sum.identifier != 'SHA1':
-                messages = messages + ['File checksum algorithm must be SHA1']
+                messages.append('File checksum algorithm must be SHA1')
 
         return messages
 
@@ -291,26 +291,26 @@ class ExternalPackageRef(object):
         Validate all fields of the ExternalPackageRef class and update the
         messages list with user friendly error messages for display.
         """
-        messages = self.validate_category(messages)
-        messages = self.validate_pkg_ext_ref_type(messages)
-        messages = self.validate_locator(messages)
+        self.validate_category(messages)
+        self.validate_pkg_ext_ref_type(messages)
+        self.validate_locator(messages)
 
         return messages
 
     def validate_category(self, messages=None):
         if self.category is None:
-            messages = messages + ['ExternalPackageRef has no category.']
+            messages.append('ExternalPackageRef has no category.')
 
         return messages
 
     def validate_pkg_ext_ref_type(self, messages=None):
         if self.pkg_ext_ref_type is None:
-            messages = messages + ['ExternalPackageRef has no type.']
+            messages.append('ExternalPackageRef has no type.')
 
         return messages
 
     def validate_locator(self, messages=None):
         if self.locator is None:
-            messages = messages + ['ExternalPackageRef has no locator.']
+            messages.append('ExternalPackageRef has no locator.')
 
         return messages

--- a/spdx/review.py
+++ b/spdx/review.py
@@ -65,19 +65,19 @@ class Review(object):
         """Returns True if all the fields are valid.
         Appends any error messages to messages parameter.
         """
-        messages = self.validate_reviewer(messages)
-        messages = self.validate_review_date(messages)
+        self.validate_reviewer(messages)
+        self.validate_review_date(messages)
 
         return messages
 
     def validate_reviewer(self, messages):
         if self.reviewer is None:
-            messages = messages + ['Review missing reviewer.']
+            messages.append('Review missing reviewer.')
 
         return messages
 
     def validate_review_date(self, messages):
         if self.review_date is None:
-            messages = messages + ['Review missing review date.']
+            messages.append('Review missing review date.')
 
         return messages

--- a/spdx/snippet.py
+++ b/spdx/snippet.py
@@ -57,63 +57,63 @@ class Snippet(object):
     def add_lics(self, lics):
         self.licenses_in_snippet.append(lics)
 
-    def validate(self, messages=None):
+    def validate(self, messages=[]):
         """
         Validate fields of the snippet and update the messages list with user
         friendly error messages for display.
         """
-        messages = self.validate_spdx_id(messages)
-        messages = self.validate_copyright_text(messages)
-        messages = self.validate_snip_from_file_spdxid(messages)
-        messages = self.validate_concluded_license(messages)
-        messages = self.validate_licenses_in_snippet(messages)
+        self.validate_spdx_id(messages)
+        self.validate_copyright_text(messages)
+        self.validate_snip_from_file_spdxid(messages)
+        self.validate_concluded_license(messages)
+        self.validate_licenses_in_snippet(messages)
 
         return messages
 
-    def validate_spdx_id(self, messages=None):
+    def validate_spdx_id(self, messages=[]):
         if self.spdx_id is None:
-            messages = messages + ['Snippet has no SPDX Identifier.']
+            messages.append('Snippet has no SPDX Identifier.')
 
         return messages
 
-    def validate_copyright_text(self, messages=None):
+    def validate_copyright_text(self, messages=[]):
         if not isinstance(
             self.copyright,
                 (six.string_types, six.text_type, utils.NoAssert,
                  utils.SPDXNone)):
-            messages = messages + [
+            messages.append(
                 'Snippet copyright must be str or unicode or utils.NoAssert or utils.SPDXNone'
-            ]
+            )
 
         return messages
 
-    def validate_snip_from_file_spdxid(self, messages=None):
+    def validate_snip_from_file_spdxid(self, messages=[]):
         if self.snip_from_file_spdxid is None:
-            messages = messages + ['Snippet has no Snippet from File SPDX Identifier.']
+            messages.append('Snippet has no Snippet from File SPDX Identifier.')
 
         return messages
 
-    def validate_concluded_license(self, messages=None):
+    def validate_concluded_license(self, messages=[]):
         if not isinstance(self.conc_lics, (document.License, utils.NoAssert,
                                        utils.SPDXNone)):
-            messages = messages + [
+            messages.append(
                 'Snippet Concluded License must be one of '
                 'document.License, utils.NoAssert or utils.SPDXNone'
-            ]
+            )
 
         return messages
 
-    def validate_licenses_in_snippet(self, messages=None):
+    def validate_licenses_in_snippet(self, messages=[]):
         if len(self.licenses_in_snippet) == 0:
-            messages = messages + ['Snippet must have at least one license in file.']
+            messages.append('Snippet must have at least one license in file.')
         else:
             for lic in self.licenses_in_snippet:
                 if not isinstance(lic, (document.License, utils.NoAssert,
                                         utils.SPDXNone)):
-                    messages = messages + [
+                    messages.append(
                         'Licenses in Snippet must be one of '
                         'document.License, utils.NoAssert or utils.SPDXNone'
-                    ]
+                    )
 
         return messages
 

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -115,6 +115,7 @@ class TestDocument(TestCase):
         package.spdx_id = 'SPDXRef-Package'
         package.cr_text = 'Some copyrught'
         package.verif_code = 'SOME code'
+        package.check_sum = Algorithm('SHA1', 'SOME-SHA1')
         package.license_declared = NoAssert()
         package.conc_lics = NoAssert()
 
@@ -131,8 +132,8 @@ class TestDocument(TestCase):
         package.add_lics_from_file(lic1)
         package.add_file(file1)
         messages = []
-        is_valid = doc.validate(messages)
-        assert is_valid
+        messages = doc.validate(messages)
+        # assert is_valid
         assert not messages
 
 


### PR DESCRIPTION
fixes #130 .

[5547e73] Remove Redundant Assignments and Minor Changes
 - messages variable is not repeatedly reassigned.
 - a new list with a single string is not created.
 - fixed a FIXME.
 - Change the default value of messages parameter from None to [] in the function definition.

[c27d292] Modify Test File

 - call of Document.validate expected different data types in tests/document.py
     - test_document_is_valid_when_using_or_later_license expected doc.validate to return bool value.
     - test_document_validate_failures_returns_informative_messages expects doc.validate to return a list
 - For pkg defined in test_document_is_valid_when_using_or_later_license to be valid, check_sum was assigned to it.