### PR TITLE
Fixes the install error in Python 2.7 and CircleCI error with Python 3.4.8

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,7 @@ jobs:
         brew update
         python --version
         sudo -H pip install --upgrade virtualenv
-        brew install pyenv
+        brew install pyenv -v 1.2.13
         echo 'eval "$(pyenv init -)"' >> ~/.bash_profile
         source ~/.bash_profile
         pyenv install 3.4.8

--- a/setup.py
+++ b/setup.py
@@ -30,11 +30,13 @@ setup(
     test_suite='setup.test_suite',
     install_requires=[
         'ply',
+        'pyparsing<=1.5.7;python_version<="2.8"',
         'rdflib',
         'six',
         'pyyaml',
         'xmltodict',
     ],
+    python_requires='>=2.7',
     entry_points={
         'console_scripts': [
             'spdx-tv2rdf = spdx.tv_to_rdf:main',


### PR DESCRIPTION
Signed-off-by: Shubham Kumar Jha <skjha832@gmail.com>

Fixes #140 
Build failures were occurring in Python2 due to `rdflib` allowing any version of `pyparsing` (it's dependency) to be installed. It eventually installs the latest version which doesn't work with Python 2.7.

Fix:
* Updated setup.py file to install pyparsing <= 1.5.7 when installed with Python 2.7
* Since, rdflib allows any version of pyparsing to be installed, the latest version is not installed.