### PR TITLE
Fix write_tv example

### DIFF
--- a/examples/write_tv.py
+++ b/examples/write_tv.py
@@ -21,7 +21,10 @@ if __name__ == '__main__':
 
     doc = Document()
     doc.version = Version(1, 2)
+    doc.name = 'Hello SPDX'
+    doc.spdx_id = 'Test#SPDXRef-DOCUMENT'
     doc.comment = 'Example Document'
+    doc.namespace = 'spdx'
     doc.data_license = License.from_identifier('CC0-1.0')
     doc.creation_info.add_creator(Person('Alice', 'alice@example.com'))
     doc.creation_info.set_created_now()
@@ -32,6 +35,7 @@ if __name__ == '__main__':
     # File
     testfile1 = File('TestFile1')
     testfile1.type = FileType.BINARY
+    testfile1.spdx_id = 'TestFilet#SPDXRef-FILE'
     testfile1.comment = 'This is a test file.'
     testfile1.chk_sum = Algorithm('SHA1', 'c537c5d99eca5333f23491d47ededd083fefb7ad')
     testfile1.conc_lics = License.from_identifier('BSD-2-Clause')
@@ -43,6 +47,7 @@ if __name__ == '__main__':
 
     testfile2 = File('TestFile2')
     testfile2.type = FileType.SOURCE
+    testfile2.spdx_id = 'TestFile2#SPDXRef-FILE'
     testfile2.comment = 'This is a test file.'
     testfile2.chk_sum = Algorithm('SHA1', 'bb154f28d1cf0646ae21bb0bec6c669a2b90e113')
     testfile2.conc_lics = License.from_identifier('Apache-2.0')
@@ -55,7 +60,9 @@ if __name__ == '__main__':
     package.name = 'TagWriteTest'
     package.version = '1.0'
     package.file_name = 'twt.jar'
+    package.spdx_id = 'TestPackage#SPDXRef-PACKAGE'
     package.download_location = 'http://www.tagwritetest.test/download'
+    package.check_sum = Algorithm('SHA1', 'c537c5d99eca5333f23491d47ededd083fefb7ad')
     package.homepage = SPDXNone()
     package.verif_code = '4e3211c67a2d28fced849ee1bb76e7391b93feba'
     license_set = LicenseConjunction(License.from_identifier('Apache-2.0'),

--- a/examples/write_tv.py
+++ b/examples/write_tv.py
@@ -89,8 +89,10 @@ if __name__ == '__main__':
     with codecs.open(file, mode='w', encoding='utf-8') as out:
         try:
             write_document(doc, out)
-        except InvalidDocumentError:
-            print('Document is Invalid')
+        except InvalidDocumentError as e:
+            print('Document is Invalid:\n\t', end='')
+            #import pdb; pdb.set_trace()
+            print("\n\t".join(e.args[0]))
             messages = []
             doc.validate(messages)
             print('\n'.join(messages))


### PR DESCRIPTION
I've been fiddling with the python library lately. I found a couple of little
hiccups in the write_tv example. I'm opening this PR so I don't forget,
although I'll admit I haven't done my due dilligence figuring out if this
example is in fact already fixed somewhere else (and apologies for that!).

Also, the spdx_id fields that I chose may prove to be not entirely compliant,
as I just read the validation code and  picked something that passed...