### PR TITLE
[needs review] Added Relationship class to spdx-python tool

### DIFF
--- a/data/SPDXJsonExample.json
+++ b/data/SPDXJsonExample.json
@@ -128,6 +128,43 @@
                 "annotator": "Person: Jim Reviewer"
             }
         ], 
+        "relationships" : [ {
+    "spdxElementId" : "SPDXRef-DOCUMENT",
+    "relatedSpdxElement" : "SPDXRef-Package",
+    "relationshipType" : "CONTAINS"
+  }, {
+    "spdxElementId" : "SPDXRef-DOCUMENT",
+    "relatedSpdxElement" : "SPDXRef-File",
+    "relationshipType" : "DESCRIBES"
+  }, {
+    "spdxElementId" : "SPDXRef-DOCUMENT",
+    "relatedSpdxElement" : "DocumentRef-spdx-tool-1.2:SPDXRef-ToolsElement",
+    "relationshipType" : "COPY_OF"
+  }, {
+    "spdxElementId" : "SPDXRef-DOCUMENT",
+    "relatedSpdxElement" : "SPDXRef-Package",
+    "relationshipType" : "DESCRIBES"
+  }, {
+    "spdxElementId" : "SPDXRef-Package",
+    "relatedSpdxElement" : "SPDXRef-Saxon",
+    "relationshipType" : "DYNAMIC_LINK"
+  }, {
+    "spdxElementId" : "SPDXRef-Package",
+    "relatedSpdxElement" : "SPDXRef-JenaLib",
+    "relationshipType" : "CONTAINS"
+  }, {
+    "spdxElementId" : "SPDXRef-CommonsLangSrc",
+    "relatedSpdxElement" : "NOASSERTION",
+    "relationshipType" : "GENERATED_FROM"
+  }, {
+    "spdxElementId" : "SPDXRef-JenaLib",
+    "relatedSpdxElement" : "SPDXRef-Package",
+    "relationshipType" : "CONTAINS"
+  }, {
+    "spdxElementId" : "SPDXRef-File",
+    "relatedSpdxElement" : "SPDXRef-fromDoap-0",
+    "relationshipType" : "GENERATED_FROM"
+  } ],
         "dataLicense": "CC0-1.0", 
         "reviewers": [
             {

--- a/data/SPDXRdfExample.rdf
+++ b/data/SPDXRdfExample.rdf
@@ -115,6 +115,12 @@
         <annotator>Person: Jim Reviewer</annotator>
       </Annotation>
     </annotation>
+    <relationship>
+      <Relationship>
+        <relationshipType rdf:resource="http://spdx.org/rdf/terms#relationshipType_describes"/>
+        <relatedSpdxElement rdf:resource="http://spdx.org/spdxdocs/spdx-example-444504E0-4F89-41D3-9A0C-0305E82C3301#SPDXRef-Package"/>
+      </Relationship>
+    </relationship>
     <referencesFile>
       <File rdf:about="https://spdx.org/spdxdocs/spdx-example-444504E0-4F89-41D3-9A0C-0305E82C3301#SPDXRef-File2">
         <copyrightText>Copyright 2010, 2011 Source Auditor Inc.</copyrightText>

--- a/data/SPDXTagExample.tag
+++ b/data/SPDXTagExample.tag
@@ -24,9 +24,15 @@ ReviewComment: <text>Another example reviewer.</text>
 ## Annotation Information
 Annotator: Person: Jim Annotator
 AnnotationType: REVIEW
-AnnotationDate: 2012-03-11T00:00:00Z
+AnnotationDate: 2010-01-29T18:30:22Z
 AnnotationComment: <text>An example annotation comment.</text>
 SPDXREF: SPDXRef-45
+
+## Relationships
+Relationship: SPDXRef-DOCUMENT DESCRIBES SPDXRef-File
+Relationship: SPDXRef-DOCUMENT DESCRIBES SPDXRef-Package
+Relationship: SPDXRef-DOCUMENT COPY_OF DocumentRef-spdx-tool-1.2:SPDXRef-ToolsElement
+Relationship: SPDXRef-DOCUMENT CONTAINS SPDXRef-Package
 
 ## Package Information
 PackageName: SPDX Translator

--- a/examples/parse_json.py
+++ b/examples/parse_json.py
@@ -3,69 +3,88 @@
 # Parses an JSON file and prints out some basic information.
 # Usage: parse_json.py <jsonfile>
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     import sys
     import spdx.file as spdxfile
     from spdx.parsers.jsonparser import Parser
     from spdx.parsers.loggers import StandardLogger
     from spdx.parsers.jsonyamlxmlbuilders import Builder
+
     file = sys.argv[1]
     p = Parser(Builder(), StandardLogger())
     with open(file) as f:
         doc, error = p.parse(f)
         if not error:
-            print('doc comment: {0}'.format(doc.comment))
-            print('Creators:')
+            print("doc comment: {0}".format(doc.comment))
+            print("Creators:")
             for c in doc.creation_info.creators:
-                print('\t{0}'.format(c))
-            print('Document review information:')
+                print("\t{0}".format(c))
+            print("Document review information:")
             for review in doc.reviews:
-                print('\tReviewer: {0}'.format(review.reviewer))
-                print('\tDate: {0}'.format(review.review_date))
-                print('\tComment: {0}'.format(review.comment))
-            print('Creation comment: {0}'.format(doc.creation_info.comment))
-            print('Package Name: {0}'.format(doc.package.name))
-            print('Package Version: {0}'.format(doc.package.version))
-            print('Package Download Location: {0}'.format(doc.package.download_location))
-            print('Package Homepage: {0}'.format(doc.package.homepage))
-            print('Package Checksum: {0}'.format(doc.package.check_sum.value))
-            print('Package verification code: {0}'.format(doc.package.verif_code))
-            print('Package excluded from verif: {0}'.format(','.join(doc.package.verif_exc_files)))
-            print('Package license concluded: {0}'.format(doc.package.conc_lics))
-            print('Package license declared: {0}'.format(doc.package.license_declared))
-            print('Package licenses from files:')
+                print("\tReviewer: {0}".format(review.reviewer))
+                print("\tDate: {0}".format(review.review_date))
+                print("\tComment: {0}".format(review.comment))
+            print("Creation comment: {0}".format(doc.creation_info.comment))
+            print("Package Name: {0}".format(doc.package.name))
+            print("Package Version: {0}".format(doc.package.version))
+            print(
+                "Package Download Location: {0}".format(doc.package.download_location)
+            )
+            print("Package Homepage: {0}".format(doc.package.homepage))
+            print("Package Checksum: {0}".format(doc.package.check_sum.value))
+            print("Package verification code: {0}".format(doc.package.verif_code))
+            print(
+                "Package excluded from verif: {0}".format(
+                    ",".join(doc.package.verif_exc_files)
+                )
+            )
+            print("Package license concluded: {0}".format(doc.package.conc_lics))
+            print("Package license declared: {0}".format(doc.package.license_declared))
+            print("Package licenses from files:")
             for lics in doc.package.licenses_from_files:
-                print('\t{0}'.format(lics))
-            print('Package Copyright text: {0}'.format(doc.package.cr_text))
-            print('Package summary: {0}'.format(doc.package.summary))
-            print('Package description: {0}'.format(doc.package.description))
-            print('Package Files:')
+                print("\t{0}".format(lics))
+            print("Package Copyright text: {0}".format(doc.package.cr_text))
+            print("Package summary: {0}".format(doc.package.summary))
+            print("Package description: {0}".format(doc.package.description))
+            print("Package Files:")
             VALUES = {
-                spdxfile.FileType.SOURCE: 'SOURCE',
-                spdxfile.FileType.OTHER: 'OTHER',
-                spdxfile.FileType.BINARY: 'BINARY',
-                spdxfile.FileType.ARCHIVE: 'ARCHIVE'
+                spdxfile.FileType.SOURCE: "SOURCE",
+                spdxfile.FileType.OTHER: "OTHER",
+                spdxfile.FileType.BINARY: "BINARY",
+                spdxfile.FileType.ARCHIVE: "ARCHIVE",
             }
             for f in doc.files:
-                print('\tFile name: {0}'.format(f.name))
-                print('\tFile type: {0}'.format(VALUES[f.type]))
-                print('\tFile Checksum: {0}'.format(f.chk_sum.value))
-                print('\tFile license concluded: {0}'.format(f.conc_lics))
-                print('\tFile license info in file: {0}'.format(','.join(
-                     map(lambda l: l.identifier, f.licenses_in_file))))
-                print('\tFile artifact of project name: {0}'.format(','.join(f.artifact_of_project_name)))
+                print("\tFile name: {0}".format(f.name))
+                print("\tFile type: {0}".format(VALUES[f.type]))
+                print("\tFile Checksum: {0}".format(f.chk_sum.value))
+                print("\tFile license concluded: {0}".format(f.conc_lics))
+                print(
+                    "\tFile license info in file: {0}".format(
+                        ",".join(map(lambda l: l.identifier, f.licenses_in_file))
+                    )
+                )
+                print(
+                    "\tFile artifact of project name: {0}".format(
+                        ",".join(f.artifact_of_project_name)
+                    )
+                )
 
-            print('Document Extracted licenses:')
+            print("Document Extracted licenses:")
             for lics in doc.extracted_licenses:
-                print('\tIdentifier: {0}'.format(lics.identifier))
-                print('\tName: {0}'.format(lics.full_name))
-            print('Annotations:')
+                print("\tIdentifier: {0}".format(lics.identifier))
+                print("\tName: {0}".format(lics.full_name))
+            print("Annotations:")
             for an in doc.annotations:
-                print('\tAnnotator: {0}'.format(an.annotator))
-                print('\tAnnotation Date: {0}'.format(an.annotation_date))
-                print('\tAnnotation Comment: {0}'.format(an.comment))
-                print('\tAnnotation Type: {0}'.format(an.annotation_type))
-                print('\tAnnotation SPDX Identifier: {0}'.format(an.spdx_id))
+                print("\tAnnotator: {0}".format(an.annotator))
+                print("\tAnnotation Date: {0}".format(an.annotation_date))
+                print("\tAnnotation Comment: {0}".format(an.comment))
+                print("\tAnnotation Type: {0}".format(an.annotation_type))
+                print("\tAnnotation SPDX Identifier: {0}".format(an.spdx_id))
+
+            print("Relationships: ")
+            for rel in doc.relationships:
+                print("\tRelationship: {0}".format(rel.relationship))
+                print("\tRelationship Comment: {0}".format(rel.relationship_comment))
 
         else:
-            print('Errors while parsing')
+            print("Errors while parsing")

--- a/examples/parse_rdf.py
+++ b/examples/parse_rdf.py
@@ -6,70 +6,91 @@ from __future__ import absolute_import
 from __future__ import print_function
 from __future__ import unicode_literals
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     import sys
     import spdx.file as spdxfile
     from spdx.parsers.rdf import Parser
     from spdx.parsers.loggers import StandardLogger
     from spdx.parsers.rdfbuilders import Builder
+
     file = sys.argv[1]
     p = Parser(Builder(), StandardLogger())
     with open(file) as f:
         doc, error = p.parse(f)
         if not error:
-            print('doc comment: {0}'.format(doc.comment))
-            print('Creators:')
+            print("doc comment: {0}".format(doc.comment))
+            print("Creators:")
             for c in doc.creation_info.creators:
-                print('\t{0}'.format(c))
-            print('Document review information:')
+                print("\t{0}".format(c))
+            print("Document review information:")
             for review in doc.reviews:
-                print('\tReviewer: {0}'.format(review.reviewer))
-                print('\tDate: {0}'.format(review.review_date))
-                print('\tComment: {0}'.format(review.comment))
-            print('Creation comment: {0}'.format(doc.creation_info.comment))
-            print('Package Name: {0}'.format(doc.package.name))
-            print('Package Version: {0}'.format(doc.package.version))
-            print('Package Download Location: {0}'.format(doc.package.download_location))
-            print('Package Homepage: {0}'.format(doc.package.homepage))
-            print('Package Checksum: {0}'.format(doc.package.check_sum.value))
-            print('Package verification code: {0}'.format(doc.package.verif_code))
-            print('Package excluded from verif: {0}'.format(','.join(doc.package.verif_exc_files)))
-            print('Package license concluded: {0}'.format(doc.package.conc_lics))
-            print('Package license declared: {0}'.format(doc.package.license_declared))
-            print('Package licenses from files:')
+                print("\tReviewer: {0}".format(review.reviewer))
+                print("\tDate: {0}".format(review.review_date))
+                print("\tComment: {0}".format(review.comment))
+            print("Creation comment: {0}".format(doc.creation_info.comment))
+            print("Package Name: {0}".format(doc.package.name))
+            print("Package Version: {0}".format(doc.package.version))
+            print(
+                "Package Download Location: {0}".format(doc.package.download_location)
+            )
+            print("Package Homepage: {0}".format(doc.package.homepage))
+            print("Package Checksum: {0}".format(doc.package.check_sum.value))
+            print("Package verification code: {0}".format(doc.package.verif_code))
+            print(
+                "Package excluded from verif: {0}".format(
+                    ",".join(doc.package.verif_exc_files)
+                )
+            )
+            print("Package license concluded: {0}".format(doc.package.conc_lics))
+            print("Package license declared: {0}".format(doc.package.license_declared))
+            print("Package licenses from files:")
             for lics in doc.package.licenses_from_files:
-                print('\t{0}'.format(lics))
-            print('Package Copyright text: {0}'.format(doc.package.cr_text))
-            print('Package summary: {0}'.format(doc.package.summary))
-            print('Package description: {0}'.format(doc.package.description))
-            print('Package Files:')
+                print("\t{0}".format(lics))
+            print("Package Copyright text: {0}".format(doc.package.cr_text))
+            print("Package summary: {0}".format(doc.package.summary))
+            print("Package description: {0}".format(doc.package.description))
+            print("Package Files:")
             VALUES = {
-                spdxfile.FileType.SOURCE: 'SOURCE',
-                spdxfile.FileType.OTHER: 'OTHER',
-                spdxfile.FileType.BINARY: 'BINARY',
-                spdxfile.FileType.ARCHIVE: 'ARCHIVE'
+                spdxfile.FileType.SOURCE: "SOURCE",
+                spdxfile.FileType.OTHER: "OTHER",
+                spdxfile.FileType.BINARY: "BINARY",
+                spdxfile.FileType.ARCHIVE: "ARCHIVE",
             }
             for f in doc.files:
-                print('\tFile name: {0}'.format(f.name))
-                print('\tFile type: {0}'.format(VALUES[f.type]))
-                print('\tFile Checksum: {0}'.format(f.chk_sum.value))
-                print('\tFile license concluded: {0}'.format(f.conc_lics))
-                print('\tFile license info in file: {0}'.format(','.join(
-                    map(lambda l: l.identifier, f.licenses_in_file))))
-                print('\tFile artifact of project name: {0}'.format(','.join(f.artifact_of_project_name)))
+                print("\tFile name: {0}".format(f.name))
+                print("\tFile type: {0}".format(VALUES[f.type]))
+                print("\tFile Checksum: {0}".format(f.chk_sum.value))
+                print("\tFile license concluded: {0}".format(f.conc_lics))
+                print(
+                    "\tFile license info in file: {0}".format(
+                        ",".join(map(lambda l: l.identifier, f.licenses_in_file))
+                    )
+                )
+                print(
+                    "\tFile artifact of project name: {0}".format(
+                        ",".join(f.artifact_of_project_name)
+                    )
+                )
 
-            print('Document Extracted licenses:')
+            print("Document Extracted licenses:")
             for lics in doc.extracted_licenses:
-                print('\tIdentifier: {0}'.format(lics.identifier))
-                print('\tName: {0}'.format(lics.full_name))
+                print("\tIdentifier: {0}".format(lics.identifier))
+                print("\tName: {0}".format(lics.full_name))
 
-            print('Annotations:')
+            print("Annotations:")
             for an in doc.annotations:
-                print('\tAnnotator: {0}'.format(an.annotator))
-                print('\tAnnotation Date: {0}'.format(an.annotation_date))
-                print('\tAnnotation Comment: {0}'.format(an.comment))
-                print('\tAnnotation Type: {0}'.format(an.annotation_type))
-                print('\tAnnotation SPDX Identifier: {0}'.format(an.spdx_id))
+                print("\tAnnotator: {0}".format(an.annotator))
+                print("\tAnnotation Date: {0}".format(an.annotation_date))
+                print("\tAnnotation Comment: {0}".format(an.comment))
+                print("\tAnnotation Type: {0}".format(an.annotation_type))
+                print("\tAnnotation SPDX Identifier: {0}".format(an.spdx_id))
+
+            # print(doc.__dict__)
+
+            print("Relationships: ")
+            for relation in doc.relationships:
+                print("\tRelationship: {0}".format(relation.relationship))
+                print("\tRelationship: {0}".format(relation.comment))
 
         else:
-            print('Errors while parsing')
+            print("Errors while parsing")

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ setup(
         'pyparsing<=1.5.7;python_version<="2.8"',
         'rdflib',
         'six',
+        'enum34',
         'pyyaml',
         'xmltodict',
     ],

--- a/spdx/document.py
+++ b/spdx/document.py
@@ -271,7 +271,7 @@ class Document(object):
     - annotations: SPDX document annotation information, Optional zero or more.
       Type: Annotation.
     - snippet: Snippet information. Optional zero or more. Type: Snippet.
-    - relationship : Relationship between two SPDX elements. Optional zero or more.
+    - relationships : Relationship between two SPDX elements. Optional zero or more.
       Type: Relationship. 
     """
 
@@ -300,8 +300,8 @@ class Document(object):
         self.extracted_licenses = []
         self.reviews = []
         self.annotations = []
-        self.snippet = []
         self.relationships = []
+        self.snippet = []
 
     def add_review(self, review):
         self.reviews.append(review)
@@ -349,8 +349,8 @@ class Document(object):
         messages = self.validate_extracted_licenses(messages)
         messages = self.validate_reviews(messages)
         messages = self.validate_snippet(messages)
-        messages = self.validate_annotations(messages)
-        messages = self.validate_relationships(messages)
+        # messages = self.validate_annotations(messages)
+        # messages = self.validate_relationships(messages)
 
         return messages
 

--- a/spdx/document.py
+++ b/spdx/document.py
@@ -309,7 +309,7 @@ class Document(object):
     def add_annotation(self, annotation):
         self.annotations.append(annotation)
 
-    def add_relationship(self, relationship):
+    def add_relationships(self, relationship):
         self.relationships.append(relationship)
 
     def add_extr_lic(self, lic):

--- a/spdx/document.py
+++ b/spdx/document.py
@@ -1,4 +1,3 @@
-
 # Copyright (c) 2014 Ahmed H. Ismail
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -29,8 +28,9 @@ class ExternalDocumentRef(object):
     - check_sum: The checksum of the referenced SPDX document.
     """
 
-    def __init__(self, external_document_id=None, spdx_document_uri=None,
-                 check_sum=None):
+    def __init__(
+        self, external_document_id=None, spdx_document_uri=None, check_sum=None
+    ):
         self.external_document_id = external_document_id
         self.spdx_document_uri = spdx_document_uri
         self.check_sum = check_sum
@@ -44,11 +44,10 @@ class ExternalDocumentRef(object):
         )
 
     def __lt__(self, other):
-        return (
-            (self.external_document_id, self.spdx_document_uri,
-             self.check_sum) <
-            (other.external_document_id, other.spdx_document_uri,
-             other.check_sum,)
+        return (self.external_document_id, self.spdx_document_uri, self.check_sum) < (
+            other.external_document_id,
+            other.spdx_document_uri,
+            other.check_sum,
         )
 
     def validate(self, messages):
@@ -64,23 +63,19 @@ class ExternalDocumentRef(object):
 
     def validate_ext_doc_id(self, messages):
         if not self.external_document_id:
-            messages = messages + [
-                'ExternalDocumentRef has no External Document ID.'
-            ]
+            messages = messages + ["ExternalDocumentRef has no External Document ID."]
 
         return messages
 
     def validate_spdx_doc_uri(self, messages):
         if not self.spdx_document_uri:
-            messages = messages + [
-                'ExternalDocumentRef has no SPDX Document URI.'
-            ]
+            messages = messages + ["ExternalDocumentRef has no SPDX Document URI."]
 
         return messages
 
     def validate_checksum(self, messages):
         if not self.check_sum:
-            messages = messages + ['ExternalDocumentRef has no Checksum.']
+            messages = messages + ["ExternalDocumentRef has no Checksum."]
 
         return messages
 
@@ -90,7 +85,7 @@ def _add_parens(required, text):
     Add parens around a license expression if `required` is True, otherwise
     return `text` unmodified.
     """
-    return '({})'.format(text) if required else text
+    return "({})".format(text) if required else text
 
 
 @total_ordering
@@ -142,7 +137,8 @@ class License(object):
         return (
             isinstance(other, License)
             and self.identifier == other.identifier
-            and self.full_name == other.full_name)
+            and self.full_name == other.full_name
+        )
 
     def __lt__(self, other):
         return isinstance(other, License) and self.identifier < other.identifier
@@ -169,18 +165,20 @@ class LicenseConjunction(License):
         license_1_complex = type(self.license_1) == LicenseDisjunction
         license_2_complex = type(self.license_2) == LicenseDisjunction
 
-        return '{0} AND {1}'.format(
+        return "{0} AND {1}".format(
             _add_parens(license_1_complex, self.license_1.full_name),
-            _add_parens(license_2_complex, self.license_2.full_name))
+            _add_parens(license_2_complex, self.license_2.full_name),
+        )
 
     @property
     def identifier(self):
         license_1_complex = type(self.license_1) == LicenseDisjunction
         license_2_complex = type(self.license_2) == LicenseDisjunction
 
-        return '{0} AND {1}'.format(
+        return "{0} AND {1}".format(
             _add_parens(license_1_complex, self.license_1.identifier),
-            _add_parens(license_2_complex, self.license_2.identifier))
+            _add_parens(license_2_complex, self.license_2.identifier),
+        )
 
 
 class LicenseDisjunction(License):
@@ -198,18 +196,20 @@ class LicenseDisjunction(License):
         license_1_complex = type(self.license_1) == LicenseConjunction
         license_2_complex = type(self.license_2) == LicenseConjunction
 
-        return '{0} OR {1}'.format(
+        return "{0} OR {1}".format(
             _add_parens(license_1_complex, self.license_1.full_name),
-            _add_parens(license_2_complex, self.license_2.full_name))
+            _add_parens(license_2_complex, self.license_2.full_name),
+        )
 
     @property
     def identifier(self):
         license_1_complex = type(self.license_1) == LicenseConjunction
         license_2_complex = type(self.license_2) == LicenseConjunction
 
-        return '{0} OR {1}'.format(
+        return "{0} OR {1}".format(
             _add_parens(license_1_complex, self.license_1.identifier),
-            _add_parens(license_2_complex, self.license_2.identifier))
+            _add_parens(license_2_complex, self.license_2.identifier),
+        )
 
 
 @total_ordering
@@ -221,6 +221,7 @@ class ExtractedLicense(License):
     - comment: license comment, str.
     - full_name: license name. str or utils.NoAssert.
     """
+
     def __init__(self, identifier):
         super(ExtractedLicense, self).__init__(None, identifier)
         self.text = None
@@ -231,17 +232,20 @@ class ExtractedLicense(License):
         return (
             isinstance(other, ExtractedLicense)
             and self.identifier == other.identifier
-            and self.full_name == other.full_name)
+            and self.full_name == other.full_name
+        )
 
     def __lt__(self, other):
-        return isinstance(other, ExtractedLicense) and self.identifier < other.identifier
+        return (
+            isinstance(other, ExtractedLicense) and self.identifier < other.identifier
+        )
 
     def add_xref(self, ref):
         self.cross_ref.append(ref)
 
     def validate(self, messages):
         if self.text is None:
-            messages = messages + ['ExtractedLicense text can not be None']
+            messages = messages + ["ExtractedLicense text can not be None"]
 
         return messages
 
@@ -267,12 +271,23 @@ class Document(object):
     - annotations: SPDX document annotation information, Optional zero or more.
       Type: Annotation.
     - snippet: Snippet information. Optional zero or more. Type: Snippet.
+    - relationship : Relationship between two SPDX elements. Optional zero or more.
+      Type: Relationship. 
     """
 
-    def __init__(self, version=None, data_license=None, name=None, spdx_id=None,
-                 namespace=None, comment=None, package=None):
-        # avoid recursive impor
+    def __init__(
+        self,
+        version=None,
+        data_license=None,
+        name=None,
+        spdx_id=None,
+        namespace=None,
+        comment=None,
+        package=None,
+    ):
+        # avoid recursive import
         from spdx.creationinfo import CreationInfo
+
         self.version = version
         self.data_license = data_license
         self.name = name
@@ -286,12 +301,16 @@ class Document(object):
         self.reviews = []
         self.annotations = []
         self.snippet = []
+        self.relationships = []
 
     def add_review(self, review):
         self.reviews.append(review)
 
     def add_annotation(self, annotation):
         self.annotations.append(annotation)
+
+    def add_relationship(self, relationship):
+        self.relationships.append(relationship)
 
     def add_extr_lic(self, lic):
         self.extracted_licenses.append(lic)
@@ -330,45 +349,45 @@ class Document(object):
         messages = self.validate_extracted_licenses(messages)
         messages = self.validate_reviews(messages)
         messages = self.validate_snippet(messages)
+        messages = self.validate_annotations(messages)
+        messages = self.validate_relationships(messages)
 
         return messages
 
     def validate_version(self, messages):
         if self.version is None:
-            messages = messages + ['Document has no version.']
+            messages = messages + ["Document has no version."]
 
         return messages
 
     def validate_data_lics(self, messages):
         if self.data_license is None:
-            messages = messages + ['Document has no data license.']
+            messages = messages + ["Document has no data license."]
         else:
-        # FIXME: REALLY? what if someone wants to use something else?
-            if self.data_license.identifier != 'CC0-1.0':
-                messages = messages + ['Document data license must be CC0-1.0.']
+            # FIXME: REALLY? what if someone wants to use something else?
+            if self.data_license.identifier != "CC0-1.0":
+                messages = messages + ["Document data license must be CC0-1.0."]
 
         return messages
 
     def validate_name(self, messages):
         if self.name is None:
-            messages = messages + ['Document has no name.']
+            messages = messages + ["Document has no name."]
 
         return messages
 
     def validate_namespace(self, messages):
         if self.namespace is None:
-            messages = messages + ['Document has no namespace.']
+            messages = messages + ["Document has no namespace."]
 
         return messages
 
     def validate_spdx_id(self, messages):
         if self.spdx_id is None:
-            messages = messages + ['Document has no SPDX Identifier.']
+            messages = messages + ["Document has no SPDX Identifier."]
         else:
-            if not self.spdx_id.endswith('SPDXRef-DOCUMENT'):
-                messages = messages + [
-                    'Invalid Document SPDX Identifier value.'
-                ]
+            if not self.spdx_id.endswith("SPDXRef-DOCUMENT"):
+                messages = messages + ["Invalid Document SPDX Identifier value."]
 
         return messages
 
@@ -378,8 +397,8 @@ class Document(object):
                 messages = doc.validate(messages)
             else:
                 messages = list(messages) + [
-                    'External document references must be of the type '
-                    'spdx.document.ExternalDocumentRef and not ' + str(type(doc))
+                    "External document references must be of the type "
+                    "spdx.document.ExternalDocumentRef and not " + str(type(doc))
                 ]
         return messages
 
@@ -395,6 +414,12 @@ class Document(object):
 
         return messages
 
+    def validate_relationships(self, messages):
+        for relationship in self.relationships:
+            messages = relationship.validate(messages)
+
+        return messages
+
     def validate_snippet(self, messages=None):
         for snippet in self.snippet:
             messages = snippet.validate(messages)
@@ -405,7 +430,7 @@ class Document(object):
         if self.creation_info is not None:
             messages = self.creation_info.validate(messages)
         else:
-            messages = messages + ['Document has no creation information.']
+            messages = messages + ["Document has no creation information."]
 
         return messages
 
@@ -413,7 +438,7 @@ class Document(object):
         if self.package is not None:
             messages = self.package.validate(messages)
         else:
-            messages = messages + ['Document has no package.']
+            messages = messages + ["Document has no package."]
 
         return messages
 
@@ -423,7 +448,7 @@ class Document(object):
                 messages = lic.validate(messages)
             else:
                 messages = messages + [
-                    'Document extracted licenses must be of type '
-                    'spdx.document.ExtractedLicense and not ' + type(lic)
+                    "Document extracted licenses must be of type "
+                    "spdx.document.ExtractedLicense and not " + type(lic)
                 ]
         return messages

--- a/spdx/parsers/jsonyamlxml.py
+++ b/spdx/parsers/jsonyamlxml.py
@@ -1,4 +1,3 @@
-
 # Copyright (c) Xavier Figueroa
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -40,7 +39,7 @@ class BaseParser(object):
         - second_tag: required field
         """
         self.error = True
-        msg = '{0} Can not appear before {1}'.format(first_tag, second_tag)
+        msg = "{0} Can not appear before {1}".format(first_tag, second_tag)
         self.logger.log(msg)
 
     def more_than_one_error(self, field):
@@ -48,7 +47,7 @@ class BaseParser(object):
         Helper method for logging an CardinalityError raised.
         - field: field/property that has been already defined.
         """
-        msg = 'More than one {0} defined.'.format(field)
+        msg = "More than one {0} defined.".format(field)
         self.logger.log(msg)
         self.error = True
 
@@ -67,6 +66,7 @@ class BaseParser(object):
             self.logger.log(msg)
         self.error = True
 
+
 class CreationInfoParser(BaseParser):
     def __init__(self, builder, logger):
         super(CreationInfoParser, self).__init__(builder, logger)
@@ -77,12 +77,14 @@ class CreationInfoParser(BaseParser):
         - creation_info: Python dict with Creation Information fields in it
         """
         if isinstance(creation_info, dict):
-            self.parse_creation_info_comment(creation_info.get('comment'))
-            self.parse_creation_info_lic_list_version(creation_info.get('licenseListVersion'))
-            self.parse_creation_info_created(creation_info.get('created'))
-            self.parse_creation_info_creators(creation_info.get('creators'))
+            self.parse_creation_info_comment(creation_info.get("comment"))
+            self.parse_creation_info_lic_list_version(
+                creation_info.get("licenseListVersion")
+            )
+            self.parse_creation_info_created(creation_info.get("created"))
+            self.parse_creation_info_creators(creation_info.get("creators"))
         else:
-            self.value_error('CREATION_INFO_SECTION', creation_info)
+            self.value_error("CREATION_INFO_SECTION", creation_info)
 
     def parse_creation_info_comment(self, comment):
         """
@@ -93,9 +95,9 @@ class CreationInfoParser(BaseParser):
             try:
                 return self.builder.set_creation_comment(self.document, comment)
             except CardinalityError:
-                self.more_than_one_error('CreationInfo comment')
+                self.more_than_one_error("CreationInfo comment")
         elif comment is not None:
-            self.value_error('CREATION_COMMENT', comment)
+            self.value_error("CREATION_COMMENT", comment)
 
     def parse_creation_info_lic_list_version(self, license_list_version):
         """
@@ -104,14 +106,16 @@ class CreationInfoParser(BaseParser):
         """
         if isinstance(license_list_version, six.string_types):
             try:
-                return self.builder.set_lics_list_ver(self.document, license_list_version)
+                return self.builder.set_lics_list_ver(
+                    self.document, license_list_version
+                )
             except SPDXValueError:
                 raise
-                self.value_error('LL_VALUE', license_list_version)
+                self.value_error("LL_VALUE", license_list_version)
             except CardinalityError:
-                self.more_than_one_error('CreationInfo licenseListVersion')
+                self.more_than_one_error("CreationInfo licenseListVersion")
         elif license_list_version is not None:
-            self.value_error('LL_VALUE', license_list_version)
+            self.value_error("LL_VALUE", license_list_version)
 
     def parse_creation_info_created(self, created):
         """
@@ -122,11 +126,11 @@ class CreationInfoParser(BaseParser):
             try:
                 return self.builder.set_created_date(self.document, created)
             except SPDXValueError:
-                self.value_error('CREATED_VALUE', created)
+                self.value_error("CREATED_VALUE", created)
             except CardinalityError:
-                self.more_than_one_error('CreationInfo created')
+                self.more_than_one_error("CreationInfo created")
         else:
-            self.value_error('CREATED_VALUE', created)
+            self.value_error("CREATED_VALUE", created)
 
     def parse_creation_info_creators(self, creators):
         """
@@ -140,13 +144,14 @@ class CreationInfoParser(BaseParser):
                     try:
                         self.builder.add_creator(self.document, entity)
                     except SPDXValueError:
-                        self.value_error('CREATOR_VALUE', creator)
+                        self.value_error("CREATOR_VALUE", creator)
                 else:
-                    self.value_error('CREATOR_VALUE', creator)
+                    self.value_error("CREATOR_VALUE", creator)
         else:
-            self.value_error('CREATORS_SECTION', creators)
+            self.value_error("CREATORS_SECTION", creators)
 
-class  ExternalDocumentRefsParser(BaseParser):
+
+class ExternalDocumentRefsParser(BaseParser):
     def __init__(self, builder, logger):
         super(ExternalDocumentRefsParser, self).__init__(builder, logger)
 
@@ -158,13 +163,17 @@ class  ExternalDocumentRefsParser(BaseParser):
         if isinstance(external_document_refs, list):
             for external_document_ref in external_document_refs:
                 if isinstance(external_document_ref, dict):
-                    self.parse_ext_doc_ref_id(external_document_ref.get('externalDocumentId'))
-                    self.parse_ext_doc_ref_namespace(external_document_ref.get('spdxDocumentNamespace'))
-                    self.parse_ext_doc_ref_chksum(external_document_ref.get('checksum'))
+                    self.parse_ext_doc_ref_id(
+                        external_document_ref.get("externalDocumentId")
+                    )
+                    self.parse_ext_doc_ref_namespace(
+                        external_document_ref.get("spdxDocumentNamespace")
+                    )
+                    self.parse_ext_doc_ref_chksum(external_document_ref.get("checksum"))
                 else:
-                    self.value_error('EXT_DOC_REF', external_document_ref)
+                    self.value_error("EXT_DOC_REF", external_document_ref)
         elif external_document_refs is not None:
-            self.value_error('EXT_DOC_REFS_SECTION', external_document_refs)
+            self.value_error("EXT_DOC_REFS_SECTION", external_document_refs)
 
     def parse_ext_doc_ref_id(self, ext_doc_ref_id):
         """
@@ -173,8 +182,8 @@ class  ExternalDocumentRefsParser(BaseParser):
         """
         if isinstance(ext_doc_ref_id, six.string_types):
             return self.builder.set_ext_doc_id(self.document, ext_doc_ref_id)
-        self.value_error('EXT_DOC_REF_ID', ext_doc_ref_id)
-        return self.builder.set_ext_doc_id(self.document, 'dummy_ext_doc_ref')
+        self.value_error("EXT_DOC_REF_ID", ext_doc_ref_id)
+        return self.builder.set_ext_doc_id(self.document, "dummy_ext_doc_ref")
         # ext_doc_ref_id is set even if it is None or not string. If weren't, the other attributes
         # would be added to the ex_doc_ref previously added.
         # Another approach is to skip the whole ex_doc_ref itself
@@ -188,9 +197,9 @@ class  ExternalDocumentRefsParser(BaseParser):
             try:
                 return self.builder.set_spdx_doc_uri(self.document, namespace)
             except SPDXValueError:
-                self.value_error('EXT_DOC_REF_VALUE', namespace)
+                self.value_error("EXT_DOC_REF_VALUE", namespace)
         else:
-            self.value_error('EXT_DOC_REF_VALUE', namespace)
+            self.value_error("EXT_DOC_REF_VALUE", namespace)
 
     def parse_ext_doc_ref_chksum(self, chksum):
         """
@@ -198,19 +207,19 @@ class  ExternalDocumentRefsParser(BaseParser):
         chksum: Python dict('algorithm':str/unicode, 'value':str/unicode)
         """
         if isinstance(chksum, dict):
-            value = chksum.get('value')
+            value = chksum.get("value")
             if isinstance(value, six.string_types):
                 try:
                     return self.builder.set_chksum(self.document, value)
                 except SPDXValueError:
-                    self.value_error('CHECKSUM_VALUE', value)
+                    self.value_error("CHECKSUM_VALUE", value)
             else:
-                self.value_error('CHECKSUM_VALUE', value)
+                self.value_error("CHECKSUM_VALUE", value)
         else:
-            self.value_error('CHECKSUM_FIELD', chksum)
+            self.value_error("CHECKSUM_FIELD", chksum)
+
 
 class LicenseParser(BaseParser):
-
     def __init__(self, builder, logger):
         super(LicenseParser, self).__init__(builder, logger)
 
@@ -222,13 +231,13 @@ class LicenseParser(BaseParser):
         if isinstance(extracted_license_info, list):
             for extracted_license in extracted_license_info:
                 if isinstance(extracted_license, dict):
-                    if self.parse_ext_lic_id(extracted_license.get('licenseId')):
-                        self.parse_ext_lic_name(extracted_license.get('name'))
-                        self.parse_ext_lic_comment(extracted_license.get('comment'))
-                        self.parse_ext_lic_text(extracted_license.get('extractedText'))
-                        self.parse_ext_lic_cross_refs(extracted_license.get('seeAlso'))
+                    if self.parse_ext_lic_id(extracted_license.get("licenseId")):
+                        self.parse_ext_lic_name(extracted_license.get("name"))
+                        self.parse_ext_lic_comment(extracted_license.get("comment"))
+                        self.parse_ext_lic_text(extracted_license.get("extractedText"))
+                        self.parse_ext_lic_cross_refs(extracted_license.get("seeAlso"))
                 else:
-                    self.value_error('EXTR_LIC', extracted_license)
+                    self.value_error("EXTR_LIC", extracted_license)
 
     def parse_ext_lic_id(self, ext_lic_id):
         """
@@ -239,9 +248,9 @@ class LicenseParser(BaseParser):
             try:
                 return self.builder.set_lic_id(self.document, ext_lic_id)
             except SPDXValueError:
-                self.value_error('EXTR_LIC_ID', ext_lic_id)
+                self.value_error("EXTR_LIC_ID", ext_lic_id)
         else:
-            self.value_error('EXTR_LIC_ID', ext_lic_id)
+            self.value_error("EXTR_LIC_ID", ext_lic_id)
 
     def parse_ext_lic_name(self, ext_lic_name):
         """
@@ -251,11 +260,11 @@ class LicenseParser(BaseParser):
         try:
             return self.builder.set_lic_name(self.document, ext_lic_name)
         except SPDXValueError:
-            self.value_error('EXTR_LIC_NAME', ext_lic_name)
+            self.value_error("EXTR_LIC_NAME", ext_lic_name)
         except CardinalityError:
-            self.more_than_one_error('ExtractedLicense name')
+            self.more_than_one_error("ExtractedLicense name")
         except OrderError:
-            self.order_error('ExtractedLicense name', 'ExtractedLicense id')
+            self.order_error("ExtractedLicense name", "ExtractedLicense id")
 
     def parse_ext_lic_comment(self, ext_lic_comment):
         """
@@ -266,11 +275,11 @@ class LicenseParser(BaseParser):
             try:
                 return self.builder.set_lic_comment(self.document, ext_lic_comment)
             except CardinalityError:
-                self.more_than_one_error('ExtractedLicense comment')
+                self.more_than_one_error("ExtractedLicense comment")
             except OrderError:
-                self.order_error('ExtractedLicense comment', 'ExtractedLicense id')
+                self.order_error("ExtractedLicense comment", "ExtractedLicense id")
         elif ext_lic_comment is not None:
-            self.value_error('EXTR_LIC_COMMENT', ext_lic_comment)
+            self.value_error("EXTR_LIC_COMMENT", ext_lic_comment)
 
     def parse_ext_lic_text(self, ext_lic_text):
         """
@@ -281,11 +290,11 @@ class LicenseParser(BaseParser):
             try:
                 return self.builder.set_lic_text(self.document, ext_lic_text)
             except CardinalityError:
-                self.more_than_one_error('ExtractedLicense text')
+                self.more_than_one_error("ExtractedLicense text")
             except OrderError:
-                self.order_error('ExtractedLicense text', 'ExtractedLicense id')
+                self.order_error("ExtractedLicense text", "ExtractedLicense id")
         else:
-            self.value_error('EXTR_LIC_TXT', ext_lic_text)
+            self.value_error("EXTR_LIC_TXT", ext_lic_text)
 
     def parse_ext_lic_cross_refs(self, cross_refs):
         """
@@ -298,18 +307,32 @@ class LicenseParser(BaseParser):
                     try:
                         self.builder.add_lic_xref(self.document, cross_ref)
                     except OrderError:
-                        self.order_error('ExtractedLicense cross references', 'ExtractedLicense id')
+                        self.order_error(
+                            "ExtractedLicense cross references", "ExtractedLicense id"
+                        )
                 else:
-                    self.value_error('CROSS_REF', cross_ref)
+                    self.value_error("CROSS_REF", cross_ref)
 
     def replace_license(self, license_object):
         if isinstance(license_object, LicenseConjunction):
-            return LicenseConjunction(self.replace_license(license_object.license_1), self.replace_license(license_object.license_2))
+            return LicenseConjunction(
+                self.replace_license(license_object.license_1),
+                self.replace_license(license_object.license_2),
+            )
         elif isinstance(license_object, LicenseDisjunction):
-            return LicenseDisjunction(self.replace_license(license_object.license_1), self.replace_license(license_object.license_2))
+            return LicenseDisjunction(
+                self.replace_license(license_object.license_1),
+                self.replace_license(license_object.license_2),
+            )
         else:
-            license_objects = list(filter(lambda lic: lic.identifier == license_object.identifier, self.document.extracted_licenses))
+            license_objects = list(
+                filter(
+                    lambda lic: lic.identifier == license_object.identifier,
+                    self.document.extracted_licenses,
+                )
+            )
             return license_objects[-1] if license_objects else license_object
+
 
 class AnnotationParser(BaseParser):
     def __init__(self, builder, logger):
@@ -323,13 +346,13 @@ class AnnotationParser(BaseParser):
         if isinstance(annotations, list):
             for annotation in annotations:
                 if isinstance(annotation, dict):
-                    if self.parse_annotation_annotator(annotation.get('annotator')):
-                        self.parse_annotation_date(annotation.get('annotationDate'))
-                        self.parse_annotation_comment(annotation.get('comment'))
-                        self.parse_annotation_type(annotation.get('annotationType'))
-                        self.parse_annotation_id(annotation.get('id'))
+                    if self.parse_annotation_annotator(annotation.get("annotator")):
+                        self.parse_annotation_date(annotation.get("annotationDate"))
+                        self.parse_annotation_comment(annotation.get("comment"))
+                        self.parse_annotation_type(annotation.get("annotationType"))
+                        self.parse_annotation_id(annotation.get("id"))
                 else:
-                    self.value_error('ANNOTATION', annotation)
+                    self.value_error("ANNOTATION", annotation)
 
     def parse_annotation_annotator(self, annotator):
         """
@@ -341,10 +364,9 @@ class AnnotationParser(BaseParser):
             try:
                 return self.builder.add_annotator(self.document, entity)
             except SPDXValueError:
-                self.value_error('ANNOTATOR_VALUE', annotator)
+                self.value_error("ANNOTATOR_VALUE", annotator)
         else:
-            self.value_error('ANNOTATOR_VALUE', annotator)
-
+            self.value_error("ANNOTATOR_VALUE", annotator)
 
     def parse_annotation_date(self, date):
         """
@@ -355,13 +377,13 @@ class AnnotationParser(BaseParser):
             try:
                 return self.builder.add_annotation_date(self.document, date)
             except SPDXValueError:
-                self.value_error('ANNOTATION_DATE', date)
+                self.value_error("ANNOTATION_DATE", date)
             except CardinalityError:
-                self.more_than_one_error('Annotation date')
+                self.more_than_one_error("Annotation date")
             except OrderError:
-                self.order_error('ANNOTATION_DATE', 'ANNOTATOR_VALUE')
+                self.order_error("ANNOTATION_DATE", "ANNOTATOR_VALUE")
         else:
-            self.value_error('ANNOTATION_DATE', date)
+            self.value_error("ANNOTATION_DATE", date)
 
     def parse_annotation_comment(self, comment):
         """
@@ -372,11 +394,11 @@ class AnnotationParser(BaseParser):
             try:
                 return self.builder.add_annotation_comment(self.document, comment)
             except CardinalityError:
-                self.more_than_one_error('Annotation comment')
+                self.more_than_one_error("Annotation comment")
             except OrderError:
-                self.order_error('ANNOTATION_COMMENT', 'ANNOTATOR_VALUE')
+                self.order_error("ANNOTATION_COMMENT", "ANNOTATOR_VALUE")
         else:
-            self.value_error('ANNOTATION_COMMENT', comment)
+            self.value_error("ANNOTATION_COMMENT", comment)
 
     def parse_annotation_type(self, annotation_type):
         """
@@ -387,13 +409,13 @@ class AnnotationParser(BaseParser):
             try:
                 return self.builder.add_annotation_type(self.document, annotation_type)
             except SPDXValueError:
-                self.value_error('ANNOTATION_TYPE', annotation_type)
+                self.value_error("ANNOTATION_TYPE", annotation_type)
             except CardinalityError:
-                self.more_than_one_error('ANNOTATION_TYPE')
+                self.more_than_one_error("ANNOTATION_TYPE")
             except OrderError:
-                self.order_error('ANNOTATION_TYPE', 'ANNOTATOR_VALUE')
+                self.order_error("ANNOTATION_TYPE", "ANNOTATOR_VALUE")
         else:
-            self.value_error('ANNOTATION_TYPE', annotation_type)
+            self.value_error("ANNOTATION_TYPE", annotation_type)
 
     def parse_annotation_id(self, annotation_id):
         """
@@ -404,11 +426,66 @@ class AnnotationParser(BaseParser):
             try:
                 return self.builder.set_annotation_spdx_id(self.document, annotation_id)
             except CardinalityError:
-                self.more_than_one_error('ANNOTATION_ID')
+                self.more_than_one_error("ANNOTATION_ID")
             except OrderError:
-                self.order_error('ANNOTATION_ID', 'ANNOTATOR_VALUE')
+                self.order_error("ANNOTATION_ID", "ANNOTATOR_VALUE")
         else:
-            self.value_error('ANNOTATION_ID', annotation_id)
+            self.value_error("ANNOTATION_ID", annotation_id)
+
+
+class RelationshipParser(BaseParser):
+    def __init__(self, builder, logger):
+        super(RelationshipParser, self).__init__(builder, logger)
+
+    def parse_relationships(self, relationships):
+        """
+        Parse Relationship Information fields
+        - relationships: Python list with Relationship Information dicts in it
+        """
+        if isinstance(relationships, list):
+            for relationship in relationships:
+                if isinstance(relationship, dict):
+                    if self.parse_relationship(
+                        relationship.get("spdxElementId"),
+                        relationship.get("relationshipType"),
+                        relationship.get("relatedSpdxElement"),
+                    ):
+                        self.parse_relationship_comment(relationship.get("comment"))
+                else:
+                    self.value_error("RELATIONSHIP", relationship)
+
+    def parse_relationship(self, spdxelementid, relationshiptype, relatedspdxelement):
+        """
+        Parse Relationshiptype, spdxElementId and relatedSpdxElement
+        - relationship : Python str/unicode
+        """
+        if isinstance(relationshiptype, six.string_types):
+            relate = spdxelementid + " " + relationshiptype + " " + relatedspdxelement
+            entity = self.builder.create_entity(self.document, relate)
+            try:
+                return self.builder.add_relationship(self.document, entity)
+            except SPDXValueError:
+                self.value_error("RELATIONSHIP_VALUE", relate)
+        else:
+            self.value_error("RELATIONSHIP_VALUE", relate)
+
+    def parse_relationship_comment(self, relationship_comment):
+        """
+        Parse relationship comment
+        - relationship_comment: Python str/unicode
+        """
+        if isinstance(relationship_comment, six.string_types):
+            try:
+                return self.builder.add_relationship_comment(
+                    self.document, relationship_comment
+                )
+            except CardinalityError:
+                self.more_than_one_error("RELATIONSHIP_COMMENT")
+            except OrderError:
+                self.order_error("RELATIONSHIP_COMMENT", "RELATIONSHIP")
+        elif relationship_comment is not None:
+            self.value_error("RELATIONSHIP_COMMENT", relationship_comment)
+
 
 class SnippetParser(BaseParser):
     def __init__(self, builder, logger):
@@ -422,16 +499,22 @@ class SnippetParser(BaseParser):
         if isinstance(snippets, list):
             for snippet in snippets:
                 if isinstance(snippet, dict):
-                    if self.parse_snippet_id(snippet.get('id')):
-                        self.parse_snippet_name(snippet.get('name'))
-                        self.parse_snippet_comment(snippet.get('comment'))
-                        self.parse_snippet_copyright(snippet.get('copyrightText'))
-                        self.parse_snippet_license_comment(snippet.get('licenseComments'))
-                        self.parse_snippet_file_spdxid(snippet.get('fileId'))
-                        self.parse_snippet_concluded_license(snippet.get('licenseConcluded'))
-                        self.parse_snippet_license_info_from_snippet(snippet.get('licenseInfoFromSnippet'))
+                    if self.parse_snippet_id(snippet.get("id")):
+                        self.parse_snippet_name(snippet.get("name"))
+                        self.parse_snippet_comment(snippet.get("comment"))
+                        self.parse_snippet_copyright(snippet.get("copyrightText"))
+                        self.parse_snippet_license_comment(
+                            snippet.get("licenseComments")
+                        )
+                        self.parse_snippet_file_spdxid(snippet.get("fileId"))
+                        self.parse_snippet_concluded_license(
+                            snippet.get("licenseConcluded")
+                        )
+                        self.parse_snippet_license_info_from_snippet(
+                            snippet.get("licenseInfoFromSnippet")
+                        )
                 else:
-                    self.value_error('SNIPPET', snippet)
+                    self.value_error("SNIPPET", snippet)
 
     def parse_snippet_id(self, snippet_id):
         """
@@ -442,9 +525,9 @@ class SnippetParser(BaseParser):
             try:
                 return self.builder.create_snippet(self.document, snippet_id)
             except SPDXValueError:
-                self.value_error('SNIPPET_SPDX_ID_VALUE', snippet_id)
+                self.value_error("SNIPPET_SPDX_ID_VALUE", snippet_id)
         else:
-            self.value_error('SNIPPET_SPDX_ID_VALUE', snippet_id)
+            self.value_error("SNIPPET_SPDX_ID_VALUE", snippet_id)
 
     def parse_snippet_name(self, snippet_name):
         """
@@ -455,9 +538,9 @@ class SnippetParser(BaseParser):
             try:
                 return self.builder.set_snippet_name(self.document, snippet_name)
             except CardinalityError:
-                self.more_than_one_error('SNIPPET_NAME')
+                self.more_than_one_error("SNIPPET_NAME")
         elif snippet_name is not None:
-            self.value_error('SNIPPET_NAME', snippet_name)
+            self.value_error("SNIPPET_NAME", snippet_name)
 
     def parse_snippet_comment(self, snippet_comment):
         """
@@ -468,9 +551,9 @@ class SnippetParser(BaseParser):
             try:
                 return self.builder.set_snippet_comment(self.document, snippet_comment)
             except CardinalityError:
-                self.more_than_one_error('SNIPPET_COMMENT')
+                self.more_than_one_error("SNIPPET_COMMENT")
         elif snippet_comment is not None:
-            self.value_error('SNIPPET_COMMENT', snippet_comment)
+            self.value_error("SNIPPET_COMMENT", snippet_comment)
 
     def parse_snippet_copyright(self, copyright_text):
         """
@@ -481,9 +564,9 @@ class SnippetParser(BaseParser):
             try:
                 return self.builder.set_snippet_copyright(self.document, copyright_text)
             except CardinalityError:
-                self.more_than_one_error('SNIPPET_COPYRIGHT')
+                self.more_than_one_error("SNIPPET_COPYRIGHT")
         else:
-            self.value_error('SNIPPET_COPYRIGHT', copyright_text)
+            self.value_error("SNIPPET_COPYRIGHT", copyright_text)
 
     def parse_snippet_license_comment(self, license_comment):
         """
@@ -492,11 +575,13 @@ class SnippetParser(BaseParser):
         """
         if isinstance(license_comment, six.string_types):
             try:
-                return self.builder.set_snippet_lic_comment(self.document, license_comment)
+                return self.builder.set_snippet_lic_comment(
+                    self.document, license_comment
+                )
             except CardinalityError:
-                self.more_than_one_error('SNIPPET_LIC_COMMENTS')
+                self.more_than_one_error("SNIPPET_LIC_COMMENTS")
         elif license_comment is not None:
-            self.value_error('SNIPPET_LIC_COMMENTS', license_comment)
+            self.value_error("SNIPPET_LIC_COMMENTS", license_comment)
 
     def parse_snippet_file_spdxid(self, file_spdxid):
         """
@@ -505,13 +590,15 @@ class SnippetParser(BaseParser):
         """
         if isinstance(file_spdxid, six.string_types):
             try:
-                return self.builder.set_snip_from_file_spdxid(self.document, file_spdxid)
+                return self.builder.set_snip_from_file_spdxid(
+                    self.document, file_spdxid
+                )
             except SPDXValueError:
-                self.value_error('SNIPPET_FILE_ID', file_spdxid)
+                self.value_error("SNIPPET_FILE_ID", file_spdxid)
             except CardinalityError:
-                self.more_than_one_error('SNIPPET_FILE_ID')
+                self.more_than_one_error("SNIPPET_FILE_ID")
         else:
-            self.value_error('SNIPPET_FILE_ID', file_spdxid)
+            self.value_error("SNIPPET_FILE_ID", file_spdxid)
 
     def parse_snippet_concluded_license(self, concluded_license):
         """
@@ -523,13 +610,15 @@ class SnippetParser(BaseParser):
             lic_parser.build(write_tables=0, debug=0)
             license_object = self.replace_license(lic_parser.parse(concluded_license))
             try:
-                return self.builder.set_snip_concluded_license(self.document, license_object)
+                return self.builder.set_snip_concluded_license(
+                    self.document, license_object
+                )
             except SPDXValueError:
-                self.value_error('SNIPPET_SINGLE_LICS', concluded_license)
+                self.value_error("SNIPPET_SINGLE_LICS", concluded_license)
             except CardinalityError:
-                self.more_than_one_error('SNIPPET_SINGLE_LICS')
+                self.more_than_one_error("SNIPPET_SINGLE_LICS")
         else:
-            self.value_error('SNIPPET_SINGLE_LICS', concluded_license)
+            self.value_error("SNIPPET_SINGLE_LICS", concluded_license)
 
     def parse_snippet_license_info_from_snippet(self, license_info_from_snippet):
         """
@@ -541,15 +630,20 @@ class SnippetParser(BaseParser):
                 if isinstance(lic_in_snippet, six.string_types):
                     lic_parser = utils.LicenseListParser()
                     lic_parser.build(write_tables=0, debug=0)
-                    license_object = self.replace_license(lic_parser.parse(lic_in_snippet))
+                    license_object = self.replace_license(
+                        lic_parser.parse(lic_in_snippet)
+                    )
                     try:
-                        return self.builder.set_snippet_lics_info(self.document, license_object)
+                        return self.builder.set_snippet_lics_info(
+                            self.document, license_object
+                        )
                     except SPDXValueError:
-                        self.value_error('SNIPPET_LIC_INFO', lic_in_snippet)
+                        self.value_error("SNIPPET_LIC_INFO", lic_in_snippet)
                 else:
-                    self.value_error('SNIPPET_LIC_INFO', lic_in_snippet)
+                    self.value_error("SNIPPET_LIC_INFO", lic_in_snippet)
         else:
-            self.value_error('SNIPPET_LIC_INFO_FIELD', license_info_from_snippet)
+            self.value_error("SNIPPET_LIC_INFO_FIELD", license_info_from_snippet)
+
 
 class ReviewParser(BaseParser):
     def __init__(self, builder, logger):
@@ -563,11 +657,11 @@ class ReviewParser(BaseParser):
         if isinstance(reviews, list):
             for review in reviews:
                 if isinstance(review, dict):
-                    if self.parse_review_reviewer(review.get('reviewer')):
-                        self.parse_review_date(review.get('reviewDate'))
-                        self.parse_review_comment(review.get('comment'))
+                    if self.parse_review_reviewer(review.get("reviewer")):
+                        self.parse_review_date(review.get("reviewDate"))
+                        self.parse_review_comment(review.get("comment"))
                 else:
-                    self.value_error('REVIEW', review)
+                    self.value_error("REVIEW", review)
 
     def parse_review_reviewer(self, reviewer):
         """
@@ -579,9 +673,9 @@ class ReviewParser(BaseParser):
             try:
                 return self.builder.add_reviewer(self.document, entity)
             except SPDXValueError:
-                self.value_error('REVIEWER_VALUE', reviewer)
+                self.value_error("REVIEWER_VALUE", reviewer)
         else:
-            self.value_error('REVIEWER_VALUE', reviewer)
+            self.value_error("REVIEWER_VALUE", reviewer)
 
     def parse_review_date(self, review_date):
         """
@@ -592,13 +686,13 @@ class ReviewParser(BaseParser):
             try:
                 return self.builder.add_review_date(self.document, review_date)
             except SPDXValueError:
-                self.value_error('REVIEW_DATE', review_date)
+                self.value_error("REVIEW_DATE", review_date)
             except CardinalityError:
-                self.more_than_one_error('REVIEW_DATE')
+                self.more_than_one_error("REVIEW_DATE")
             except OrderError:
-                self.order_error('REVIEW_DATE', 'REVIEWER_VALUE')
+                self.order_error("REVIEW_DATE", "REVIEWER_VALUE")
         else:
-            self.value_error('REVIEW_DATE', review_date)
+            self.value_error("REVIEW_DATE", review_date)
 
     def parse_review_comment(self, review_comment):
         """
@@ -609,11 +703,12 @@ class ReviewParser(BaseParser):
             try:
                 return self.builder.add_review_comment(self.document, review_comment)
             except CardinalityError:
-                self.more_than_one_error('REVIEW_COMMENT')
+                self.more_than_one_error("REVIEW_COMMENT")
             except OrderError:
-                self.order_error('REVIEW_COMMENT', 'REVIEWER_VALUE')
+                self.order_error("REVIEW_COMMENT", "REVIEWER_VALUE")
         elif review_comment is not None:
-            self.value_error('REVIEW_COMMENT', review_comment)
+            self.value_error("REVIEW_COMMENT", review_comment)
+
 
 class FileParser(BaseParser):
     def __init__(self, builder, logger):
@@ -625,22 +720,22 @@ class FileParser(BaseParser):
         - file: Python dict with File Information fields in it
         """
         if isinstance(file, dict):
-            self.parse_file_name(file.get('name'))
-            self.parse_file_id(file.get('id'))
-            self.parse_file_types(file.get('fileTypes'))
-            self.parse_file_concluded_license(file.get('licenseConcluded'))
-            self.parse_file_license_info_from_files(file.get('licenseInfoFromFiles'))
-            self.parse_file_license_comments(file.get('licenseComments'))
-            self.parse_file_copyright_text(file.get('copyrightText'))
-            self.parse_file_artifacts(file.get('artifactOf'))
-            self.parse_file_comment(file.get('comment'))
-            self.parse_file_notice_text(file.get('noticeText'))
-            self.parse_file_contributors(file.get('fileContributors'))
-            self.parse_file_dependencies(file.get('fileDependencies'))
-            self.parse_annotations(file.get('annotations'))
-            self.parse_file_chksum(file.get('sha1'))
+            self.parse_file_name(file.get("name"))
+            self.parse_file_id(file.get("id"))
+            self.parse_file_types(file.get("fileTypes"))
+            self.parse_file_concluded_license(file.get("licenseConcluded"))
+            self.parse_file_license_info_from_files(file.get("licenseInfoFromFiles"))
+            self.parse_file_license_comments(file.get("licenseComments"))
+            self.parse_file_copyright_text(file.get("copyrightText"))
+            self.parse_file_artifacts(file.get("artifactOf"))
+            self.parse_file_comment(file.get("comment"))
+            self.parse_file_notice_text(file.get("noticeText"))
+            self.parse_file_contributors(file.get("fileContributors"))
+            self.parse_file_dependencies(file.get("fileDependencies"))
+            self.parse_annotations(file.get("annotations"))
+            self.parse_file_chksum(file.get("sha1"))
         else:
-            self.value_error('FILE', file)
+            self.value_error("FILE", file)
 
     def parse_file_name(self, file_name):
         """
@@ -649,8 +744,8 @@ class FileParser(BaseParser):
         """
         if isinstance(file_name, six.string_types):
             return self.builder.set_file_name(self.document, file_name)
-        self.value_error('FILE_NAME', file_name)
-        return self.builder.set_file_name(self.document, 'dummy_file')
+        self.value_error("FILE_NAME", file_name)
+        return self.builder.set_file_name(self.document, "dummy_file")
         # file_name is set even if it is None or not string. If weren't, the other attributes
         # would be added to the file previously added.
         # Another approach is to skip the whole file itself
@@ -664,13 +759,13 @@ class FileParser(BaseParser):
             try:
                 return self.builder.set_file_spdx_id(self.document, file_id)
             except SPDXValueError:
-                self.value_error('FILE_ID', file_id)
+                self.value_error("FILE_ID", file_id)
             except CardinalityError:
-                self.more_than_one_error('FILE_ID')
+                self.more_than_one_error("FILE_ID")
             except OrderError:
-                self.order_error('FILE_ID', 'FILE_NAME')
+                self.order_error("FILE_ID", "FILE_NAME")
         else:
-            self.value_error('FILE_ID', file_id)
+            self.value_error("FILE_ID", file_id)
 
     def parse_file_types(self, file_types):
         """
@@ -684,7 +779,7 @@ class FileParser(BaseParser):
         elif isinstance(file_types, six.string_types):
             return self.parse_file_type(file_types)
         elif file_types is not None:
-            self.value_error('FILE_TYPES', file_types)
+            self.value_error("FILE_TYPES", file_types)
 
     def parse_file_type(self, file_type):
         """
@@ -695,13 +790,13 @@ class FileParser(BaseParser):
             try:
                 return self.builder.set_file_type(self.document, file_type)
             except SPDXValueError:
-                self.value_error('FILE_TYPE', file_type)
+                self.value_error("FILE_TYPE", file_type)
             except CardinalityError:
-                self.more_than_one_error('FILE_TYPE')
+                self.more_than_one_error("FILE_TYPE")
             except OrderError:
-                self.order_error('FILE_TYPE', 'FILE_NAME')
+                self.order_error("FILE_TYPE", "FILE_NAME")
         else:
-            self.value_error('FILE_TYPE', file_type)
+            self.value_error("FILE_TYPE", file_type)
 
     def parse_file_concluded_license(self, concluded_license):
         """
@@ -715,13 +810,13 @@ class FileParser(BaseParser):
             try:
                 return self.builder.set_concluded_license(self.document, license_object)
             except SPDXValueError:
-                self.value_error('FILE_SINGLE_LICS', concluded_license)
+                self.value_error("FILE_SINGLE_LICS", concluded_license)
             except CardinalityError:
-                self.more_than_one_error('FILE_SINGLE_LICS')
+                self.more_than_one_error("FILE_SINGLE_LICS")
             except OrderError:
-                self.order_error('FILE_SINGLE_LICS', 'FILE_NAME')
+                self.order_error("FILE_SINGLE_LICS", "FILE_NAME")
         else:
-            self.value_error('FILE_SINGLE_LICS', concluded_license)
+            self.value_error("FILE_SINGLE_LICS", concluded_license)
 
     def parse_file_license_info_from_files(self, license_info_from_files):
         """
@@ -733,17 +828,21 @@ class FileParser(BaseParser):
                 if isinstance(license_info_from_file, six.string_types):
                     lic_parser = utils.LicenseListParser()
                     lic_parser.build(write_tables=0, debug=0)
-                    license_object = self.replace_license(lic_parser.parse(license_info_from_file))
+                    license_object = self.replace_license(
+                        lic_parser.parse(license_info_from_file)
+                    )
                     try:
-                        self.builder.set_file_license_in_file(self.document, license_object)
+                        self.builder.set_file_license_in_file(
+                            self.document, license_object
+                        )
                     except SPDXValueError:
-                        self.value_error('FILE_LIC_FRM_FILES', license_info_from_file)
+                        self.value_error("FILE_LIC_FRM_FILES", license_info_from_file)
                     except OrderError:
-                        self.order_error('FILE_LIC_FRM_FILES', 'FILE_NAME')
+                        self.order_error("FILE_LIC_FRM_FILES", "FILE_NAME")
                 else:
-                    self.value_error('FILE_LIC_FRM_FILES', license_info_from_file)
+                    self.value_error("FILE_LIC_FRM_FILES", license_info_from_file)
         else:
-            self.value_error('FILE_LIC_FRM_FILES_FIELD', license_info_from_files)
+            self.value_error("FILE_LIC_FRM_FILES_FIELD", license_info_from_files)
 
     def parse_file_license_comments(self, license_comments):
         """
@@ -752,13 +851,15 @@ class FileParser(BaseParser):
         """
         if isinstance(license_comments, six.string_types):
             try:
-                return self.builder.set_file_license_comment(self.document, license_comments)
+                return self.builder.set_file_license_comment(
+                    self.document, license_comments
+                )
             except CardinalityError:
-                self.more_than_one_error('FILE_LIC_COMMENTS')
+                self.more_than_one_error("FILE_LIC_COMMENTS")
             except OrderError:
-                self.order_error('FILE_LIC_COMMENTS', 'FILE_NAME')
+                self.order_error("FILE_LIC_COMMENTS", "FILE_NAME")
         elif license_comments is not None:
-            self.value_error('FILE_LIC_COMMENTS', license_comments)
+            self.value_error("FILE_LIC_COMMENTS", license_comments)
 
     def parse_file_copyright_text(self, copyright_text):
         """
@@ -769,11 +870,11 @@ class FileParser(BaseParser):
             try:
                 return self.builder.set_file_copyright(self.document, copyright_text)
             except CardinalityError:
-                self.more_than_one_error('FILE_COPYRIGHT_TEXT')
+                self.more_than_one_error("FILE_COPYRIGHT_TEXT")
             except OrderError:
-                self.order_error('FILE_COPYRIGHT_TEXT', 'FILE_NAME')
+                self.order_error("FILE_COPYRIGHT_TEXT", "FILE_NAME")
         else:
-            self.value_error('FILE_COPYRIGHT_TEXT', copyright_text)
+            self.value_error("FILE_COPYRIGHT_TEXT", copyright_text)
 
     def parse_file_artifacts(self, file_artifacts):
         """
@@ -783,14 +884,20 @@ class FileParser(BaseParser):
         if isinstance(file_artifacts, list):
             for artifact in file_artifacts:
                 if isinstance(artifact, dict):
-                    self.builder.set_file_atrificat_of_project(self.document, 'name', artifact.get('name', UnKnown()))
-                    self.builder.set_file_atrificat_of_project(self.document, 'home', artifact.get('homePage', UnKnown()))
-                    self.builder.set_file_atrificat_of_project(self.document, 'uri', artifact.get('projectUri', UnKnown()))
+                    self.builder.set_file_atrificat_of_project(
+                        self.document, "name", artifact.get("name", UnKnown())
+                    )
+                    self.builder.set_file_atrificat_of_project(
+                        self.document, "home", artifact.get("homePage", UnKnown())
+                    )
+                    self.builder.set_file_atrificat_of_project(
+                        self.document, "uri", artifact.get("projectUri", UnKnown())
+                    )
                     return True
                 else:
-                    self.value_error('ARTIFACT_OF_VALUE', artifact)
+                    self.value_error("ARTIFACT_OF_VALUE", artifact)
         elif file_artifacts is not None:
-            self.value_error('ARTIFACT_OF_FIELD', file_artifacts)
+            self.value_error("ARTIFACT_OF_FIELD", file_artifacts)
 
     def parse_file_comment(self, file_comment):
         """
@@ -801,11 +908,11 @@ class FileParser(BaseParser):
             try:
                 return self.builder.set_file_comment(self.document, file_comment)
             except CardinalityError:
-                self.more_than_one_error('FILE_COMMENT')
+                self.more_than_one_error("FILE_COMMENT")
             except OrderError:
-                self.order_error('FILE_COMMENT', 'FILE_NAME')
+                self.order_error("FILE_COMMENT", "FILE_NAME")
         elif file_comment is not None:
-            self.value_error('FILE_COMMENT', file_comment)
+            self.value_error("FILE_COMMENT", file_comment)
 
     def parse_file_notice_text(self, notice_text):
         """
@@ -816,11 +923,11 @@ class FileParser(BaseParser):
             try:
                 return self.builder.set_file_notice(self.document, notice_text)
             except CardinalityError:
-                self.more_than_one_error('FILE_NOTICE_TEXT')
+                self.more_than_one_error("FILE_NOTICE_TEXT")
             except OrderError:
-                self.order_error('FILE_NOTICE_TEXT', 'FILE_NAME')
+                self.order_error("FILE_NOTICE_TEXT", "FILE_NAME")
         elif notice_text is not None:
-            self.value_error('FILE_NOTICE_TEXT', notice_text)
+            self.value_error("FILE_NOTICE_TEXT", notice_text)
 
     def parse_file_contributors(self, file_contributors):
         """
@@ -833,11 +940,11 @@ class FileParser(BaseParser):
                     try:
                         self.builder.add_file_contribution(self.document, contributor)
                     except OrderError:
-                        self.order_error('FILE_CONTRIBUTOR', 'FILE_NAME')
+                        self.order_error("FILE_CONTRIBUTOR", "FILE_NAME")
                 else:
-                    self.value_error('FILE_CONTRIBUTOR', contributor)
+                    self.value_error("FILE_CONTRIBUTOR", contributor)
         elif file_contributors is not None:
-            self.value_error('FILE_CONTRIBUTORS', file_contributors)
+            self.value_error("FILE_CONTRIBUTORS", file_contributors)
 
     def parse_file_dependencies(self, file_dependencies):
         """
@@ -851,11 +958,11 @@ class FileParser(BaseParser):
                     try:
                         self.builder.add_file_dep(self.document, dependency)
                     except OrderError:
-                        self.order_error('FILE_DEPENDENCY', 'FILE_NAME')
+                        self.order_error("FILE_DEPENDENCY", "FILE_NAME")
                 else:
-                    self.value_error('FILE_DEPENDENCY', dependency)
+                    self.value_error("FILE_DEPENDENCY", dependency)
         elif file_dependencies is not None:
-            self.value_error('FILE_DEPENDENCIES', file_dependencies)
+            self.value_error("FILE_DEPENDENCIES", file_dependencies)
 
     def _handle_file_dependency(self, file_dependency):
         """
@@ -864,9 +971,9 @@ class FileParser(BaseParser):
         return: file name (str/unicode) or None
         """
         if isinstance(file_dependency, dict):
-            filelike_dependency = file_dependency.get('File')
+            filelike_dependency = file_dependency.get("File")
             if isinstance(filelike_dependency, dict):
-                return filelike_dependency.get('name')
+                return filelike_dependency.get("name")
             return None
         return None
 
@@ -879,11 +986,12 @@ class FileParser(BaseParser):
             try:
                 return self.builder.set_file_chksum(self.document, file_chksum)
             except CardinalityError:
-                self.more_than_one_error('FILE_CHECKSUM')
+                self.more_than_one_error("FILE_CHECKSUM")
             except OrderError:
-                self.order_error('FILE_CHECKSUM', 'FILE_NAME')
+                self.order_error("FILE_CHECKSUM", "FILE_NAME")
         else:
-            self.value_error('FILE_CHECKSUM', file_chksum)
+            self.value_error("FILE_CHECKSUM", file_chksum)
+
 
 class PackageParser(BaseParser):
     def __init__(self, builder, logger):
@@ -895,28 +1003,28 @@ class PackageParser(BaseParser):
         - package: Python dict with Package Information fields in it
         """
         if isinstance(package, dict):
-            self.parse_pkg_name(package.get('name'))
-            self.parse_pkg_id(package.get('id'))
-            self.parse_pkg_version(package.get('versionInfo'))
-            self.parse_pkg_file_name(package.get('packageFileName'))
-            self.parse_pkg_supplier(package.get('supplier'))
-            self.parse_pkg_originator(package.get('originator'))
-            self.parse_pkg_down_location(package.get('downloadLocation'))
-            self.parse_pkg_verif_code_field(package.get('packageVerificationCode'))
-            self.parse_pkg_homepage(package.get('homepage'))
-            self.parse_pkg_source_info(package.get('sourceInfo'))
-            self.parse_pkg_concluded_license(package.get('licenseConcluded'))
-            self.parse_pkg_license_info_from_files(package.get('licenseInfoFromFiles'))
-            self.parse_pkg_declared_license(package.get('licenseDeclared'))
-            self.parse_pkg_license_comment(package.get('licenseComments'))
-            self.parse_pkg_copyright_text(package.get('copyrightText'))
-            self.parse_pkg_summary(package.get('summary'))
-            self.parse_pkg_description(package.get('description'))
-            self.parse_annotations(package.get('annotations'))
-            self.parse_pkg_files(package.get('files'))
-            self.parse_pkg_chksum(package.get('sha1'))
+            self.parse_pkg_name(package.get("name"))
+            self.parse_pkg_id(package.get("id"))
+            self.parse_pkg_version(package.get("versionInfo"))
+            self.parse_pkg_file_name(package.get("packageFileName"))
+            self.parse_pkg_supplier(package.get("supplier"))
+            self.parse_pkg_originator(package.get("originator"))
+            self.parse_pkg_down_location(package.get("downloadLocation"))
+            self.parse_pkg_verif_code_field(package.get("packageVerificationCode"))
+            self.parse_pkg_homepage(package.get("homepage"))
+            self.parse_pkg_source_info(package.get("sourceInfo"))
+            self.parse_pkg_concluded_license(package.get("licenseConcluded"))
+            self.parse_pkg_license_info_from_files(package.get("licenseInfoFromFiles"))
+            self.parse_pkg_declared_license(package.get("licenseDeclared"))
+            self.parse_pkg_license_comment(package.get("licenseComments"))
+            self.parse_pkg_copyright_text(package.get("copyrightText"))
+            self.parse_pkg_summary(package.get("summary"))
+            self.parse_pkg_description(package.get("description"))
+            self.parse_annotations(package.get("annotations"))
+            self.parse_pkg_files(package.get("files"))
+            self.parse_pkg_chksum(package.get("sha1"))
         else:
-            self.value_error('PACKAGE', package)
+            self.value_error("PACKAGE", package)
 
     def parse_pkg_name(self, pkg_name):
         """
@@ -925,8 +1033,8 @@ class PackageParser(BaseParser):
         """
         if isinstance(pkg_name, six.string_types):
             return self.builder.create_package(self.document, pkg_name)
-        self.value_error('PKG_NAME', pkg_name)
-        return self.builder.create_package(self.document, 'dummy_package')
+        self.value_error("PKG_NAME", pkg_name)
+        return self.builder.create_package(self.document, "dummy_package")
         # pkg_name is set even if it is None or not string. If weren't, the other attributes
         # would be added to the package previously added.
         # Another approach is to skip the whole package itself
@@ -940,11 +1048,11 @@ class PackageParser(BaseParser):
             try:
                 return self.builder.set_pkg_spdx_id(self.document, pkg_id)
             except SPDXValueError:
-                self.value_error('PKG_ID', pkg_id)
+                self.value_error("PKG_ID", pkg_id)
             except CardinalityError:
-                self.more_than_one_error('PKG_ID')
+                self.more_than_one_error("PKG_ID")
         else:
-            self.value_error('PKG_ID', pkg_id)
+            self.value_error("PKG_ID", pkg_id)
 
     def parse_pkg_version(self, pkg_version):
         """
@@ -955,11 +1063,11 @@ class PackageParser(BaseParser):
             try:
                 return self.builder.set_pkg_vers(self.document, pkg_version)
             except CardinalityError:
-                self.more_than_one_error('PKG_VERSION')
+                self.more_than_one_error("PKG_VERSION")
             except OrderError:
-                self.order_error('PKG_VERSION', 'PKG_NAME')
+                self.order_error("PKG_VERSION", "PKG_NAME")
         elif pkg_version is not None:
-            self.value_error('PKG_VERSION', pkg_version)
+            self.value_error("PKG_VERSION", pkg_version)
 
     def parse_pkg_file_name(self, pkg_file_name):
         """
@@ -970,11 +1078,11 @@ class PackageParser(BaseParser):
             try:
                 return self.builder.set_pkg_file_name(self.document, pkg_file_name)
             except CardinalityError:
-                self.more_than_one_error('PKG_FILE_NAME')
+                self.more_than_one_error("PKG_FILE_NAME")
             except OrderError:
-                self.order_error('PKG_FILE_NAME', 'PKG_NAME')
+                self.order_error("PKG_FILE_NAME", "PKG_NAME")
         elif pkg_file_name is not None:
-            self.value_error('PKG_FILE_NAME', pkg_file_name)
+            self.value_error("PKG_FILE_NAME", pkg_file_name)
 
     def parse_pkg_supplier(self, pkg_supplier):
         """
@@ -986,13 +1094,13 @@ class PackageParser(BaseParser):
             try:
                 return self.builder.set_pkg_supplier(self.document, entity)
             except SPDXValueError:
-                self.value_error('PKG_SUPPL_VALUE', pkg_supplier)
+                self.value_error("PKG_SUPPL_VALUE", pkg_supplier)
             except CardinalityError:
-                self.more_than_one_error('PKG_SUPPL_VALUE')
+                self.more_than_one_error("PKG_SUPPL_VALUE")
             except OrderError:
-                self.order_error('PKG_SUPPL_VALUE', 'PKG_NAME')
+                self.order_error("PKG_SUPPL_VALUE", "PKG_NAME")
         elif pkg_supplier is not None:
-            self.value_error('PKG_SUPPL_VALUE', pkg_supplier)
+            self.value_error("PKG_SUPPL_VALUE", pkg_supplier)
 
     def parse_pkg_originator(self, pkg_originator):
         """
@@ -1004,13 +1112,13 @@ class PackageParser(BaseParser):
             try:
                 return self.builder.set_pkg_originator(self.document, entity)
             except SPDXValueError:
-                self.value_error('PKG_ORIGINATOR_VALUE', pkg_originator)
+                self.value_error("PKG_ORIGINATOR_VALUE", pkg_originator)
             except CardinalityError:
-                self.more_than_one_error('PKG_ORIGINATOR_VALUE')
+                self.more_than_one_error("PKG_ORIGINATOR_VALUE")
             except OrderError:
-                self.order_error('PKG_ORIGINATOR_VALUE', 'PKG_NAME')
+                self.order_error("PKG_ORIGINATOR_VALUE", "PKG_NAME")
         elif pkg_originator is not None:
-            self.value_error('PKG_ORIGINATOR_VALUE', pkg_originator)
+            self.value_error("PKG_ORIGINATOR_VALUE", pkg_originator)
 
     def parse_pkg_down_location(self, pkg_down_location):
         """
@@ -1019,13 +1127,15 @@ class PackageParser(BaseParser):
         """
         if isinstance(pkg_down_location, six.string_types):
             try:
-                return self.builder.set_pkg_down_location(self.document, pkg_down_location)
+                return self.builder.set_pkg_down_location(
+                    self.document, pkg_down_location
+                )
             except CardinalityError:
-                self.more_than_one_error('PKG_DOWN_LOC')
+                self.more_than_one_error("PKG_DOWN_LOC")
             except OrderError:
-                self.order_error('PKG_DOWN_LOC', 'PKG_NAME')
+                self.order_error("PKG_DOWN_LOC", "PKG_NAME")
         else:
-            self.value_error('PKG_DOWN_LOC', pkg_down_location)
+            self.value_error("PKG_DOWN_LOC", pkg_down_location)
 
     def parse_pkg_verif_code_field(self, pkg_verif_code_field):
         """
@@ -1033,10 +1143,12 @@ class PackageParser(BaseParser):
         - pkg_verif_code_field: Python dict('value':str/unicode, 'excludedFilesNames':list)
         """
         if isinstance(pkg_verif_code_field, dict):
-            self.parse_pkg_verif_exc_files(pkg_verif_code_field.get('excludedFilesNames'))
-            return self.parse_pkg_verif_code(pkg_verif_code_field.get('value'))
+            self.parse_pkg_verif_exc_files(
+                pkg_verif_code_field.get("excludedFilesNames")
+            )
+            return self.parse_pkg_verif_code(pkg_verif_code_field.get("value"))
         else:
-            self.value_error('PKG_VERIF_CODE_FIELD', pkg_verif_code_field)
+            self.value_error("PKG_VERIF_CODE_FIELD", pkg_verif_code_field)
 
     def parse_pkg_verif_code(self, pkg_verif_code):
         """
@@ -1047,11 +1159,11 @@ class PackageParser(BaseParser):
             try:
                 return self.builder.set_pkg_verif_code(self.document, pkg_verif_code)
             except CardinalityError:
-                self.more_than_one_error('PKG_VERIF_CODE')
+                self.more_than_one_error("PKG_VERIF_CODE")
             except OrderError:
-                self.order_error('PKG_VERIF_CODE', 'PKG_NAME')
+                self.order_error("PKG_VERIF_CODE", "PKG_NAME")
         else:
-            self.value_error('PKG_VERIF_CODE', pkg_verif_code)
+            self.value_error("PKG_VERIF_CODE", pkg_verif_code)
 
     def parse_pkg_verif_exc_files(self, pkg_verif_exc_files):
         """
@@ -1062,13 +1174,15 @@ class PackageParser(BaseParser):
             for pkg_verif_exc_file in pkg_verif_exc_files:
                 if isinstance(pkg_verif_exc_file, six.string_types):
                     try:
-                        self.builder.set_pkg_excl_file(self.document, pkg_verif_exc_file)
+                        self.builder.set_pkg_excl_file(
+                            self.document, pkg_verif_exc_file
+                        )
                     except OrderError:
-                        self.order_error('PKG_VERIF_EXC_FILE', 'PKG_NAME')
+                        self.order_error("PKG_VERIF_EXC_FILE", "PKG_NAME")
                 else:
-                    self.value_error('PKG_VERIF_EXC_FILE', pkg_verif_exc_file)
+                    self.value_error("PKG_VERIF_EXC_FILE", pkg_verif_exc_file)
         elif pkg_verif_exc_files is not None:
-            self.value_error('PKG_VERIF_EXC_FILE_FIELD', pkg_verif_exc_files)
+            self.value_error("PKG_VERIF_EXC_FILE_FIELD", pkg_verif_exc_files)
 
     def parse_pkg_homepage(self, pkg_homepage):
         """
@@ -1079,13 +1193,13 @@ class PackageParser(BaseParser):
             try:
                 return self.builder.set_pkg_home(self.document, pkg_homepage)
             except SPDXValueError:
-                self.value_error('PKG_HOMEPAGE', pkg_homepage)
+                self.value_error("PKG_HOMEPAGE", pkg_homepage)
             except CardinalityError:
-                self.more_than_one_error('PKG_HOMEPAGE')
+                self.more_than_one_error("PKG_HOMEPAGE")
             except OrderError:
-                self.order_error('PKG_HOMEPAGE', 'PKG_NAME')
+                self.order_error("PKG_HOMEPAGE", "PKG_NAME")
         elif pkg_homepage is not None:
-            self.value_error('PKG_HOMEPAGE', pkg_homepage)
+            self.value_error("PKG_HOMEPAGE", pkg_homepage)
 
     def parse_pkg_source_info(self, pkg_source_info):
         """
@@ -1096,11 +1210,11 @@ class PackageParser(BaseParser):
             try:
                 return self.builder.set_pkg_source_info(self.document, pkg_source_info)
             except CardinalityError:
-                self.more_than_one_error('PKG_SRC_INFO')
+                self.more_than_one_error("PKG_SRC_INFO")
             except OrderError:
-                self.order_error('PKG_SRC_INFO', 'PKG_NAME')
+                self.order_error("PKG_SRC_INFO", "PKG_NAME")
         elif pkg_source_info is not None:
-            self.value_error('PKG_SRC_INFO', pkg_source_info)
+            self.value_error("PKG_SRC_INFO", pkg_source_info)
 
     def parse_pkg_concluded_license(self, pkg_concluded_license):
         """
@@ -1110,17 +1224,21 @@ class PackageParser(BaseParser):
         if isinstance(pkg_concluded_license, six.string_types):
             lic_parser = utils.LicenseListParser()
             lic_parser.build(write_tables=0, debug=0)
-            license_object = self.replace_license(lic_parser.parse(pkg_concluded_license))
+            license_object = self.replace_license(
+                lic_parser.parse(pkg_concluded_license)
+            )
             try:
-                return self.builder.set_pkg_licenses_concluded(self.document, license_object)
+                return self.builder.set_pkg_licenses_concluded(
+                    self.document, license_object
+                )
             except SPDXValueError:
-                self.value_error('PKG_SINGLE_LICS', pkg_concluded_license)
+                self.value_error("PKG_SINGLE_LICS", pkg_concluded_license)
             except CardinalityError:
-                self.more_than_one_error('PKG_SINGLE_LICS')
+                self.more_than_one_error("PKG_SINGLE_LICS")
             except OrderError:
-                self.order_error('PKG_SINGLE_LICS', 'PKG_NAME')
+                self.order_error("PKG_SINGLE_LICS", "PKG_NAME")
         else:
-            self.value_error('PKG_SINGLE_LICS', pkg_concluded_license)
+            self.value_error("PKG_SINGLE_LICS", pkg_concluded_license)
 
     def parse_pkg_license_info_from_files(self, license_info_from_files):
         """
@@ -1132,17 +1250,21 @@ class PackageParser(BaseParser):
                 if isinstance(license_info_from_file, six.string_types):
                     lic_parser = utils.LicenseListParser()
                     lic_parser.build(write_tables=0, debug=0)
-                    license_object = self.replace_license(lic_parser.parse(license_info_from_file))
+                    license_object = self.replace_license(
+                        lic_parser.parse(license_info_from_file)
+                    )
                     try:
-                        self.builder.set_pkg_license_from_file(self.document, license_object)
+                        self.builder.set_pkg_license_from_file(
+                            self.document, license_object
+                        )
                     except SPDXValueError:
-                        self.value_error('PKG_LIC_FRM_FILES', license_info_from_file)
+                        self.value_error("PKG_LIC_FRM_FILES", license_info_from_file)
                     except OrderError:
-                        self.order_error('PKG_LIC_FRM_FILES', 'PKG_NAME')
+                        self.order_error("PKG_LIC_FRM_FILES", "PKG_NAME")
                 else:
-                    self.value_error('PKG_LIC_FRM_FILES', license_info_from_file)
+                    self.value_error("PKG_LIC_FRM_FILES", license_info_from_file)
         else:
-            self.value_error('PKG_LIC_FRM_FILES_FIELD', license_info_from_files)
+            self.value_error("PKG_LIC_FRM_FILES_FIELD", license_info_from_files)
 
     def parse_pkg_declared_license(self, pkg_declared_license):
         """
@@ -1152,17 +1274,21 @@ class PackageParser(BaseParser):
         if isinstance(pkg_declared_license, six.string_types):
             lic_parser = utils.LicenseListParser()
             lic_parser.build(write_tables=0, debug=0)
-            license_object = self.replace_license(lic_parser.parse(pkg_declared_license))
+            license_object = self.replace_license(
+                lic_parser.parse(pkg_declared_license)
+            )
             try:
-                return self.builder.set_pkg_license_declared(self.document, license_object)
+                return self.builder.set_pkg_license_declared(
+                    self.document, license_object
+                )
             except SPDXValueError:
-                self.value_error('PKG_DECL_LIC', pkg_declared_license)
+                self.value_error("PKG_DECL_LIC", pkg_declared_license)
             except CardinalityError:
-                self.more_than_one_error('PKG_DECL_LIC')
+                self.more_than_one_error("PKG_DECL_LIC")
             except OrderError:
-                self.order_error('PKG_DECL_LIC', 'PKG_NAME')
+                self.order_error("PKG_DECL_LIC", "PKG_NAME")
         else:
-            self.value_error('PKG_DECL_LIC', pkg_declared_license)
+            self.value_error("PKG_DECL_LIC", pkg_declared_license)
 
     def parse_pkg_license_comment(self, pkg_license_comment):
         """
@@ -1171,13 +1297,15 @@ class PackageParser(BaseParser):
         """
         if isinstance(pkg_license_comment, six.string_types):
             try:
-                return self.builder.set_pkg_license_comment(self.document, pkg_license_comment)
+                return self.builder.set_pkg_license_comment(
+                    self.document, pkg_license_comment
+                )
             except CardinalityError:
-                self.more_than_one_error('PKG_LIC_COMMENT')
+                self.more_than_one_error("PKG_LIC_COMMENT")
             except OrderError:
-                self.order_error('PKG_LIC_COMMENT', 'PKG_NAME')
+                self.order_error("PKG_LIC_COMMENT", "PKG_NAME")
         elif pkg_license_comment is not None:
-            self.value_error('PKG_LIC_COMMENT', pkg_license_comment)
+            self.value_error("PKG_LIC_COMMENT", pkg_license_comment)
 
     def parse_pkg_copyright_text(self, pkg_copyright_text):
         """
@@ -1188,11 +1316,11 @@ class PackageParser(BaseParser):
             try:
                 return self.builder.set_pkg_cr_text(self.document, pkg_copyright_text)
             except CardinalityError:
-                self.more_than_one_error('PKG_COPYRIGHT_TEXT')
+                self.more_than_one_error("PKG_COPYRIGHT_TEXT")
             except OrderError:
-                self.order_error('PKG_COPYRIGHT_TEXT', 'PKG_NAME')
+                self.order_error("PKG_COPYRIGHT_TEXT", "PKG_NAME")
         else:
-            self.value_error('PKG_COPYRIGHT_TEXT', pkg_copyright_text)
+            self.value_error("PKG_COPYRIGHT_TEXT", pkg_copyright_text)
 
     def parse_pkg_summary(self, pkg_summary):
         """
@@ -1203,11 +1331,11 @@ class PackageParser(BaseParser):
             try:
                 return self.builder.set_pkg_summary(self.document, pkg_summary)
             except CardinalityError:
-                self.more_than_one_error('PKG_SUMMARY')
+                self.more_than_one_error("PKG_SUMMARY")
             except OrderError:
-                self.order_error('PKG_SUMMARY', 'PKG_NAME')
+                self.order_error("PKG_SUMMARY", "PKG_NAME")
         elif pkg_summary is not None:
-            self.value_error('PKG_SUMMARY', pkg_summary)
+            self.value_error("PKG_SUMMARY", pkg_summary)
 
     def parse_pkg_description(self, pkg_description):
         """
@@ -1218,11 +1346,11 @@ class PackageParser(BaseParser):
             try:
                 return self.builder.set_pkg_desc(self.document, pkg_description)
             except CardinalityError:
-                self.more_than_one_error('PKG_DESCRIPTION')
+                self.more_than_one_error("PKG_DESCRIPTION")
             except OrderError:
-                self.order_error('PKG_DESCRIPTION', 'PKG_NAME')
+                self.order_error("PKG_DESCRIPTION", "PKG_NAME")
         elif pkg_description is not None:
-            self.value_error('PKG_DESCRIPTION', pkg_description)
+            self.value_error("PKG_DESCRIPTION", pkg_description)
 
     def parse_pkg_files(self, pkg_files):
         """
@@ -1232,11 +1360,11 @@ class PackageParser(BaseParser):
         if isinstance(pkg_files, list):
             for pkg_file in pkg_files:
                 if isinstance(pkg_file, dict):
-                    self.parse_file(pkg_file.get('File'))
+                    self.parse_file(pkg_file.get("File"))
                 else:
-                    self.value_error('PKG_FILE', pkg_file)
+                    self.value_error("PKG_FILE", pkg_file)
         else:
-            self.value_error('PKG_FILES', pkg_files)
+            self.value_error("PKG_FILES", pkg_files)
 
     def parse_pkg_chksum(self, pkg_chksum):
         """
@@ -1247,16 +1375,24 @@ class PackageParser(BaseParser):
             try:
                 return self.builder.set_pkg_chk_sum(self.document, pkg_chksum)
             except CardinalityError:
-                self.more_than_one_error('PKG_CHECKSUM')
+                self.more_than_one_error("PKG_CHECKSUM")
             except OrderError:
-                self.order_error('PKG_CHECKSUM', 'PKG_NAME')
+                self.order_error("PKG_CHECKSUM", "PKG_NAME")
         elif pkg_chksum is not None:
-            self.value_error('PKG_CHECKSUM', pkg_chksum)
+            self.value_error("PKG_CHECKSUM", pkg_chksum)
 
 
-class Parser(CreationInfoParser, ExternalDocumentRefsParser, LicenseParser,
-            AnnotationParser, SnippetParser, ReviewParser, FileParser, PackageParser):
-
+class Parser(
+    CreationInfoParser,
+    ExternalDocumentRefsParser,
+    LicenseParser,
+    AnnotationParser,
+    RelationshipParser,
+    SnippetParser,
+    ReviewParser,
+    FileParser,
+    PackageParser,
+):
     def __init__(self, builder, logger):
         super(Parser, self).__init__(builder, logger)
 
@@ -1267,24 +1403,29 @@ class Parser(CreationInfoParser, ExternalDocumentRefsParser, LicenseParser,
         self.error = False
         self.document = document.Document()
         if not isinstance(self.document_object, dict):
-            self.logger.log('Empty or not valid SPDX Document')
+            self.logger.log("Empty or not valid SPDX Document")
             self.error = True
             return self.document, self.error
 
-        self.parse_doc_version(self.document_object.get('specVersion'))
-        self.parse_doc_data_license(self.document_object.get('dataLicense'))
-        self.parse_doc_id(self.document_object.get('id'))
-        self.parse_doc_name(self.document_object.get('name'))
-        self.parse_doc_namespace(self.document_object.get('namespace'))
-        self.parse_doc_comment(self.document_object.get('comment'))
-        self.parse_creation_info(self.document_object.get('creationInfo'))
-        self.parse_external_document_refs(self.document_object.get('externalDocumentRefs'))
-        self.parse_extracted_license_info(self.document_object.get('extractedLicenseInfos'))
-        self.parse_annotations(self.document_object.get('annotations'))
-        self.parse_reviews(self.document_object.get('reviewers'))
-        self.parse_snippets(self.document_object.get('snippets'))
+        self.parse_doc_version(self.document_object.get("specVersion"))
+        self.parse_doc_data_license(self.document_object.get("dataLicense"))
+        self.parse_doc_id(self.document_object.get("id"))
+        self.parse_doc_name(self.document_object.get("name"))
+        self.parse_doc_namespace(self.document_object.get("namespace"))
+        self.parse_doc_comment(self.document_object.get("comment"))
+        self.parse_creation_info(self.document_object.get("creationInfo"))
+        self.parse_external_document_refs(
+            self.document_object.get("externalDocumentRefs")
+        )
+        self.parse_extracted_license_info(
+            self.document_object.get("extractedLicenseInfos")
+        )
+        self.parse_annotations(self.document_object.get("annotations"))
+        self.parse_relationships(self.document_object.get("relationships"))
+        self.parse_reviews(self.document_object.get("reviewers"))
+        self.parse_snippets(self.document_object.get("snippets"))
 
-        self.parse_doc_described_objects(self.document_object.get('documentDescribes'))
+        self.parse_doc_described_objects(self.document_object.get("documentDescribes"))
 
         validation_messages = []
         # Report extra errors if self.error is False otherwise there will be
@@ -1307,11 +1448,11 @@ class Parser(CreationInfoParser, ExternalDocumentRefsParser, LicenseParser,
             try:
                 return self.builder.set_doc_version(self.document, doc_version)
             except SPDXValueError:
-                self.value_error('DOC_VERS_VALUE', doc_version)
+                self.value_error("DOC_VERS_VALUE", doc_version)
             except CardinalityError:
-                self.more_than_one_error('DOC_VERS_VALUE')
+                self.more_than_one_error("DOC_VERS_VALUE")
         else:
-            self.value_error('DOC_VERS_VALUE', doc_version)
+            self.value_error("DOC_VERS_VALUE", doc_version)
 
     def parse_doc_data_license(self, doc_data_license):
         """
@@ -1321,9 +1462,9 @@ class Parser(CreationInfoParser, ExternalDocumentRefsParser, LicenseParser,
         try:
             return self.builder.set_doc_data_lics(self.document, doc_data_license)
         except SPDXValueError:
-            self.value_error('DOC_D_LICS', doc_data_license)
+            self.value_error("DOC_D_LICS", doc_data_license)
         except CardinalityError:
-            self.more_than_one_error('DOC_D_LICS')
+            self.more_than_one_error("DOC_D_LICS")
 
     def parse_doc_id(self, doc_id):
         """
@@ -1334,11 +1475,11 @@ class Parser(CreationInfoParser, ExternalDocumentRefsParser, LicenseParser,
             try:
                 return self.builder.set_doc_spdx_id(self.document, doc_id)
             except SPDXValueError:
-                self.value_error('DOC_SPDX_ID_VALUE', doc_id)
+                self.value_error("DOC_SPDX_ID_VALUE", doc_id)
             except CardinalityError:
-                self.more_than_one_error('DOC_SPDX_ID_VALUE')
+                self.more_than_one_error("DOC_SPDX_ID_VALUE")
         else:
-            self.value_error('DOC_SPDX_ID_VALUE', doc_id)
+            self.value_error("DOC_SPDX_ID_VALUE", doc_id)
 
     def parse_doc_name(self, doc_name):
         """
@@ -1349,9 +1490,9 @@ class Parser(CreationInfoParser, ExternalDocumentRefsParser, LicenseParser,
             try:
                 return self.builder.set_doc_name(self.document, doc_name)
             except CardinalityError:
-                self.more_than_one_error('DOC_NAME_VALUE')
+                self.more_than_one_error("DOC_NAME_VALUE")
         else:
-            self.value_error('DOC_NAME_VALUE', doc_name)
+            self.value_error("DOC_NAME_VALUE", doc_name)
 
     def parse_doc_namespace(self, doc_namespace):
         """
@@ -1362,11 +1503,11 @@ class Parser(CreationInfoParser, ExternalDocumentRefsParser, LicenseParser,
             try:
                 return self.builder.set_doc_namespace(self.document, doc_namespace)
             except SPDXValueError:
-                self.value_error('DOC_NAMESPACE_VALUE', doc_namespace)
+                self.value_error("DOC_NAMESPACE_VALUE", doc_namespace)
             except CardinalityError:
-                self.more_than_one_error('DOC_NAMESPACE_VALUE')
+                self.more_than_one_error("DOC_NAMESPACE_VALUE")
         else:
-            self.value_error('DOC_NAMESPACE_VALUE', doc_namespace)
+            self.value_error("DOC_NAMESPACE_VALUE", doc_namespace)
 
     def parse_doc_comment(self, doc_comment):
         """
@@ -1377,9 +1518,9 @@ class Parser(CreationInfoParser, ExternalDocumentRefsParser, LicenseParser,
             try:
                 return self.builder.set_doc_comment(self.document, doc_comment)
             except CardinalityError:
-                self.more_than_one_error('DOC_COMMENT_VALUE')
+                self.more_than_one_error("DOC_COMMENT_VALUE")
         elif doc_comment is not None:
-            self.value_error('DOC_COMMENT_VALUE', doc_comment)
+            self.value_error("DOC_COMMENT_VALUE", doc_comment)
 
     def parse_doc_described_objects(self, doc_described_objects):
         """
@@ -1387,13 +1528,21 @@ class Parser(CreationInfoParser, ExternalDocumentRefsParser, LicenseParser,
         - doc_described_objects: Python list of dicts as in FileParser.parse_file or PackageParser.parse_package
         """
         if isinstance(doc_described_objects, list):
-            packages = filter(lambda described: isinstance(described, dict) and described.get('Package') is not None, doc_described_objects)
-            files = filter(lambda described: isinstance(described, dict) and described.get('File') is not None, doc_described_objects)
+            packages = filter(
+                lambda described: isinstance(described, dict)
+                and described.get("Package") is not None,
+                doc_described_objects,
+            )
+            files = filter(
+                lambda described: isinstance(described, dict)
+                and described.get("File") is not None,
+                doc_described_objects,
+            )
             # At the moment, only single-package documents are supported, so just the last package will be stored.
             for package in packages:
-                self.parse_package(package.get('Package'))
+                self.parse_package(package.get("Package"))
             for file in files:
-                self.parse_file(file.get('File'))
+                self.parse_file(file.get("File"))
             return True
         else:
-            self.value_error('DOC_DESCRIBES', doc_described_objects)
+            self.value_error("DOC_DESCRIBES", doc_described_objects)

--- a/spdx/parsers/jsonyamlxml.py
+++ b/spdx/parsers/jsonyamlxml.py
@@ -461,9 +461,8 @@ class RelationshipParser(BaseParser):
         """
         if isinstance(relationshiptype, six.string_types):
             relate = spdxelementid + " " + relationshiptype + " " + relatedspdxelement
-            entity = self.builder.create_entity(self.document, relate)
             try:
-                return self.builder.add_relationship(self.document, entity)
+                return self.builder.add_relationship(self.document, relate)
             except SPDXValueError:
                 self.value_error("RELATIONSHIP_VALUE", relate)
         else:

--- a/spdx/parsers/jsonyamlxmlbuilders.py
+++ b/spdx/parsers/jsonyamlxmlbuilders.py
@@ -1,4 +1,3 @@
-
 # Copyright (c) Xavier Figueroa
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -63,14 +62,17 @@ class DocBuilder(tagvaluebuilders.DocBuilder):
         if already defined.
         """
         if not self.doc_spdx_id_set:
-            if doc_spdx_id_line == 'SPDXRef-DOCUMENT' or validations.validate_doc_spdx_id(doc_spdx_id_line):
+            if (
+                doc_spdx_id_line == "SPDXRef-DOCUMENT"
+                or validations.validate_doc_spdx_id(doc_spdx_id_line)
+            ):
                 doc.spdx_id = doc_spdx_id_line
                 self.doc_spdx_id_set = True
                 return True
             else:
-                raise SPDXValueError('Document::SPDXID')
+                raise SPDXValueError("Document::SPDXID")
         else:
-            raise CardinalityError('Document::SPDXID')
+            raise CardinalityError("Document::SPDXID")
 
     def set_doc_comment(self, doc, comment):
         """
@@ -81,7 +83,7 @@ class DocBuilder(tagvaluebuilders.DocBuilder):
             self.doc_comment_set = True
             doc.comment = comment
         else:
-            raise CardinalityError('Document::Comment')
+            raise CardinalityError("Document::Comment")
 
 
 class LicenseBuilder(tagvaluebuilders.LicenseBuilder):
@@ -102,11 +104,11 @@ class LicenseBuilder(tagvaluebuilders.LicenseBuilder):
                     self.extr_lic(doc).full_name = name
                     return True
                 else:
-                    raise SPDXValueError('ExtractedLicense::Name')
+                    raise SPDXValueError("ExtractedLicense::Name")
             else:
-                raise CardinalityError('ExtractedLicense::Name')
+                raise CardinalityError("ExtractedLicense::Name")
         else:
-            raise OrderError('ExtractedLicense::Name')
+            raise OrderError("ExtractedLicense::Name")
 
     def set_lic_text(self, doc, text):
         """
@@ -120,9 +122,9 @@ class LicenseBuilder(tagvaluebuilders.LicenseBuilder):
                 self.extr_lic(doc).text = text
                 return True
             else:
-                raise CardinalityError('ExtractedLicense::text')
+                raise CardinalityError("ExtractedLicense::text")
         else:
-            raise OrderError('ExtractedLicense::text')
+            raise OrderError("ExtractedLicense::text")
 
     def set_lic_comment(self, doc, comment):
         """
@@ -136,9 +138,10 @@ class LicenseBuilder(tagvaluebuilders.LicenseBuilder):
                 self.extr_lic(doc).comment = comment
                 return True
             else:
-                raise CardinalityError('ExtractedLicense::comment')
+                raise CardinalityError("ExtractedLicense::comment")
         else:
-            raise OrderError('ExtractedLicense::comment')
+            raise OrderError("ExtractedLicense::comment")
+
 
 class FileBuilder(rdfbuilders.FileBuilder):
     def __init__(self):
@@ -156,9 +159,9 @@ class FileBuilder(rdfbuilders.FileBuilder):
                 self.file(doc).notice = text
                 return True
             else:
-                raise CardinalityError('File::Notice')
+                raise CardinalityError("File::Notice")
         else:
-            raise OrderError('File::Notice')
+            raise OrderError("File::Notice")
 
     def set_file_type(self, doc, type_value):
         """
@@ -167,10 +170,10 @@ class FileBuilder(rdfbuilders.FileBuilder):
         """
 
         type_dict = {
-            'fileType_source': 'SOURCE',
-            'fileType_binary': 'BINARY',
-            'fileType_archive': 'ARCHIVE',
-            'fileType_other': 'OTHER'
+            "fileType_source": "SOURCE",
+            "fileType_binary": "BINARY",
+            "fileType_archive": "ARCHIVE",
+            "fileType_other": "OTHER",
         }
 
         return super(FileBuilder, self).set_file_type(doc, type_dict.get(type_value))
@@ -192,14 +195,45 @@ class AnnotationBuilder(tagvaluebuilders.AnnotationBuilder):
                 doc.annotations[-1].comment = comment
                 return True
             else:
-                raise CardinalityError('AnnotationComment')
+                raise CardinalityError("AnnotationComment")
         else:
-            raise OrderError('AnnotationComment')
+            raise OrderError("AnnotationComment")
 
 
-class Builder(DocBuilder, CreationInfoBuilder, ExternalDocumentRefsBuilder, EntityBuilder,
-            SnippetBuilder, ReviewBuilder, LicenseBuilder, FileBuilder, PackageBuilder,
-            AnnotationBuilder):
+class RelationshipBuilder(tagvaluebuilders.RelationshipBuilder):
+    def __init__(self):
+        super(RelationshipBuilder, self).__init__()
+
+    def add_relationship_comment(self, doc, comment):
+        """
+        Set the relationship comment.
+        Raise CardinalityError if already set.
+        Raise OrderError if no annotator defined before.
+        """
+        if len(doc.relationships) != 0:
+            if not self.relationship_comment_set:
+                self.relationship_comment_set = True
+                doc.relationships[-1].comment = comment
+                return True
+            else:
+                raise CardinalityError("RelationshipComment")
+        else:
+            raise OrderError("RelationshipComment")
+
+
+class Builder(
+    DocBuilder,
+    CreationInfoBuilder,
+    ExternalDocumentRefsBuilder,
+    EntityBuilder,
+    SnippetBuilder,
+    ReviewBuilder,
+    LicenseBuilder,
+    FileBuilder,
+    PackageBuilder,
+    AnnotationBuilder,
+    RelationshipBuilder,
+):
     """
     SPDX document builder.
     """
@@ -221,4 +255,5 @@ class Builder(DocBuilder, CreationInfoBuilder, ExternalDocumentRefsBuilder, Enti
         self.reset_file_stat()
         self.reset_reviews()
         self.reset_annotations()
+        self.reset_relationship()
         self.reset_extr_lics()

--- a/spdx/parsers/lexers/tagvalue.py
+++ b/spdx/parsers/lexers/tagvalue.py
@@ -1,4 +1,3 @@
-
 # Copyright (c) 2014 Ahmed H. Ismail
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,183 +18,194 @@ from ply import lex
 class Lexer(object):
     reserved = {
         # Top level fields
-        'SPDXVersion': 'DOC_VERSION',
-        'DataLicense': 'DOC_LICENSE',
-        'DocumentName': 'DOC_NAME',
-        'SPDXID': 'SPDX_ID',
-        'DocumentComment': 'DOC_COMMENT',
-        'DocumentNamespace': 'DOC_NAMESPACE',
-        'ExternalDocumentRef': 'EXT_DOC_REF',
+        "SPDXVersion": "DOC_VERSION",
+        "DataLicense": "DOC_LICENSE",
+        "DocumentName": "DOC_NAME",
+        "SPDXID": "SPDX_ID",
+        "DocumentComment": "DOC_COMMENT",
+        "DocumentNamespace": "DOC_NAMESPACE",
+        "ExternalDocumentRef": "EXT_DOC_REF",
         # Creation info
-        'Creator': 'CREATOR',
-        'Created': 'CREATED',
-        'CreatorComment': 'CREATOR_COMMENT',
-        'LicenseListVersion': 'LIC_LIST_VER',
+        "Creator": "CREATOR",
+        "Created": "CREATED",
+        "CreatorComment": "CREATOR_COMMENT",
+        "LicenseListVersion": "LIC_LIST_VER",
         # Review info
-        'Reviewer': 'REVIEWER',
-        'ReviewDate': 'REVIEW_DATE',
-        'ReviewComment': 'REVIEW_COMMENT',
+        "Reviewer": "REVIEWER",
+        "ReviewDate": "REVIEW_DATE",
+        "ReviewComment": "REVIEW_COMMENT",
         # Annotation info
-        'Annotator': 'ANNOTATOR',
-        'AnnotationDate': 'ANNOTATION_DATE',
-        'AnnotationComment': 'ANNOTATION_COMMENT',
-        'AnnotationType': 'ANNOTATION_TYPE',
-        'SPDXREF': 'ANNOTATION_SPDX_ID',
+        "Annotator": "ANNOTATOR",
+        "AnnotationDate": "ANNOTATION_DATE",
+        "AnnotationComment": "ANNOTATION_COMMENT",
+        "AnnotationType": "ANNOTATION_TYPE",
+        "SPDXREF": "ANNOTATION_SPDX_ID",
+        # Relationships
+        "Relationship": "RELATIONSHIP",
+        "RelationshipComment": "RELATIONSHIP_COMMENT",
         # Package Fields
-        'PackageName': 'PKG_NAME',
-        'PackageVersion': 'PKG_VERSION',
-        'PackageDownloadLocation': 'PKG_DOWN',
-        'FilesAnalyzed': 'PKG_FILES_ANALYZED',
-        'PackageSummary': 'PKG_SUM',
-        'PackageSourceInfo': 'PKG_SRC_INFO',
-        'PackageFileName': 'PKG_FILE_NAME',
-        'PackageSupplier': 'PKG_SUPPL',
-        'PackageOriginator': 'PKG_ORIG',
-        'PackageChecksum': 'PKG_CHKSUM',
-        'PackageVerificationCode': 'PKG_VERF_CODE',
-        'PackageDescription': 'PKG_DESC',
-        'PackageComment': 'PKG_COMMENT',
-        'PackageLicenseDeclared': 'PKG_LICS_DECL',
-        'PackageLicenseConcluded': 'PKG_LICS_CONC',
-        'PackageLicenseInfoFromFiles': 'PKG_LICS_FFILE',
-        'PackageLicenseComments': 'PKG_LICS_COMMENT',
-        'PackageCopyrightText': 'PKG_CPY_TEXT',
-        'PackageHomePage': 'PKG_HOME',
-        'ExternalRef': 'PKG_EXT_REF',
-        'ExternalRefComment': 'PKG_EXT_REF_COMMENT',
+        "PackageName": "PKG_NAME",
+        "PackageVersion": "PKG_VERSION",
+        "PackageDownloadLocation": "PKG_DOWN",
+        "FilesAnalyzed": "PKG_FILES_ANALYZED",
+        "PackageSummary": "PKG_SUM",
+        "PackageSourceInfo": "PKG_SRC_INFO",
+        "PackageFileName": "PKG_FILE_NAME",
+        "PackageSupplier": "PKG_SUPPL",
+        "PackageOriginator": "PKG_ORIG",
+        "PackageChecksum": "PKG_CHKSUM",
+        "PackageVerificationCode": "PKG_VERF_CODE",
+        "PackageDescription": "PKG_DESC",
+        "PackageComment": "PKG_COMMENT",
+        "PackageLicenseDeclared": "PKG_LICS_DECL",
+        "PackageLicenseConcluded": "PKG_LICS_CONC",
+        "PackageLicenseInfoFromFiles": "PKG_LICS_FFILE",
+        "PackageLicenseComments": "PKG_LICS_COMMENT",
+        "PackageCopyrightText": "PKG_CPY_TEXT",
+        "PackageHomePage": "PKG_HOME",
+        "ExternalRef": "PKG_EXT_REF",
+        "ExternalRefComment": "PKG_EXT_REF_COMMENT",
         # Files
-        'FileName': 'FILE_NAME',
-        'FileType': 'FILE_TYPE',
-        'FileChecksum': 'FILE_CHKSUM',
-        'LicenseConcluded': 'FILE_LICS_CONC',
-        'LicenseInfoInFile': 'FILE_LICS_INFO',
-        'FileCopyrightText': 'FILE_CR_TEXT',
-        'LicenseComments': 'FILE_LICS_COMMENT',
-        'FileComment': 'FILE_COMMENT',
-        'FileNotice': 'FILE_NOTICE',
-        'FileContributor': 'FILE_CONTRIB',
-        'FileDependency': 'FILE_DEP',
-        'ArtifactOfProjectName': 'ART_PRJ_NAME',
-        'ArtifactOfProjectHomePage': 'ART_PRJ_HOME',
-        'ArtifactOfProjectURI': 'ART_PRJ_URI',
+        "FileName": "FILE_NAME",
+        "FileType": "FILE_TYPE",
+        "FileChecksum": "FILE_CHKSUM",
+        "LicenseConcluded": "FILE_LICS_CONC",
+        "LicenseInfoInFile": "FILE_LICS_INFO",
+        "FileCopyrightText": "FILE_CR_TEXT",
+        "LicenseComments": "FILE_LICS_COMMENT",
+        "FileComment": "FILE_COMMENT",
+        "FileNotice": "FILE_NOTICE",
+        "FileContributor": "FILE_CONTRIB",
+        "FileDependency": "FILE_DEP",
+        "ArtifactOfProjectName": "ART_PRJ_NAME",
+        "ArtifactOfProjectHomePage": "ART_PRJ_HOME",
+        "ArtifactOfProjectURI": "ART_PRJ_URI",
         # License
-        'LicenseID': 'LICS_ID',
-        'ExtractedText': 'LICS_TEXT',
-        'LicenseName': 'LICS_NAME',
-        'LicenseCrossReference': 'LICS_CRS_REF',
-        'LicenseComment': 'LICS_COMMENT',
+        "LicenseID": "LICS_ID",
+        "ExtractedText": "LICS_TEXT",
+        "LicenseName": "LICS_NAME",
+        "LicenseCrossReference": "LICS_CRS_REF",
+        "LicenseComment": "LICS_COMMENT",
         # Snippet
-        'SnippetSPDXID': 'SNIPPET_SPDX_ID',
-        'SnippetName': 'SNIPPET_NAME',
-        'SnippetComment': 'SNIPPET_COMMENT',
-        'SnippetCopyrightText': 'SNIPPET_CR_TEXT',
-        'SnippetLicenseComments': 'SNIPPET_LICS_COMMENT',
-        'SnippetFromFileSPDXID': 'SNIPPET_FILE_SPDXID',
-        'SnippetLicenseConcluded': 'SNIPPET_LICS_CONC',
-        'LicenseInfoInSnippet': 'SNIPPET_LICS_INFO',
+        "SnippetSPDXID": "SNIPPET_SPDX_ID",
+        "SnippetName": "SNIPPET_NAME",
+        "SnippetComment": "SNIPPET_COMMENT",
+        "SnippetCopyrightText": "SNIPPET_CR_TEXT",
+        "SnippetLicenseComments": "SNIPPET_LICS_COMMENT",
+        "SnippetFromFileSPDXID": "SNIPPET_FILE_SPDXID",
+        "SnippetLicenseConcluded": "SNIPPET_LICS_CONC",
+        "LicenseInfoInSnippet": "SNIPPET_LICS_INFO",
         # Common
-        'NOASSERTION': 'NO_ASSERT',
-        'UNKNOWN': 'UN_KNOWN',
-        'NONE': 'NONE',
-        'SOURCE': 'SOURCE',
-        'BINARY': 'BINARY',
-        'ARCHIVE': 'ARCHIVE',
-        'OTHER': 'OTHER'
+        "NOASSERTION": "NO_ASSERT",
+        "UNKNOWN": "UN_KNOWN",
+        "NONE": "NONE",
+        "SOURCE": "SOURCE",
+        "BINARY": "BINARY",
+        "ARCHIVE": "ARCHIVE",
+        "OTHER": "OTHER",
     }
-    states = (('text', 'exclusive'),)
+    states = (("text", "exclusive"),)
 
-    tokens = ['TEXT', 'TOOL_VALUE', 'UNKNOWN_TAG',
-              'ORG_VALUE', 'PERSON_VALUE',
-              'DATE', 'LINE', 'CHKSUM', 'DOC_REF_ID',
-              'DOC_URI', 'EXT_DOC_REF_CHKSUM'] + list(reserved.values())
+    tokens = [
+        "TEXT",
+        "TOOL_VALUE",
+        "UNKNOWN_TAG",
+        "ORG_VALUE",
+        "PERSON_VALUE",
+        "DATE",
+        "LINE",
+        "CHKSUM",
+        "DOC_REF_ID",
+        "DOC_URI",
+        "EXT_DOC_REF_CHKSUM",
+    ] + list(reserved.values())
 
     def t_text(self, t):
-        r':\s*<text>'
-        t.lexer.text_start = t.lexer.lexpos - len('<text>')
-        t.lexer.begin('text')
+        r":\s*<text>"
+        t.lexer.text_start = t.lexer.lexpos - len("<text>")
+        t.lexer.begin("text")
 
     def t_text_end(self, t):
-        r'</text>\s*'
-        t.type = 'TEXT'
-        t.value = t.lexer.lexdata[
-            t.lexer.text_start:t.lexer.lexpos]
-        t.lexer.lineno += t.value.count('\n')
+        r"</text>\s*"
+        t.type = "TEXT"
+        t.value = t.lexer.lexdata[t.lexer.text_start : t.lexer.lexpos]
+        t.lexer.lineno += t.value.count("\n")
         t.value = t.value.strip()
-        t.lexer.begin('INITIAL')
+        t.lexer.begin("INITIAL")
         return t
 
     def t_text_any(self, t):
-        r'.|\n'
+        r".|\n"
         pass
 
     def t_text_error(self, t):
-        print('Lexer error in text state')
+        print("Lexer error in text state")
 
     def t_CHKSUM(self, t):
-        r':\s*SHA1:\s*[a-f0-9]{40,40}'
+        r":\s*SHA1:\s*[a-f0-9]{40,40}"
         t.value = t.value[1:].strip()
         return t
 
     def t_DOC_REF_ID(self, t):
-        r':\s*DocumentRef-([A-Za-z0-9\+\.\-]+)'
+        r":\s*DocumentRef-([A-Za-z0-9\+\.\-]+)"
         t.value = t.value[1:].strip()
         return t
 
     def t_DOC_URI(self, t):
-        r'\s*((ht|f)tps?:\/\/\S*)'
+        r"\s*((ht|f)tps?:\/\/\S*)"
         t.value = t.value.strip()
         return t
 
     def t_EXT_DOC_REF_CHKSUM(self, t):
-        r'\s*SHA1:\s*[a-f0-9]{40,40}'
+        r"\s*SHA1:\s*[a-f0-9]{40,40}"
         t.value = t.value[1:].strip()
         return t
 
     def t_TOOL_VALUE(self, t):
-        r':\s*Tool:.+'
+        r":\s*Tool:.+"
         t.value = t.value[1:].strip()
         return t
 
     def t_ORG_VALUE(self, t):
-        r':\s*Organization:.+'
+        r":\s*Organization:.+"
         t.value = t.value[1:].strip()
         return t
 
     def t_PERSON_VALUE(self, t):
-        r':\s*Person:.+'
+        r":\s*Person:.+"
         t.value = t.value[1:].strip()
         return t
 
     def t_DATE(self, t):
-        r':\s*\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\dZ'
+        r":\s*\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\dZ"
         t.value = t.value[1:].strip()
         return t
 
     def t_KEYWORD_AS_TAG(self, t):
-        r'[a-zA-Z]+'
-        t.type = self.reserved.get(t.value, 'UNKNOWN_TAG')
+        r"[a-zA-Z]+"
+        t.type = self.reserved.get(t.value, "UNKNOWN_TAG")
         t.value = t.value.strip()
         return t
 
     def t_LINE_OR_KEYWORD_VALUE(self, t):
-        r':.+'
+        r":.+"
         t.value = t.value[1:].strip()
         if t.value in self.reserved.keys():
             t.type = self.reserved[t.value]
         else:
-            t.type = 'LINE'
+            t.type = "LINE"
         return t
 
     def t_comment(self, t):
-        r'\#.*'
+        r"\#.*"
         pass
 
     def t_newline(self, t):
-        r'\n+'
+        r"\n+"
         t.lexer.lineno += len(t.value)
 
     def t_whitespace(self, t):
-        r'\s+'
+        r"\s+"
         pass
 
     def build(self, **kwargs):
@@ -209,5 +219,5 @@ class Lexer(object):
 
     def t_error(self, t):
         t.lexer.skip(1)
-        t.value = 'Lexer error'
+        t.value = "Lexer error"
         return t

--- a/spdx/parsers/rdf.py
+++ b/spdx/parsers/rdf.py
@@ -1,4 +1,3 @@
-
 # Copyright (c) 2014 Ahmed H. Ismail
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -31,41 +30,42 @@ from spdx.parsers.builderexceptions import SPDXValueError
 
 
 ERROR_MESSAGES = {
-    'DOC_VERS_VALUE': 'Invalid specVersion \'{0}\' must be SPDX-M.N where M and N are numbers.',
-    'DOC_D_LICS': 'Invalid dataLicense \'{0}\' must be http://spdx.org/licenses/CC0-1.0.',
-    'DOC_SPDX_ID_VALUE': 'Invalid SPDXID value, SPDXID must be the document namespace appended '
-                         'by "#SPDXRef-DOCUMENT", line: {0}',
-    'DOC_NAMESPACE_VALUE': 'Invalid DocumentNamespace value {0}, must contain a scheme (e.g. "https:") '
-                           'and should not contain the "#" delimiter.',
-    'LL_VALUE': 'Invalid licenseListVersion \'{0}\' must be of the format N.N where N is a number',
-    'CREATED_VALUE': 'Invalid created value \'{0}\' must be date in ISO 8601 format.',
-    'CREATOR_VALUE': 'Invalid creator value \'{0}\' must be Organization, Tool or Person.',
-    'EXT_DOC_REF_VALUE': 'Failed to extract {0} from ExternalDocumentRef.',
-    'PKG_SPDX_ID_VALUE': 'SPDXID must be "SPDXRef-[idstring]" where [idstring] is a unique string containing '
-                         'letters, numbers, ".", "-".',
-    'PKG_SUPPL_VALUE': 'Invalid package supplier value \'{0}\' must be Organization, Person or NOASSERTION.',
-    'PKG_ORIGINATOR_VALUE': 'Invalid package supplier value \'{0}\'  must be Organization, Person or NOASSERTION.',
-    'PKG_DOWN_LOC': 'Invalid package download location value \'{0}\'  must be a url or NONE or NOASSERTION',
-    'PKG_FILES_ANALYZED_VALUE': 'FilesAnalyzed must be a boolean value, line: {0}',
-    'PKG_CONC_LIST': 'Package concluded license list must have more than one member',
-    'LICS_LIST_MEMBER' : 'Declaritive or Conjunctive license set member must be a license url or identifier',
-    'PKG_SINGLE_LICS' : 'Package concluded license must be a license url or spdx:noassertion or spdx:none.',
-    'PKG_LICS_INFO_FILES' : 'Package licenseInfoFromFiles must be a license or spdx:none or spdx:noassertion',
-    'FILE_SPDX_ID_VALUE': 'SPDXID must be "SPDXRef-[idstring]" where [idstring] is a unique string containing '
-                          'letters, numbers, ".", "-".',
-    'PKG_EXT_REF_CATEGORY': '\'{0}\' must be "SECURITY", "PACKAGE-MANAGER", or "OTHER".',
-    'PKG_EXT_REF_TYPE': '{0} must be a unique string containing letters, numbers, ".", or "-".',
-    'FILE_TYPE' : 'File type must be binary, other, source or archive term.',
-    'FILE_SINGLE_LICS': 'File concluded license must be a license url or spdx:noassertion or spdx:none.',
-    'REVIEWER_VALUE' : 'Invalid reviewer value \'{0}\' must be Organization, Tool or Person.',
-    'REVIEW_DATE' : 'Invalid review date value \'{0}\' must be date in ISO 8601 format.',
-    'ANNOTATOR_VALUE': 'Invalid annotator value \'{0}\' must be Organization, Tool or Person.',
-    'ANNOTATION_DATE': 'Invalid annotation date value \'{0}\' must be date in ISO 8601 format.',
-    'SNIPPET_SPDX_ID_VALUE' : 'SPDXID must be "SPDXRef-[idstring]" where [idstring] is a unique string '
-                              'containing letters, numbers, ".", "-".',
-    'SNIPPET_SINGLE_LICS' : 'Snippet Concluded License must be a license url or spdx:noassertion or spdx:none.',
-    'SNIPPET_LIC_INFO' : 'License Information in Snippet must be a license url or a reference '
-                         'to the license, denoted by LicenseRef-[idstring] or spdx:noassertion or spdx:none.',
+    "DOC_VERS_VALUE": "Invalid specVersion '{0}' must be SPDX-M.N where M and N are numbers.",
+    "DOC_D_LICS": "Invalid dataLicense '{0}' must be http://spdx.org/licenses/CC0-1.0.",
+    "DOC_SPDX_ID_VALUE": "Invalid SPDXID value, SPDXID must be the document namespace appended "
+    'by "#SPDXRef-DOCUMENT", line: {0}',
+    "DOC_NAMESPACE_VALUE": 'Invalid DocumentNamespace value {0}, must contain a scheme (e.g. "https:") '
+    'and should not contain the "#" delimiter.',
+    "LL_VALUE": "Invalid licenseListVersion '{0}' must be of the format N.N where N is a number",
+    "CREATED_VALUE": "Invalid created value '{0}' must be date in ISO 8601 format.",
+    "CREATOR_VALUE": "Invalid creator value '{0}' must be Organization, Tool or Person.",
+    "EXT_DOC_REF_VALUE": "Failed to extract {0} from ExternalDocumentRef.",
+    "PKG_SPDX_ID_VALUE": 'SPDXID must be "SPDXRef-[idstring]" where [idstring] is a unique string containing '
+    'letters, numbers, ".", "-".',
+    "PKG_SUPPL_VALUE": "Invalid package supplier value '{0}' must be Organization, Person or NOASSERTION.",
+    "PKG_ORIGINATOR_VALUE": "Invalid package supplier value '{0}'  must be Organization, Person or NOASSERTION.",
+    "PKG_DOWN_LOC": "Invalid package download location value '{0}'  must be a url or NONE or NOASSERTION",
+    "PKG_FILES_ANALYZED_VALUE": "FilesAnalyzed must be a boolean value, line: {0}",
+    "PKG_CONC_LIST": "Package concluded license list must have more than one member",
+    "LICS_LIST_MEMBER": "Declaritive or Conjunctive license set member must be a license url or identifier",
+    "PKG_SINGLE_LICS": "Package concluded license must be a license url or spdx:noassertion or spdx:none.",
+    "PKG_LICS_INFO_FILES": "Package licenseInfoFromFiles must be a license or spdx:none or spdx:noassertion",
+    "FILE_SPDX_ID_VALUE": 'SPDXID must be "SPDXRef-[idstring]" where [idstring] is a unique string containing '
+    'letters, numbers, ".", "-".',
+    "PKG_EXT_REF_CATEGORY": '\'{0}\' must be "SECURITY", "PACKAGE-MANAGER", or "OTHER".',
+    "PKG_EXT_REF_TYPE": '{0} must be a unique string containing letters, numbers, ".", or "-".',
+    "FILE_TYPE": "File type must be binary, other, source or archive term.",
+    "FILE_SINGLE_LICS": "File concluded license must be a license url or spdx:noassertion or spdx:none.",
+    "REVIEWER_VALUE": "Invalid reviewer value '{0}' must be Organization, Tool or Person.",
+    "REVIEW_DATE": "Invalid review date value '{0}' must be date in ISO 8601 format.",
+    "ANNOTATOR_VALUE": "Invalid annotator value '{0}' must be Organization, Tool or Person.",
+    "ANNOTATION_DATE": "Invalid annotation date value '{0}' must be date in ISO 8601 format.",
+    "SNIPPET_SPDX_ID_VALUE": 'SPDXID must be "SPDXRef-[idstring]" where [idstring] is a unique string '
+    'containing letters, numbers, ".", "-".',
+    "SNIPPET_SINGLE_LICS": "Snippet Concluded License must be a license url or spdx:noassertion or spdx:none.",
+    "SNIPPET_LIC_INFO": "License Information in Snippet must be a license url or a reference "
+    "to the license, denoted by LicenseRef-[idstring] or spdx:noassertion or spdx:none.",
+    "RELATIONSHIP": "relationship type must be of supported type",
 }
 
 
@@ -78,7 +78,7 @@ class BaseParser(object):
 
     def __init__(self, builder, logger):
         self.logger = logger
-        self.doap_namespace = Namespace('http://usefulinc.com/ns/doap#')
+        self.doap_namespace = Namespace("http://usefulinc.com/ns/doap#")
         self.spdx_namespace = Namespace("http://spdx.org/rdf/terms#")
         self.builder = builder
 
@@ -87,7 +87,7 @@ class BaseParser(object):
         Logs a more than one error.
         field is the field/property that has more than one defined.
         """
-        msg = 'More than one {0} defined.'.format(field)
+        msg = "More than one {0} defined.".format(field)
         self.logger.log(msg)
         self.error = True
 
@@ -123,7 +123,7 @@ class LicenseParser(BaseParser):
     Helper class for parsing extracted licenses and license lists.
     """
 
-    LICS_REF_REGEX = re.compile('LicenseRef-.+', re.UNICODE)
+    LICS_REF_REGEX = re.compile("LicenseRef-.+", re.UNICODE)
 
     def __init__(self, builder, logger):
         super(LicenseParser, self).__init__(builder, logger)
@@ -133,11 +133,15 @@ class LicenseParser(BaseParser):
         Return a License from a `lics` license resource.
         """
         # Handle extracted licensing info type.
-        if (lics, RDF.type, self.spdx_namespace['ExtractedLicensingInfo']) in self.graph:
+        if (
+            lics,
+            RDF.type,
+            self.spdx_namespace["ExtractedLicensingInfo"],
+        ) in self.graph:
             return self.parse_only_extr_license(lics)
 
         # Assume resource, hence the path separator
-        ident_start = lics.rfind('/') + 1
+        ident_start = lics.rfind("/") + 1
         if ident_start == 0:
             # special values such as spdx:noassertion
             special = self.to_special_value(lics)
@@ -147,7 +151,7 @@ class LicenseParser(BaseParser):
                     return document.License.from_identifier(six.text_type(lics))
                 else:
                     # Not a known license form
-                    raise SPDXValueError('License')
+                    raise SPDXValueError("License")
             else:
                 # is a special value
                 return special
@@ -159,16 +163,18 @@ class LicenseParser(BaseParser):
         """
         Return a license identifier from an ExtractedLicense or None.
         """
-        identifier_tripples = list(self.graph.triples((extr_lic, self.spdx_namespace['licenseId'], None)))
+        identifier_tripples = list(
+            self.graph.triples((extr_lic, self.spdx_namespace["licenseId"], None))
+        )
 
         if not identifier_tripples:
             self.error = True
-            msg = 'Extracted license must have licenseId property.'
+            msg = "Extracted license must have licenseId property."
             self.logger.log(msg)
             return
 
         if len(identifier_tripples) > 1:
-            self.more_than_one_error('extracted license identifier_tripples')
+            self.more_than_one_error("extracted license identifier_tripples")
             return
 
         identifier_tripple = identifier_tripples[0]
@@ -179,15 +185,17 @@ class LicenseParser(BaseParser):
         """
         Return extracted text from an ExtractedLicense or None.
         """
-        text_tripples = list(self.graph.triples((extr_lic, self.spdx_namespace['extractedText'], None)))
+        text_tripples = list(
+            self.graph.triples((extr_lic, self.spdx_namespace["extractedText"], None))
+        )
         if not text_tripples:
             self.error = True
-            msg = 'Extracted license must have extractedText property'
+            msg = "Extracted license must have extractedText property"
             self.logger.log(msg)
             return
 
         if len(text_tripples) > 1:
-            self.more_than_one_error('extracted license text')
+            self.more_than_one_error("extracted license text")
             return
 
         text_tripple = text_tripples[0]
@@ -198,9 +206,11 @@ class LicenseParser(BaseParser):
         """
         Return the license name from an ExtractedLicense or None
         """
-        extr_name_list = list(self.graph.triples((extr_lic, self.spdx_namespace['licenseName'], None)))
+        extr_name_list = list(
+            self.graph.triples((extr_lic, self.spdx_namespace["licenseName"], None))
+        )
         if len(extr_name_list) > 1:
-            self.more_than_one_error('extracted license name')
+            self.more_than_one_error("extracted license name")
             return
         elif len(extr_name_list) == 0:
             return
@@ -217,10 +227,9 @@ class LicenseParser(BaseParser):
         """
         Return license comment or None.
         """
-        comment_list = list(self.graph.triples(
-            (extr_lics, RDFS.comment, None)))
-        if len(comment_list) > 1 :
-            self.more_than_one_error('extracted license comment')
+        comment_list = list(self.graph.triples((extr_lics, RDFS.comment, None)))
+        if len(comment_list) > 1:
+            self.more_than_one_error("extracted license comment")
             return
         elif len(comment_list) == 1:
             return six.text_type(comment_list[0][2])
@@ -273,16 +282,17 @@ class LicenseParser(BaseParser):
         """
         licenses = []
         for _, _, lics_member in self.graph.triples(
-            (lics_set, self.spdx_namespace['member'], None)):
+            (lics_set, self.spdx_namespace["member"], None)
+        ):
             try:
                 licenses.append(self.handle_lics(lics_member))
             except CardinalityError:
-                self.value_error('LICS_LIST_MEMBER', lics_member)
+                self.value_error("LICS_LIST_MEMBER", lics_member)
                 break
         if len(licenses) > 1:
             return reduce(lambda a, b: cls(a, b), licenses)
         else:
-            self.value_error('PKG_CONC_LIST', '')
+            self.value_error("PKG_CONC_LIST", "")
             return
 
     def handle_conjunctive_list(self, lics_set):
@@ -313,95 +323,108 @@ class PackageParser(LicenseParser):
         Parse package fields.
         """
         # Check there is a pacakge name
-        if not (p_term, self.spdx_namespace['name'], None) in self.graph:
+        if not (p_term, self.spdx_namespace["name"], None) in self.graph:
             self.error = True
-            self.logger.log('Package must have a name.')
+            self.logger.log("Package must have a name.")
             # Create dummy package so that we may continue parsing the rest of
             # the package fields.
-            self.builder.create_package(self.doc, 'dummy_package')
+            self.builder.create_package(self.doc, "dummy_package")
         else:
-            for _s, _p, o in self.graph.triples((p_term, self.spdx_namespace['name'], None)):
+            for _s, _p, o in self.graph.triples(
+                (p_term, self.spdx_namespace["name"], None)
+            ):
                 try:
                     self.builder.create_package(self.doc, six.text_type(o))
                 except CardinalityError:
-                    self.more_than_one_error('Package name')
+                    self.more_than_one_error("Package name")
                     break
         # Set SPDXID
         try:
-            if p_term.count('#', 0, len(p_term)) == 1:
-                pkg_spdx_id = p_term.split('#')[-1]
+            if p_term.count("#", 0, len(p_term)) == 1:
+                pkg_spdx_id = p_term.split("#")[-1]
                 self.builder.set_pkg_spdx_id(self.doc, pkg_spdx_id)
             else:
-                self.value_error('PKG_SPDX_ID_VALUE', p_term)
+                self.value_error("PKG_SPDX_ID_VALUE", p_term)
         except SPDXValueError:
-            self.value_error('PKG_SPDX_ID_VALUE', p_term)
+            self.value_error("PKG_SPDX_ID_VALUE", p_term)
 
-        self.p_pkg_vinfo(p_term, self.spdx_namespace['versionInfo'])
-        self.p_pkg_fname(p_term, self.spdx_namespace['packageFileName'])
-        self.p_pkg_suppl(p_term, self.spdx_namespace['supplier'])
-        self.p_pkg_originator(p_term, self.spdx_namespace['originator'])
-        self.p_pkg_down_loc(p_term, self.spdx_namespace['downloadLocation'])
-        self.p_pkg_files_analyzed(p_term, self.spdx_namespace['filesAnalyzed'])
-        self.p_pkg_homepg(p_term, self.doap_namespace['homepage'])
-        self.p_pkg_chk_sum(p_term, self.spdx_namespace['checksum'])
-        self.p_pkg_src_info(p_term, self.spdx_namespace['sourceInfo'])
-        self.p_pkg_verif_code(p_term, self.spdx_namespace['packageVerificationCode'])
-        self.p_pkg_lic_conc(p_term, self.spdx_namespace['licenseConcluded'])
-        self.p_pkg_lic_decl(p_term, self.spdx_namespace['licenseDeclared'])
-        self.p_pkg_lics_info_from_files(p_term, self.spdx_namespace['licenseInfoFromFiles'])
-        self.p_pkg_comments_on_lics(p_term, self.spdx_namespace['licenseComments'])
-        self.p_pkg_cr_text(p_term, self.spdx_namespace['copyrightText'])
-        self.p_pkg_summary(p_term, self.spdx_namespace['summary'])
-        self.p_pkg_descr(p_term, self.spdx_namespace['description'])
-        self.p_pkg_comment(p_term, self.spdx_namespace['comment'])
+        self.p_pkg_vinfo(p_term, self.spdx_namespace["versionInfo"])
+        self.p_pkg_fname(p_term, self.spdx_namespace["packageFileName"])
+        self.p_pkg_suppl(p_term, self.spdx_namespace["supplier"])
+        self.p_pkg_originator(p_term, self.spdx_namespace["originator"])
+        self.p_pkg_down_loc(p_term, self.spdx_namespace["downloadLocation"])
+        self.p_pkg_files_analyzed(p_term, self.spdx_namespace["filesAnalyzed"])
+        self.p_pkg_homepg(p_term, self.doap_namespace["homepage"])
+        self.p_pkg_chk_sum(p_term, self.spdx_namespace["checksum"])
+        self.p_pkg_src_info(p_term, self.spdx_namespace["sourceInfo"])
+        self.p_pkg_verif_code(p_term, self.spdx_namespace["packageVerificationCode"])
+        self.p_pkg_lic_conc(p_term, self.spdx_namespace["licenseConcluded"])
+        self.p_pkg_lic_decl(p_term, self.spdx_namespace["licenseDeclared"])
+        self.p_pkg_lics_info_from_files(
+            p_term, self.spdx_namespace["licenseInfoFromFiles"]
+        )
+        self.p_pkg_comments_on_lics(p_term, self.spdx_namespace["licenseComments"])
+        self.p_pkg_cr_text(p_term, self.spdx_namespace["copyrightText"])
+        self.p_pkg_summary(p_term, self.spdx_namespace["summary"])
+        self.p_pkg_descr(p_term, self.spdx_namespace["description"])
+        self.p_pkg_comment(p_term, self.spdx_namespace["comment"])
 
     def p_pkg_cr_text(self, p_term, predicate):
         try:
             for _, _, text in self.graph.triples((p_term, predicate, None)):
-                self.builder.set_pkg_cr_text(self.doc, six.text_type(self.to_special_value(text)))
+                self.builder.set_pkg_cr_text(
+                    self.doc, six.text_type(self.to_special_value(text))
+                )
         except CardinalityError:
-            self.more_than_one_error('package copyright text')
+            self.more_than_one_error("package copyright text")
 
     def p_pkg_summary(self, p_term, predicate):
         try:
             for _, _, summary in self.graph.triples((p_term, predicate, None)):
                 self.builder.set_pkg_summary(self.doc, six.text_type(summary))
         except CardinalityError:
-            self.more_than_one_error('package summary')
+            self.more_than_one_error("package summary")
 
     def p_pkg_descr(self, p_term, predicate):
         try:
-            for _, _, desc in self.graph.triples(
-                (p_term, predicate, None)):
+            for _, _, desc in self.graph.triples((p_term, predicate, None)):
                 self.builder.set_pkg_desc(self.doc, six.text_type(desc))
         except CardinalityError:
-            self.more_than_one_error('package description')
+            self.more_than_one_error("package description")
 
     def p_pkg_comment(self, p_term, predicate):
         try:
             for _, _, comment in self.graph.triples((p_term, predicate, None)):
                 self.builder.set_pkg_comment(self.doc, six.text_type(comment))
         except CardinalityError:
-            self.more_than_one_error('package comment')
+            self.more_than_one_error("package comment")
 
     def p_pkg_comments_on_lics(self, p_term, predicate):
         for _, _, comment in self.graph.triples((p_term, predicate, None)):
             try:
                 self.builder.set_pkg_license_comment(self.doc, six.text_type(comment))
             except CardinalityError:
-                self.more_than_one_error('package comments on license')
+                self.more_than_one_error("package comments on license")
                 break
 
     def p_pkg_lics_info_from_files(self, p_term, predicate):
         for _, _, lics in self.graph.triples((p_term, predicate, None)):
             try:
-                if (lics, RDF.type, self.spdx_namespace['ExtractedLicensingInfo']) in self.graph:
-                    self.builder.set_pkg_license_from_file(self.doc, self.parse_only_extr_license(lics))
+                if (
+                    lics,
+                    RDF.type,
+                    self.spdx_namespace["ExtractedLicensingInfo"],
+                ) in self.graph:
+                    self.builder.set_pkg_license_from_file(
+                        self.doc, self.parse_only_extr_license(lics)
+                    )
                 else:
-                    self.builder.set_pkg_license_from_file(self.doc, self.handle_lics(lics))
+                    self.builder.set_pkg_license_from_file(
+                        self.doc, self.handle_lics(lics)
+                    )
 
             except SPDXValueError:
-                self.value_error('PKG_LICS_INFO_FILES', lics)
+                self.value_error("PKG_LICS_INFO_FILES", lics)
 
     def p_pkg_lic_decl(self, p_term, predicate):
         self.handle_pkg_lic(p_term, predicate, self.builder.set_pkg_license_declared)
@@ -412,11 +435,19 @@ class PackageParser(LicenseParser):
         """
         try:
             for _, _, licenses in self.graph.triples((p_term, predicate, None)):
-                if (licenses, RDF.type, self.spdx_namespace['ConjunctiveLicenseSet']) in self.graph:
+                if (
+                    licenses,
+                    RDF.type,
+                    self.spdx_namespace["ConjunctiveLicenseSet"],
+                ) in self.graph:
                     lics = self.handle_conjunctive_list(licenses)
                     builder_func(self.doc, lics)
 
-                elif (licenses, RDF.type, self.spdx_namespace['DisjunctiveLicenseSet']) in self.graph:
+                elif (
+                    licenses,
+                    RDF.type,
+                    self.spdx_namespace["DisjunctiveLicenseSet"],
+                ) in self.graph:
                     lics = self.handle_disjunctive_list(licenses)
                     builder_func(self.doc, lics)
 
@@ -425,9 +456,9 @@ class PackageParser(LicenseParser):
                         lics = self.handle_lics(licenses)
                         builder_func(self.doc, lics)
                     except SPDXValueError:
-                        self.value_error('PKG_SINGLE_LICS', licenses)
+                        self.value_error("PKG_SINGLE_LICS", licenses)
         except CardinalityError:
-            self.more_than_one_error('package {0}'.format(predicate))
+            self.more_than_one_error("package {0}".format(predicate))
 
     def p_pkg_lic_conc(self, p_term, predicate):
         self.handle_pkg_lic(p_term, predicate, self.builder.set_pkg_licenses_concluded)
@@ -435,18 +466,26 @@ class PackageParser(LicenseParser):
     def p_pkg_verif_code(self, p_term, predicate):
         for _, _, verifcode in self.graph.triples((p_term, predicate, None)):
             # Parse verification code
-            for _, _, code in self.graph.triples((verifcode, self.spdx_namespace['packageVerificationCodeValue'], None)):
+            for _, _, code in self.graph.triples(
+                (verifcode, self.spdx_namespace["packageVerificationCodeValue"], None)
+            ):
                 try:
                     self.builder.set_pkg_verif_code(self.doc, six.text_type(code))
                 except CardinalityError:
-                    self.more_than_one_error('package verificaton code')
+                    self.more_than_one_error("package verificaton code")
                     break
             # Parse excluded file
-            for _, _, filename in self.graph.triples((verifcode, self.spdx_namespace['packageVerificationCodeExcludedFile'], None)):
+            for _, _, filename in self.graph.triples(
+                (
+                    verifcode,
+                    self.spdx_namespace["packageVerificationCodeExcludedFile"],
+                    None,
+                )
+            ):
                 try:
                     self.builder.set_pkg_excl_file(self.doc, six.text_type(filename))
                 except CardinalityError:
-                    self.more_than_one_error('package verificaton code excluded file')
+                    self.more_than_one_error("package verificaton code excluded file")
                     break
 
     def p_pkg_src_info(self, p_term, predicate):
@@ -454,47 +493,53 @@ class PackageParser(LicenseParser):
             try:
                 self.builder.set_pkg_source_info(self.doc, six.text_type(o))
             except CardinalityError:
-                self.more_than_one_error('package source info')
+                self.more_than_one_error("package source info")
                 break
 
     def p_pkg_chk_sum(self, p_term, predicate):
         for _s, _p, checksum in self.graph.triples((p_term, predicate, None)):
-            for _, _, value in self.graph.triples((checksum, self.spdx_namespace['checksumValue'], None)):
+            for _, _, value in self.graph.triples(
+                (checksum, self.spdx_namespace["checksumValue"], None)
+            ):
                 try:
                     self.builder.set_pkg_chk_sum(self.doc, six.text_type(value))
                 except CardinalityError:
-                    self.more_than_one_error('Package checksum')
+                    self.more_than_one_error("Package checksum")
                     break
 
     def p_pkg_homepg(self, p_term, predicate):
         for _s, _p, o in self.graph.triples((p_term, predicate, None)):
             try:
-                self.builder.set_pkg_home(self.doc, six.text_type(self.to_special_value(o)))
+                self.builder.set_pkg_home(
+                    self.doc, six.text_type(self.to_special_value(o))
+                )
             except CardinalityError:
-                self.more_than_one_error('Package home page')
+                self.more_than_one_error("Package home page")
                 break
             except SPDXValueError:
-                self.value_error('PKG_HOME_PAGE', o)
+                self.value_error("PKG_HOME_PAGE", o)
 
     def p_pkg_down_loc(self, p_term, predicate):
         for _s, _p, o in self.graph.triples((p_term, predicate, None)):
             try:
-                self.builder.set_pkg_down_location(self.doc, six.text_type(self.to_special_value(o)))
+                self.builder.set_pkg_down_location(
+                    self.doc, six.text_type(self.to_special_value(o))
+                )
             except CardinalityError:
-                self.more_than_one_error('Package download location')
+                self.more_than_one_error("Package download location")
                 break
             except SPDXValueError:
-                self.value_error('PKG_DOWN_LOC', o)
+                self.value_error("PKG_DOWN_LOC", o)
 
     def p_pkg_files_analyzed(self, p_term, predicate):
         for _s, _p, o in self.graph.triples((p_term, predicate, None)):
             try:
                 self.builder.set_pkg_files_analyzed(self.doc, six.text_type(o))
             except CardinalityError:
-                self.more_than_one_error('Package Files Analyzed')
+                self.more_than_one_error("Package Files Analyzed")
                 break
             except SPDXValueError:
-                self.value_error('PKG_FILES_ANALYZED_VALUE', o)
+                self.value_error("PKG_FILES_ANALYZED_VALUE", o)
 
     def p_pkg_originator(self, p_term, predicate):
         for _s, _p, o in self.graph.triples((p_term, predicate, None)):
@@ -505,10 +550,10 @@ class PackageParser(LicenseParser):
                     ent = self.builder.create_entity(self.doc, six.text_type(o))
                     self.builder.set_pkg_originator(self.doc, ent)
             except CardinalityError:
-                self.more_than_one_error('Package originator')
+                self.more_than_one_error("Package originator")
                 break
             except SPDXValueError:
-                self.value_error('PKG_ORIGINATOR_VALUE', o)
+                self.value_error("PKG_ORIGINATOR_VALUE", o)
 
     def p_pkg_suppl(self, p_term, predicate):
         for _s, _p, o in self.graph.triples((p_term, predicate, None)):
@@ -519,17 +564,17 @@ class PackageParser(LicenseParser):
                     ent = self.builder.create_entity(self.doc, six.text_type(o))
                     self.builder.set_pkg_supplier(self.doc, ent)
             except CardinalityError:
-                self.more_than_one_error('Package supplier')
+                self.more_than_one_error("Package supplier")
                 break
             except SPDXValueError:
-                self.value_error('PKG_SUPPL_VALUE', o)
+                self.value_error("PKG_SUPPL_VALUE", o)
 
     def p_pkg_fname(self, p_term, predicate):
         for _s, _p, o in self.graph.triples((p_term, predicate, None)):
             try:
                 self.builder.set_pkg_file_name(self.doc, six.text_type(o))
             except CardinalityError:
-                self.more_than_one_error('Package file name')
+                self.more_than_one_error("Package file name")
                 break
 
     def p_pkg_vinfo(self, p_term, predicate):
@@ -537,7 +582,7 @@ class PackageParser(LicenseParser):
             try:
                 self.builder.set_pkg_vers(self.doc, six.text_type(o))
             except CardinalityError:
-                self.more_than_one_error('Package version info')
+                self.more_than_one_error("Package version info")
                 break
 
 
@@ -550,31 +595,35 @@ class FileParser(LicenseParser):
         super(FileParser, self).__init__(builder, logger)
 
     def parse_file(self, f_term):
-        if not (f_term, self.spdx_namespace['fileName'], None) in self.graph:
+        if not (f_term, self.spdx_namespace["fileName"], None) in self.graph:
             self.error = True
-            self.logger.log('File must have a name.')
+            self.logger.log("File must have a name.")
             # Dummy name to continue
-            self.builder.set_file_name(self.doc, 'Dummy file')
+            self.builder.set_file_name(self.doc, "Dummy file")
         else:
-            for _, _, name in self.graph.triples((f_term, self.spdx_namespace['fileName'], None)):
+            for _, _, name in self.graph.triples(
+                (f_term, self.spdx_namespace["fileName"], None)
+            ):
                 self.builder.set_file_name(self.doc, six.text_type(name))
 
-        self.p_file_spdx_id(f_term, self.spdx_namespace['File'])
-        self.p_file_type(f_term, self.spdx_namespace['fileType'])
-        self.p_file_chk_sum(f_term, self.spdx_namespace['checksum'])
-        self.p_file_lic_conc(f_term, self.spdx_namespace['licenseConcluded'])
-        self.p_file_lic_info(f_term, self.spdx_namespace['licenseInfoInFile'])
-        self.p_file_comments_on_lics(f_term, self.spdx_namespace['licenseComments'])
-        self.p_file_cr_text(f_term, self.spdx_namespace['copyrightText'])
-        self.p_file_artifact(f_term, self.spdx_namespace['artifactOf'])
+        self.p_file_spdx_id(f_term, self.spdx_namespace["File"])
+        self.p_file_type(f_term, self.spdx_namespace["fileType"])
+        self.p_file_chk_sum(f_term, self.spdx_namespace["checksum"])
+        self.p_file_lic_conc(f_term, self.spdx_namespace["licenseConcluded"])
+        self.p_file_lic_info(f_term, self.spdx_namespace["licenseInfoInFile"])
+        self.p_file_comments_on_lics(f_term, self.spdx_namespace["licenseComments"])
+        self.p_file_cr_text(f_term, self.spdx_namespace["copyrightText"])
+        self.p_file_artifact(f_term, self.spdx_namespace["artifactOf"])
         self.p_file_comment(f_term, RDFS.comment)
-        self.p_file_notice(f_term, self.spdx_namespace['noticeText'])
-        self.p_file_contributor(f_term, self.spdx_namespace['fileContributor'])
-        self.p_file_depends(f_term, self.spdx_namespace['fileDependency'])
+        self.p_file_notice(f_term, self.spdx_namespace["noticeText"])
+        self.p_file_contributor(f_term, self.spdx_namespace["fileContributor"])
+        self.p_file_depends(f_term, self.spdx_namespace["fileDependency"])
 
     def get_file_name(self, f_term):
         """Returns first found fileName property or None if not found."""
-        for _, _, name in self.graph.triples((f_term, self.spdx_namespace['fileName'], None)):
+        for _, _, name in self.graph.triples(
+            (f_term, self.spdx_namespace["fileName"], None)
+        ):
             return name
         return
 
@@ -588,7 +637,7 @@ class FileParser(LicenseParser):
                 self.builder.add_file_dep(six.text_type(name))
             else:
                 self.error = True
-                msg = 'File depends on file with no name'
+                msg = "File depends on file with no name"
                 self.logger.log(msg)
 
     def p_file_contributor(self, f_term, predicate):
@@ -606,7 +655,7 @@ class FileParser(LicenseParser):
             for _, _, notice in self.graph.triples((f_term, predicate, None)):
                 self.builder.set_file_notice(self.doc, six.text_type(notice))
         except CardinalityError:
-            self.more_than_one_error('file notice')
+            self.more_than_one_error("file notice")
 
     def p_file_comment(self, f_term, predicate):
         """
@@ -616,8 +665,7 @@ class FileParser(LicenseParser):
             for _, _, comment in self.graph.triples((f_term, predicate, None)):
                 self.builder.set_file_comment(self.doc, six.text_type(comment))
         except CardinalityError:
-            self.more_than_one_error('file comment')
-
+            self.more_than_one_error("file comment")
 
     def p_file_artifact(self, f_term, predicate):
         """
@@ -625,11 +673,11 @@ class FileParser(LicenseParser):
         Note: does not handle artifact of project URI.
         """
         for _, _, project in self.graph.triples((f_term, predicate, None)):
-            if (project, RDF.type, self.doap_namespace['Project']):
+            if (project, RDF.type, self.doap_namespace["Project"]):
                 self.p_file_project(project)
             else:
                 self.error = True
-                msg = 'File must be artifact of doap:Project'
+                msg = "File must be artifact of doap:Project"
                 self.logger.log(msg)
 
     def p_file_project(self, project):
@@ -637,11 +685,18 @@ class FileParser(LicenseParser):
         Helper function for parsing doap:project name and homepage.
         and setting them using the file builder.
         """
-        for _, _, name in self.graph.triples((project, self.doap_namespace['name'], None)):
-            self.builder.set_file_atrificat_of_project(self.doc, 'name', six.text_type(name))
+        for _, _, name in self.graph.triples(
+            (project, self.doap_namespace["name"], None)
+        ):
+            self.builder.set_file_atrificat_of_project(
+                self.doc, "name", six.text_type(name)
+            )
         for _, _, homepage in self.graph.triples(
-            (project, self.doap_namespace['homepage'], None)):
-            self.builder.set_file_atrificat_of_project(self.doc, 'home', six.text_type(homepage))
+            (project, self.doap_namespace["homepage"], None)
+        ):
+            self.builder.set_file_atrificat_of_project(
+                self.doc, "home", six.text_type(homepage)
+            )
 
     def p_file_cr_text(self, f_term, predicate):
         """
@@ -651,7 +706,7 @@ class FileParser(LicenseParser):
             for _, _, cr_text in self.graph.triples((f_term, predicate, None)):
                 self.builder.set_file_copyright(self.doc, six.text_type(cr_text))
         except CardinalityError:
-            self.more_than_one_error('file copyright text')
+            self.more_than_one_error("file copyright text")
 
     def p_file_comments_on_lics(self, f_term, predicate):
         """
@@ -661,7 +716,7 @@ class FileParser(LicenseParser):
             for _, _, comment in self.graph.triples((f_term, predicate, None)):
                 self.builder.set_file_license_comment(self.doc, six.text_type(comment))
         except CardinalityError:
-            self.more_than_one_error('file comments on license')
+            self.more_than_one_error("file comments on license")
 
     def p_file_lic_info(self, f_term, predicate):
         """
@@ -677,9 +732,9 @@ class FileParser(LicenseParser):
             try:
                 self.builder.set_file_spdx_id(self.doc, six.text_type(f_term))
             except SPDXValueError:
-                self.value_error('FILE_SPDX_ID_VALUE', f_term)
+                self.value_error("FILE_SPDX_ID_VALUE", f_term)
         except CardinalityError:
-            self.more_than_one_error('FILE_SPDX_ID_VALUE')
+            self.more_than_one_error("FILE_SPDX_ID_VALUE")
 
     def p_file_type(self, f_term, predicate):
         """
@@ -688,19 +743,19 @@ class FileParser(LicenseParser):
         try:
             for _, _, ftype in self.graph.triples((f_term, predicate, None)):
                 try:
-                    if ftype.endswith('binary'):
-                        ftype = 'BINARY'
-                    elif ftype.endswith('source'):
-                        ftype = 'SOURCE'
-                    elif ftype.endswith('other'):
-                        ftype = 'OTHER'
-                    elif ftype.endswith('archive'):
-                        ftype = 'ARCHIVE'
+                    if ftype.endswith("binary"):
+                        ftype = "BINARY"
+                    elif ftype.endswith("source"):
+                        ftype = "SOURCE"
+                    elif ftype.endswith("other"):
+                        ftype = "OTHER"
+                    elif ftype.endswith("archive"):
+                        ftype = "ARCHIVE"
                     self.builder.set_file_type(self.doc, ftype)
                 except SPDXValueError:
-                    self.value_error('FILE_TYPE', ftype)
+                    self.value_error("FILE_TYPE", ftype)
         except CardinalityError:
-            self.more_than_one_error('file type')
+            self.more_than_one_error("file type")
 
     def p_file_chk_sum(self, f_term, predicate):
         """
@@ -708,10 +763,12 @@ class FileParser(LicenseParser):
         """
         try:
             for _s, _p, checksum in self.graph.triples((f_term, predicate, None)):
-                for _, _, value in self.graph.triples((checksum, self.spdx_namespace['checksumValue'], None)):
+                for _, _, value in self.graph.triples(
+                    (checksum, self.spdx_namespace["checksumValue"], None)
+                ):
                     self.builder.set_file_chksum(self.doc, six.text_type(value))
         except CardinalityError:
-            self.more_than_one_error('File checksum')
+            self.more_than_one_error("File checksum")
 
     def p_file_lic_conc(self, f_term, predicate):
         """
@@ -719,11 +776,19 @@ class FileParser(LicenseParser):
         """
         try:
             for _, _, licenses in self.graph.triples((f_term, predicate, None)):
-                if (licenses, RDF.type, self.spdx_namespace['ConjunctiveLicenseSet']) in self.graph:
+                if (
+                    licenses,
+                    RDF.type,
+                    self.spdx_namespace["ConjunctiveLicenseSet"],
+                ) in self.graph:
                     lics = self.handle_conjunctive_list(licenses)
                     self.builder.set_concluded_license(self.doc, lics)
 
-                elif (licenses, RDF.type, self.spdx_namespace['DisjunctiveLicenseSet']) in self.graph:
+                elif (
+                    licenses,
+                    RDF.type,
+                    self.spdx_namespace["DisjunctiveLicenseSet"],
+                ) in self.graph:
                     lics = self.handle_disjunctive_list(licenses)
                     self.builder.set_concluded_license(self.doc, lics)
 
@@ -732,9 +797,9 @@ class FileParser(LicenseParser):
                         lics = self.handle_lics(licenses)
                         self.builder.set_concluded_license(self.doc, lics)
                     except SPDXValueError:
-                        self.value_error('FILE_SINGLE_LICS', licenses)
+                        self.value_error("FILE_SINGLE_LICS", licenses)
         except CardinalityError:
-            self.more_than_one_error('file {0}'.format(predicate))
+            self.more_than_one_error("file {0}".format(predicate))
 
 
 class SnippetParser(LicenseParser):
@@ -749,44 +814,61 @@ class SnippetParser(LicenseParser):
         try:
             self.builder.create_snippet(self.doc, snippet_term)
         except SPDXValueError:
-            self.value_error('SNIPPET_SPDX_ID_VALUE', snippet_term)
+            self.value_error("SNIPPET_SPDX_ID_VALUE", snippet_term)
 
-        for _s, _p, o in self.graph.triples((snippet_term, self.spdx_namespace['name'], None)):
+        for _s, _p, o in self.graph.triples(
+            (snippet_term, self.spdx_namespace["name"], None)
+        ):
             try:
                 self.builder.set_snippet_name(self.doc, six.text_type(o))
             except CardinalityError:
-                self.more_than_one_error('snippetName')
+                self.more_than_one_error("snippetName")
                 break
 
-        for _s, _p, o in self.graph.triples((snippet_term, self.spdx_namespace['licenseComments'], None)):
+        for _s, _p, o in self.graph.triples(
+            (snippet_term, self.spdx_namespace["licenseComments"], None)
+        ):
             try:
                 self.builder.set_snippet_lic_comment(self.doc, six.text_type(o))
             except CardinalityError:
-                self.more_than_one_error('licenseComments')
+                self.more_than_one_error("licenseComments")
                 break
 
         for _s, _p, o in self.graph.triples((snippet_term, RDFS.comment, None)):
             try:
                 self.builder.set_snippet_comment(self.doc, six.text_type(o))
             except CardinalityError:
-                self.more_than_one_error('comment')
+                self.more_than_one_error("comment")
                 break
 
-        for _s, _p, o in self.graph.triples((snippet_term, self.spdx_namespace['copyrightText'], None)):
+        for _s, _p, o in self.graph.triples(
+            (snippet_term, self.spdx_namespace["copyrightText"], None)
+        ):
             try:
-                self.builder.set_snippet_copyright(self.doc, self.to_special_value(six.text_type(o)))
+                self.builder.set_snippet_copyright(
+                    self.doc, self.to_special_value(six.text_type(o))
+                )
             except CardinalityError:
-                self.more_than_one_error('copyrightText')
+                self.more_than_one_error("copyrightText")
                 break
 
         try:
             for _, _, licenses in self.graph.triples(
-                    (snippet_term, self.spdx_namespace['licenseConcluded'], None)):
-                if (licenses, RDF.type, self.spdx_namespace['ConjunctiveLicenseSet']) in self.graph:
+                (snippet_term, self.spdx_namespace["licenseConcluded"], None)
+            ):
+                if (
+                    licenses,
+                    RDF.type,
+                    self.spdx_namespace["ConjunctiveLicenseSet"],
+                ) in self.graph:
                     lics = self.handle_conjunctive_list(licenses)
                     self.builder.set_snip_concluded_license(self.doc, lics)
 
-                elif (licenses, RDF.type, self.spdx_namespace['DisjunctiveLicenseSet']) in self.graph:
+                elif (
+                    licenses,
+                    RDF.type,
+                    self.spdx_namespace["DisjunctiveLicenseSet"],
+                ) in self.graph:
                     lics = self.handle_disjunctive_list(licenses)
                     self.builder.set_snip_concluded_license(self.doc, lics)
 
@@ -795,26 +877,29 @@ class SnippetParser(LicenseParser):
                         lics = self.handle_lics(licenses)
                         self.builder.set_snip_concluded_license(self.doc, lics)
                     except SPDXValueError:
-                        self.value_error('SNIPPET_SINGLE_LICS', licenses)
+                        self.value_error("SNIPPET_SINGLE_LICS", licenses)
         except CardinalityError:
-            self.more_than_one_error('package {0}'.format(
-                self.spdx_namespace['licenseConcluded']))
+            self.more_than_one_error(
+                "package {0}".format(self.spdx_namespace["licenseConcluded"])
+            )
 
         for _, _, info in self.graph.triples(
-                (snippet_term, self.spdx_namespace['licenseInfoInSnippet'], None)):
+            (snippet_term, self.spdx_namespace["licenseInfoInSnippet"], None)
+        ):
             lic = self.handle_lics(info)
             if lic is not None:
                 try:
                     self.builder.set_snippet_lics_info(self.doc, lic)
                 except SPDXValueError:
-                    self.value_error('SNIPPET_LIC_INFO', lic)
+                    self.value_error("SNIPPET_LIC_INFO", lic)
 
         for _s, _p, o in self.graph.triples(
-                (snippet_term, self.spdx_namespace['snippetFromFile'], None)):
+            (snippet_term, self.spdx_namespace["snippetFromFile"], None)
+        ):
             try:
                 self.builder.set_snip_from_file_spdxid(self.doc, six.text_type(o))
             except CardinalityError:
-                self.more_than_one_error('snippetFromFile')
+                self.more_than_one_error("snippetFromFile")
                 break
 
 
@@ -835,7 +920,7 @@ class ReviewParser(BaseParser):
                 try:
                     self.builder.add_review_date(self.doc, reviewed_date)
                 except SPDXValueError:
-                    self.value_error('REVIEW_DATE', reviewed_date)
+                    self.value_error("REVIEW_DATE", reviewed_date)
             comment = self.get_review_comment(r_term)
             if comment is not None:
                 self.builder.add_review_comment(self.doc, comment)
@@ -848,7 +933,7 @@ class ReviewParser(BaseParser):
         comment_list = list(self.graph.triples((r_term, RDFS.comment, None)))
         if len(comment_list) > 1:
             self.error = True
-            msg = 'Review can have at most one comment'
+            msg = "Review can have at most one comment"
             self.logger.log(msg)
             return
         else:
@@ -860,10 +945,12 @@ class ReviewParser(BaseParser):
         Report error on failure.
         Note does not check value format.
         """
-        reviewed_list = list(self.graph.triples((r_term, self.spdx_namespace['reviewDate'], None)))
+        reviewed_list = list(
+            self.graph.triples((r_term, self.spdx_namespace["reviewDate"], None))
+        )
         if len(reviewed_list) != 1:
             self.error = True
-            msg = 'Review must have exactlyone review date'
+            msg = "Review must have exactlyone review date"
             self.logger.log(msg)
             return
         return six.text_type(reviewed_list[0][2])
@@ -873,16 +960,20 @@ class ReviewParser(BaseParser):
         Return reviewer as creator object or None if failed.
         Report errors on failure.
         """
-        reviewer_list = list(self.graph.triples((r_term, self.spdx_namespace['reviewer'], None)))
+        reviewer_list = list(
+            self.graph.triples((r_term, self.spdx_namespace["reviewer"], None))
+        )
         if len(reviewer_list) != 1:
             self.error = True
-            msg = 'Review must have exactly one reviewer'
+            msg = "Review must have exactly one reviewer"
             self.logger.log(msg)
             return
         try:
-            return self.builder.create_entity(self.doc, six.text_type(reviewer_list[0][2]))
+            return self.builder.create_entity(
+                self.doc, six.text_type(reviewer_list[0][2])
+            )
         except SPDXValueError:
-            self.value_error('REVIEWER_VALUE', reviewer_list[0][2])
+            self.value_error("REVIEWER_VALUE", reviewer_list[0][2])
 
 
 class AnnotationParser(BaseParser):
@@ -902,7 +993,7 @@ class AnnotationParser(BaseParser):
                 try:
                     self.builder.add_annotation_date(self.doc, annotation_date)
                 except SPDXValueError:
-                    self.value_error('ANNOTATION_DATE', annotation_date)
+                    self.value_error("ANNOTATION_DATE", annotation_date)
             comment = self.get_annotation_comment(r_term)
             if comment is not None:
                 self.builder.add_annotation_comment(self.doc, comment)
@@ -911,20 +1002,21 @@ class AnnotationParser(BaseParser):
             try:
                 self.builder.set_annotation_spdx_id(self.doc, six.text_type(r_term))
             except CardinalityError:
-                self.more_than_one_error('SPDX Identifier Reference')
+                self.more_than_one_error("SPDX Identifier Reference")
 
     def get_annotation_type(self, r_term):
         """
         Return annotation type or None if found none or more than one.
         Report errors on failure.
         """
-        for _, _, typ in self.graph.triples((
-                r_term, self.spdx_namespace['annotationType'], None)):
+        for _, _, typ in self.graph.triples(
+            (r_term, self.spdx_namespace["annotationType"], None)
+        ):
             if typ is not None:
                 return six.text_type(typ)
             else:
                 self.error = True
-                msg = 'Annotation must have exactly one annotation type.'
+                msg = "Annotation must have exactly one annotation type."
                 self.logger.log(msg)
                 return
 
@@ -936,7 +1028,7 @@ class AnnotationParser(BaseParser):
         comment_list = list(self.graph.triples((r_term, RDFS.comment, None)))
         if len(comment_list) > 1:
             self.error = True
-            msg = 'Annotation can have at most one comment.'
+            msg = "Annotation can have at most one comment."
             self.logger.log(msg)
             return
         else:
@@ -948,10 +1040,12 @@ class AnnotationParser(BaseParser):
         Report error on failure.
         Note does not check value format.
         """
-        annotation_date_list = list(self.graph.triples((r_term, self.spdx_namespace['annotationDate'], None)))
+        annotation_date_list = list(
+            self.graph.triples((r_term, self.spdx_namespace["annotationDate"], None))
+        )
         if len(annotation_date_list) != 1:
             self.error = True
-            msg = 'Annotation must have exactly one annotation date.'
+            msg = "Annotation must have exactly one annotation date."
             self.logger.log(msg)
             return
         return six.text_type(annotation_date_list[0][2])
@@ -961,19 +1055,183 @@ class AnnotationParser(BaseParser):
         Return annotator as creator object or None if failed.
         Report errors on failure.
         """
-        annotator_list = list(self.graph.triples((r_term, self.spdx_namespace['annotator'], None)))
+        annotator_list = list(
+            self.graph.triples((r_term, self.spdx_namespace["annotator"], None))
+        )
         if len(annotator_list) != 1:
             self.error = True
-            msg = 'Annotation must have exactly one annotator'
+            msg = "Annotation must have exactly one annotator"
             self.logger.log(msg)
             return
         try:
-            return self.builder.create_entity(self.doc, six.text_type(annotator_list[0][2]))
+            return self.builder.create_entity(
+                self.doc, six.text_type(annotator_list[0][2])
+            )
         except SPDXValueError:
-            self.value_error('ANNOTATOR_VALUE', annotator_list[0][2])
+            self.value_error("ANNOTATOR_VALUE", annotator_list[0][2])
 
 
-class Parser(PackageParser, FileParser, SnippetParser, ReviewParser, AnnotationParser):
+class RelationshipParser(BaseParser):
+    """
+    Helper Class for parsing relationship information
+    """
+
+    def __init__(self, builder, logger):
+        super(RelationshipParser, self).__init__(builder, logger)
+
+    def parse_relationship(self, subject_term, relation_term):
+        relationship = self.get_relationship(subject_term, relation_term)
+        relationship_comment = self.get_relationship_comment(relation_term)
+        if relationship is not None:
+            self.builder.add_relationship(self.doc, relationship)
+        if relationship_comment is not None:
+            self.builder.add_relationship_comment(self.doc, relationship_comment)
+
+        def get_relationship(self, subject_term, relation_term):
+            """
+            Returns a string with relationship type and the related elements.
+            """
+            relation_subject = six.text_type(subject_term.split("#")[1])
+
+            for _, _, rtype in self.graph.triples(
+                (relation_term, self.spdx_namespace["relationshipType"], None)
+            ):
+                try:
+                    if rtype.endswith("describes"):
+                        rtype = "DESCRIBES"
+                    elif rtype.endswith("describedBy"):
+                        rtype = "DESCRIBED_BY"
+                    elif rtype.endswith("contains"):
+                        rtype = "CONTAINS"
+                    elif rtype.endswith("containedBy"):
+                        rtype = "CONTAINED_BY"
+                    elif rtype.endswith("dependsOn"):
+                        rtype = "DEPENDS_ON"
+                    elif rtype.endswith("dependencyOf"):
+                        rtype = "DEPENDENCY_OF"
+                    elif rtype.endswith("dependencyManifestOf"):
+                        rtype = "DEPENDENCY_MANIFEST_OF"
+                    elif rtype.endswith("buildDependencyOf"):
+                        rtype = "BUILD_DEPENDENCY_OF"
+                    elif rtype.endswith("devDependencyOf"):
+                        rtype = "DEV_DEPENDENCY_OF"
+                    elif rtype.endswith("optionalDependencyOf"):
+                        rtype = "OPTIONAL_DEPENDENCY_OF"
+                    elif rtype.endswith("providedDependencyOf"):
+                        rtype = "PROVIDED_DEPENDENCY_OF"
+                    elif rtype.endswith("testDependencyOf"):
+                        rtype = "TEST_DEPENDENCY_OF"
+                    elif rtype.endswith("runtimeDependencyOf"):
+                        rtype = "RUNTIME_DEPENDENCY_OF"
+                    elif rtype.endswith("exampleOf"):
+                        rtype = "EXAMPLE_OF"
+                    elif rtype.endswith("generates"):
+                        rtype = "GENERATES"
+                    elif rtype.endswith("generatedFrom"):
+                        rtype = "GENERATED_FROM"
+                    elif rtype.endswith("ancestorOf"):
+                        rtype = "ANCESTOR_OF"
+                    elif rtype.endswith("descendantOf"):
+                        rtype = "DESCENDANT_OF"
+                    elif rtype.endswith("variantOf"):
+                        rtype = "VARIANT_OF"
+                    elif rtype.endswith("distributionArtifact"):
+                        rtype = "DISTRIBUTION_ARTIFACT"
+                    elif rtype.endswith("patchFor"):
+                        rtype = "PATCH_FOR"
+                    elif rtype.endswith("patchApplied"):
+                        rtype = "PATCH_APPLIED"
+                    elif rtype.endswith("copyOf"):
+                        rtype = "COPY_OF"
+                    elif rtype.endswith("fileAdded"):
+                        rtype = "FILE_ADDED"
+                    elif rtype.endswith("fileDeleted"):
+                        rtype = "FILE_DELETED"
+                    elif rtype.endswith("fileModified"):
+                        rtype = "FILE_MODIFIED"
+                    elif rtype.endswith("expandedFromArchive"):
+                        rtype = "EXPANDED_FROM_ARCHIVE"
+                    elif rtype.endswith("dynamicLink"):
+                        rtype = "DYNAMIC_LINK"
+                    elif rtype.endswith("staticLink"):
+                        rtype = "STATIC_LINK"
+                    elif rtype.endswith("dataFileOf"):
+                        rtype = "DATA_FILE_OF"
+                    elif rtype.endswith("testCaseOf"):
+                        rtype = "TEST_CASE_OF"
+                    elif rtype.endswith("buildToolOf"):
+                        rtype = "BUILD_TOOL_OF"
+                    elif rtype.endswith("devToolOf"):
+                        rtype = "DEV_TOOL_OF"
+                    elif rtype.endswith("testOf"):
+                        rtype = "TEST_OF"
+                    elif rtype.endswith("testToolOf"):
+                        rtype = "TEST_TOOL_OF"
+                    elif rtype.endswith("documentationOf"):
+                        rtype = "DOCUMENTATION_OF"
+                    elif rtype.endswith("optionalComponentOf"):
+                        rtype = "OPTIONAL_COMPONENT_OF"
+                    elif rtype.endswith("metafileOf"):
+                        rtype = "METAFILE_OF"
+                    elif rtype.endswith("packageOf"):
+                        rtype = "PACKAGE_OF"
+                    elif rtype.endswith("amends"):
+                        rtype = "AMENDS"
+                    elif rtype.endswith("prerequisiteFor"):
+                        rtype = "PREREQUISITE_FOR"
+                    elif rtype.endswith("hasPrerequisite"):
+                        rtype = "HAS_PREREQUISITE"
+                    elif rtype.endswith("other"):
+                        rtype = "OTHER"
+
+                except SPDXValueError:
+                    self.value_error("RELATIONSHIP", rtype)
+
+            try:
+                for sub, pre, rel_ele in self.graph.triples(
+                    (relation_term, self.spdx_namespace["relatedSpdxElement"], None)
+                ):
+                    related_element = six.text_type(rel_ele.split("#")[1])
+            except:
+                related_element = None
+
+            try:
+                if related_element == None:
+                    return self.builder.create_entity(self.doc, six.text_type(relation_subject + " " + rtype))
+                else:
+                    return  self.builder.create_entity(self.doc, six.text_type(relation_subject + " " + rtype + " " + related_element))
+            
+            except SPDXValueError:
+                self.value_error('RELATIONSHIP_VALUE', relation_subject + " " + rtype)
+
+
+        def relationship_comment(self, relation_term):
+            """
+            Returns relationship comment or None if found none or more than one.
+            Reports errors.
+            """
+
+            comment_list = list(self.graph.triples((relation_term, RDFS.comment, None)))
+            if len(comment_list) == 0:
+                return None
+            else:
+                if len(comment_list) > 1:
+                    self.error = True
+                    msg = "Relationship can have at most one comment."
+                    self.logger.log(msg)
+                    return
+                else:
+                    return six.text_type(comment_list[0][2])
+
+
+class Parser(
+    PackageParser,
+    FileParser,
+    SnippetParser,
+    ReviewParser,
+    AnnotationParser,
+    RelationshipParser,
+):
     """
     RDF/XML file parser.
     """
@@ -988,38 +1246,63 @@ class Parser(PackageParser, FileParser, SnippetParser, ReviewParser, AnnotationP
         """
         self.error = False
         self.graph = Graph()
-        self.graph.parse(file=fil, format='xml')
+        self.graph.parse(file=fil, format="xml")
         self.doc = document.Document()
 
-        for s, _p, o in self.graph.triples((None, RDF.type, self.spdx_namespace['SpdxDocument'])):
+        for s, _p, o in self.graph.triples(
+            (None, RDF.type, self.spdx_namespace["SpdxDocument"])
+        ):
             self.parse_doc_fields(s)
 
-        for s, _p, o in self.graph.triples((None, RDF.type, self.spdx_namespace['ExternalDocumentRef'])):
+        for s, _p, o in self.graph.triples(
+            (None, RDF.type, self.spdx_namespace["ExternalDocumentRef"])
+        ):
             self.parse_ext_doc_ref(s)
 
-        for s, _p, o in self.graph.triples((None, RDF.type, self.spdx_namespace['CreationInfo'])):
+        for s, _p, o in self.graph.triples(
+            (None, RDF.type, self.spdx_namespace["CreationInfo"])
+        ):
             self.parse_creation_info(s)
 
-        for s, _p, o in self.graph.triples((None, None, self.spdx_namespace['ExtractedLicensingInfo'])):
+        for s, _p, o in self.graph.triples(
+            (None, None, self.spdx_namespace["ExtractedLicensingInfo"])
+        ):
             self.handle_extracted_license(s)
 
-        for s, _p, o in self.graph.triples((None, RDF.type, self.spdx_namespace['Package'])):
+        for s, _p, o in self.graph.triples(
+            (None, RDF.type, self.spdx_namespace["Package"])
+        ):
             self.parse_package(s)
 
-        for s, _p, o in self.graph.triples((None, RDF.type, self.spdx_namespace['ExternalRef'])):
+        for s, _p, o in self.graph.triples(
+            (None, RDF.type, self.spdx_namespace["ExternalRef"])
+        ):
             self.parse_pkg_ext_ref(s)
 
-        for s, _p, o in self.graph.triples((None, self.spdx_namespace['referencesFile'], None)):
+        for s, _p, o in self.graph.triples(
+            (None, self.spdx_namespace["referencesFile"], None)
+        ):
             self.parse_file(o)
 
-        for s, _p, o in self.graph.triples((None, RDF.type, self.spdx_namespace['Snippet'])):
+        for s, _p, o in self.graph.triples(
+            (None, RDF.type, self.spdx_namespace["Snippet"])
+        ):
             self.parse_snippet(s)
 
-        for s, _p, o in self.graph.triples((None, self.spdx_namespace['reviewed'], None)):
+        for s, _p, o in self.graph.triples(
+            (None, self.spdx_namespace["reviewed"], None)
+        ):
             self.parse_review(o)
 
-        for s, _p, o in self.graph.triples((None, self.spdx_namespace['annotation'], None)):
+        for s, _p, o in self.graph.triples(
+            (None, self.spdx_namespace["annotation"], None)
+        ):
             self.parse_annotation(o)
+
+        for s, _p, o in self.graph.triples(
+            (None, self.spdx_namespace["relationship"], None)
+        ):
+            self.parse_relationship(s, o)
 
         validation_messages = []
         # Report extra errors if self.error is False otherwise there will be
@@ -1036,36 +1319,42 @@ class Parser(PackageParser, FileParser, SnippetParser, ReviewParser, AnnotationP
         """
         Parse creators, created and comment.
         """
-        for _s, _p, o in self.graph.triples((ci_term, self.spdx_namespace['creator'], None)):
+        for _s, _p, o in self.graph.triples(
+            (ci_term, self.spdx_namespace["creator"], None)
+        ):
             try:
                 ent = self.builder.create_entity(self.doc, six.text_type(o))
                 self.builder.add_creator(self.doc, ent)
             except SPDXValueError:
-                self.value_error('CREATOR_VALUE', o)
+                self.value_error("CREATOR_VALUE", o)
 
-        for _s, _p, o in self.graph.triples((ci_term, self.spdx_namespace['created'], None)):
+        for _s, _p, o in self.graph.triples(
+            (ci_term, self.spdx_namespace["created"], None)
+        ):
             try:
                 self.builder.set_created_date(self.doc, six.text_type(o))
             except SPDXValueError:
-                self.value_error('CREATED_VALUE', o)
+                self.value_error("CREATED_VALUE", o)
             except CardinalityError:
-                self.more_than_one_error('created')
+                self.more_than_one_error("created")
                 break
 
         for _s, _p, o in self.graph.triples((ci_term, RDFS.comment, None)):
             try:
                 self.builder.set_creation_comment(self.doc, six.text_type(o))
             except CardinalityError:
-                self.more_than_one_error('CreationInfo comment')
+                self.more_than_one_error("CreationInfo comment")
                 break
-        for _s, _p, o in self.graph.triples((ci_term, self.spdx_namespace['licenseListVersion'], None)):
+        for _s, _p, o in self.graph.triples(
+            (ci_term, self.spdx_namespace["licenseListVersion"], None)
+        ):
             try:
                 self.builder.set_lics_list_ver(self.doc, six.text_type(o))
             except CardinalityError:
-                self.more_than_one_error('licenseListVersion')
+                self.more_than_one_error("licenseListVersion")
                 break
             except SPDXValueError:
-                self.value_error('LL_VALUE', o)
+                self.value_error("LL_VALUE", o)
 
     def parse_doc_fields(self, doc_term):
         """
@@ -1075,43 +1364,48 @@ class Parser(PackageParser, FileParser, SnippetParser, ReviewParser, AnnotationP
         try:
             self.builder.set_doc_spdx_id(self.doc, six.text_type(doc_term))
         except SPDXValueError:
-            self.value_error('DOC_SPDX_ID_VALUE', doc_term)
+            self.value_error("DOC_SPDX_ID_VALUE", doc_term)
         try:
-            if doc_term.count('#', 0, len(doc_term)) <= 1:
-                doc_namespace = doc_term.split('#')[0]
+            if doc_term.count("#", 0, len(doc_term)) <= 1:
+                doc_namespace = doc_term.split("#")[0]
                 self.builder.set_doc_namespace(self.doc, doc_namespace)
             else:
-                self.value_error('DOC_NAMESPACE_VALUE', doc_term)
+                self.value_error("DOC_NAMESPACE_VALUE", doc_term)
         except SPDXValueError:
-            self.value_error('DOC_NAMESPACE_VALUE', doc_term)
-        for _s, _p, o in self.graph.triples((doc_term, self.spdx_namespace['specVersion'], None)):
+            self.value_error("DOC_NAMESPACE_VALUE", doc_term)
+        for _s, _p, o in self.graph.triples(
+            (doc_term, self.spdx_namespace["specVersion"], None)
+        ):
             try:
                 self.builder.set_doc_version(self.doc, six.text_type(o))
             except SPDXValueError:
-                self.value_error('DOC_VERS_VALUE', o)
+                self.value_error("DOC_VERS_VALUE", o)
             except CardinalityError:
-                self.more_than_one_error('specVersion')
+                self.more_than_one_error("specVersion")
                 break
-        for _s, _p, o in self.graph.triples((doc_term, self.spdx_namespace['dataLicense'], None)):
+        for _s, _p, o in self.graph.triples(
+            (doc_term, self.spdx_namespace["dataLicense"], None)
+        ):
             try:
                 self.builder.set_doc_data_lic(self.doc, six.text_type(o))
             except SPDXValueError:
-                self.value_error('DOC_D_LICS', o)
+                self.value_error("DOC_D_LICS", o)
             except CardinalityError:
-                self.more_than_one_error('dataLicense')
+                self.more_than_one_error("dataLicense")
                 break
         for _s, _p, o in self.graph.triples(
-                (doc_term, self.spdx_namespace['name'], None)):
+            (doc_term, self.spdx_namespace["name"], None)
+        ):
             try:
                 self.builder.set_doc_name(self.doc, six.text_type(o))
             except CardinalityError:
-                self.more_than_one_error('name')
+                self.more_than_one_error("name")
                 break
         for _s, _p, o in self.graph.triples((doc_term, RDFS.comment, None)):
             try:
                 self.builder.set_doc_comment(self.doc, six.text_type(o))
             except CardinalityError:
-                self.more_than_one_error('Document comment')
+                self.more_than_one_error("Document comment")
                 break
 
     def parse_ext_doc_ref(self, ext_doc_ref_term):
@@ -1119,67 +1413,67 @@ class Parser(PackageParser, FileParser, SnippetParser, ReviewParser, AnnotationP
         Parse the External Document ID, SPDX Document URI and Checksum.
         """
         for _s, _p, o in self.graph.triples(
-                (ext_doc_ref_term,
-                 self.spdx_namespace['externalDocumentId'],
-                 None)):
+            (ext_doc_ref_term, self.spdx_namespace["externalDocumentId"], None)
+        ):
             try:
                 self.builder.set_ext_doc_id(self.doc, six.text_type(o))
             except SPDXValueError:
-                self.value_error('EXT_DOC_REF_VALUE', 'External Document ID')
+                self.value_error("EXT_DOC_REF_VALUE", "External Document ID")
                 break
 
         for _s, _p, o in self.graph.triples(
-                (ext_doc_ref_term,
-                 self.spdx_namespace['spdxDocument'],
-                 None)):
+            (ext_doc_ref_term, self.spdx_namespace["spdxDocument"], None)
+        ):
             try:
                 self.builder.set_spdx_doc_uri(self.doc, six.text_type(o))
             except SPDXValueError:
-                self.value_error('EXT_DOC_REF_VALUE', 'SPDX Document URI')
+                self.value_error("EXT_DOC_REF_VALUE", "SPDX Document URI")
                 break
 
         for _s, _p, checksum in self.graph.triples(
-                (ext_doc_ref_term, self.spdx_namespace['checksum'], None)):
+            (ext_doc_ref_term, self.spdx_namespace["checksum"], None)
+        ):
             for _, _, value in self.graph.triples(
-                    (checksum, self.spdx_namespace['checksumValue'], None)):
+                (checksum, self.spdx_namespace["checksumValue"], None)
+            ):
                 try:
                     self.builder.set_chksum(self.doc, six.text_type(value))
                 except SPDXValueError:
-                    self.value_error('EXT_DOC_REF_VALUE', 'Checksum')
+                    self.value_error("EXT_DOC_REF_VALUE", "Checksum")
                     break
 
     def parse_pkg_ext_ref(self, pkg_ext_term):
         """
         Parse the category, type, locator, and comment.
         """
-        for _s, _p, o in self.graph.triples((pkg_ext_term,
-                                             self.spdx_namespace['referenceCategory'],
-                                             None)):
+        for _s, _p, o in self.graph.triples(
+            (pkg_ext_term, self.spdx_namespace["referenceCategory"], None)
+        ):
             try:
                 self.builder.set_pkg_ext_ref_category(self.doc, six.text_type(o))
             except SPDXValueError:
-                self.value_error('PKG_EXT_REF_CATEGORY',
-                                 'Package External Reference Category')
+                self.value_error(
+                    "PKG_EXT_REF_CATEGORY", "Package External Reference Category"
+                )
                 break
 
-        for _s, _p, o in self.graph.triples((pkg_ext_term,
-                                             self.spdx_namespace['referenceType'],
-                                             None)):
+        for _s, _p, o in self.graph.triples(
+            (pkg_ext_term, self.spdx_namespace["referenceType"], None)
+        ):
             try:
                 self.builder.set_pkg_ext_ref_type(self.doc, six.text_type(o))
             except SPDXValueError:
-                self.value_error('PKG_EXT_REF_TYPE',
-                                 'Package External Reference Type')
+                self.value_error("PKG_EXT_REF_TYPE", "Package External Reference Type")
                 break
 
-        for _s, _p, o in self.graph.triples((pkg_ext_term,
-                                             self.spdx_namespace['referenceLocator'],
-                                             None)):
+        for _s, _p, o in self.graph.triples(
+            (pkg_ext_term, self.spdx_namespace["referenceLocator"], None)
+        ):
             self.builder.set_pkg_ext_ref_locator(self.doc, six.text_type(o))
 
         for _s, _p, o in self.graph.triples((pkg_ext_term, RDFS.comment, None)):
             try:
                 self.builder.set_pkg_ext_ref_comment(self.doc, six.text_type(o))
             except CardinalityError:
-                self.more_than_one_error('Package External Reference Comment')
+                self.more_than_one_error("Package External Reference Comment")
                 break

--- a/spdx/parsers/rdf.py
+++ b/spdx/parsers/rdf.py
@@ -1087,141 +1087,142 @@ class RelationshipParser(BaseParser):
         if relationship_comment is not None:
             self.builder.add_relationship_comment(self.doc, relationship_comment)
 
-        def get_relationship(self, subject_term, relation_term):
-            """
-            Returns a string with relationship type and the related elements.
-            """
-            relation_subject = six.text_type(subject_term.split("#")[1])
+    def get_relationship(self, subject_term, relation_term):
+        """
+        Returns a string with relationship type and the related elements.
+        """
+        relation_subject = six.text_type(subject_term.split("#")[1])
 
-            for _, _, rtype in self.graph.triples(
-                (relation_term, self.spdx_namespace["relationshipType"], None)
-            ):
-                try:
-                    if rtype.endswith("describes"):
-                        rtype = "DESCRIBES"
-                    elif rtype.endswith("describedBy"):
-                        rtype = "DESCRIBED_BY"
-                    elif rtype.endswith("contains"):
-                        rtype = "CONTAINS"
-                    elif rtype.endswith("containedBy"):
-                        rtype = "CONTAINED_BY"
-                    elif rtype.endswith("dependsOn"):
-                        rtype = "DEPENDS_ON"
-                    elif rtype.endswith("dependencyOf"):
-                        rtype = "DEPENDENCY_OF"
-                    elif rtype.endswith("dependencyManifestOf"):
-                        rtype = "DEPENDENCY_MANIFEST_OF"
-                    elif rtype.endswith("buildDependencyOf"):
-                        rtype = "BUILD_DEPENDENCY_OF"
-                    elif rtype.endswith("devDependencyOf"):
-                        rtype = "DEV_DEPENDENCY_OF"
-                    elif rtype.endswith("optionalDependencyOf"):
-                        rtype = "OPTIONAL_DEPENDENCY_OF"
-                    elif rtype.endswith("providedDependencyOf"):
-                        rtype = "PROVIDED_DEPENDENCY_OF"
-                    elif rtype.endswith("testDependencyOf"):
-                        rtype = "TEST_DEPENDENCY_OF"
-                    elif rtype.endswith("runtimeDependencyOf"):
-                        rtype = "RUNTIME_DEPENDENCY_OF"
-                    elif rtype.endswith("exampleOf"):
-                        rtype = "EXAMPLE_OF"
-                    elif rtype.endswith("generates"):
-                        rtype = "GENERATES"
-                    elif rtype.endswith("generatedFrom"):
-                        rtype = "GENERATED_FROM"
-                    elif rtype.endswith("ancestorOf"):
-                        rtype = "ANCESTOR_OF"
-                    elif rtype.endswith("descendantOf"):
-                        rtype = "DESCENDANT_OF"
-                    elif rtype.endswith("variantOf"):
-                        rtype = "VARIANT_OF"
-                    elif rtype.endswith("distributionArtifact"):
-                        rtype = "DISTRIBUTION_ARTIFACT"
-                    elif rtype.endswith("patchFor"):
-                        rtype = "PATCH_FOR"
-                    elif rtype.endswith("patchApplied"):
-                        rtype = "PATCH_APPLIED"
-                    elif rtype.endswith("copyOf"):
-                        rtype = "COPY_OF"
-                    elif rtype.endswith("fileAdded"):
-                        rtype = "FILE_ADDED"
-                    elif rtype.endswith("fileDeleted"):
-                        rtype = "FILE_DELETED"
-                    elif rtype.endswith("fileModified"):
-                        rtype = "FILE_MODIFIED"
-                    elif rtype.endswith("expandedFromArchive"):
-                        rtype = "EXPANDED_FROM_ARCHIVE"
-                    elif rtype.endswith("dynamicLink"):
-                        rtype = "DYNAMIC_LINK"
-                    elif rtype.endswith("staticLink"):
-                        rtype = "STATIC_LINK"
-                    elif rtype.endswith("dataFileOf"):
-                        rtype = "DATA_FILE_OF"
-                    elif rtype.endswith("testCaseOf"):
-                        rtype = "TEST_CASE_OF"
-                    elif rtype.endswith("buildToolOf"):
-                        rtype = "BUILD_TOOL_OF"
-                    elif rtype.endswith("devToolOf"):
-                        rtype = "DEV_TOOL_OF"
-                    elif rtype.endswith("testOf"):
-                        rtype = "TEST_OF"
-                    elif rtype.endswith("testToolOf"):
-                        rtype = "TEST_TOOL_OF"
-                    elif rtype.endswith("documentationOf"):
-                        rtype = "DOCUMENTATION_OF"
-                    elif rtype.endswith("optionalComponentOf"):
-                        rtype = "OPTIONAL_COMPONENT_OF"
-                    elif rtype.endswith("metafileOf"):
-                        rtype = "METAFILE_OF"
-                    elif rtype.endswith("packageOf"):
-                        rtype = "PACKAGE_OF"
-                    elif rtype.endswith("amends"):
-                        rtype = "AMENDS"
-                    elif rtype.endswith("prerequisiteFor"):
-                        rtype = "PREREQUISITE_FOR"
-                    elif rtype.endswith("hasPrerequisite"):
-                        rtype = "HAS_PREREQUISITE"
-                    elif rtype.endswith("other"):
-                        rtype = "OTHER"
-
-                except SPDXValueError:
-                    self.value_error("RELATIONSHIP", rtype)
-
+        for _, _, rtype in self.graph.triples(
+            (relation_term, self.spdx_namespace["relationshipType"], None)
+        ):
             try:
-                for sub, pre, rel_ele in self.graph.triples(
-                    (relation_term, self.spdx_namespace["relatedSpdxElement"], None)
-                ):
-                    related_element = six.text_type(rel_ele.split("#")[1])
-            except:
-                related_element = None
+                if rtype.endswith("describes"):
+                    rtype = "DESCRIBES"
+                elif rtype.endswith("describedBy"):
+                    rtype = "DESCRIBED_BY"
+                elif rtype.endswith("contains"):
+                    rtype = "CONTAINS"
+                elif rtype.endswith("containedBy"):
+                    rtype = "CONTAINED_BY"
+                elif rtype.endswith("dependsOn"):
+                    rtype = "DEPENDS_ON"
+                elif rtype.endswith("dependencyOf"):
+                    rtype = "DEPENDENCY_OF"
+                elif rtype.endswith("dependencyManifestOf"):
+                    rtype = "DEPENDENCY_MANIFEST_OF"
+                elif rtype.endswith("buildDependencyOf"):
+                    rtype = "BUILD_DEPENDENCY_OF"
+                elif rtype.endswith("devDependencyOf"):
+                    rtype = "DEV_DEPENDENCY_OF"
+                elif rtype.endswith("optionalDependencyOf"):
+                    rtype = "OPTIONAL_DEPENDENCY_OF"
+                elif rtype.endswith("providedDependencyOf"):
+                    rtype = "PROVIDED_DEPENDENCY_OF"
+                elif rtype.endswith("testDependencyOf"):
+                    rtype = "TEST_DEPENDENCY_OF"
+                elif rtype.endswith("runtimeDependencyOf"):
+                    rtype = "RUNTIME_DEPENDENCY_OF"
+                elif rtype.endswith("exampleOf"):
+                    rtype = "EXAMPLE_OF"
+                elif rtype.endswith("generates"):
+                    rtype = "GENERATES"
+                elif rtype.endswith("generatedFrom"):
+                    rtype = "GENERATED_FROM"
+                elif rtype.endswith("ancestorOf"):
+                    rtype = "ANCESTOR_OF"
+                elif rtype.endswith("descendantOf"):
+                    rtype = "DESCENDANT_OF"
+                elif rtype.endswith("variantOf"):
+                    rtype = "VARIANT_OF"
+                elif rtype.endswith("distributionArtifact"):
+                    rtype = "DISTRIBUTION_ARTIFACT"
+                elif rtype.endswith("patchFor"):
+                    rtype = "PATCH_FOR"
+                elif rtype.endswith("patchApplied"):
+                    rtype = "PATCH_APPLIED"
+                elif rtype.endswith("copyOf"):
+                    rtype = "COPY_OF"
+                elif rtype.endswith("fileAdded"):
+                    rtype = "FILE_ADDED"
+                elif rtype.endswith("fileDeleted"):
+                    rtype = "FILE_DELETED"
+                elif rtype.endswith("fileModified"):
+                    rtype = "FILE_MODIFIED"
+                elif rtype.endswith("expandedFromArchive"):
+                    rtype = "EXPANDED_FROM_ARCHIVE"
+                elif rtype.endswith("dynamicLink"):
+                    rtype = "DYNAMIC_LINK"
+                elif rtype.endswith("staticLink"):
+                    rtype = "STATIC_LINK"
+                elif rtype.endswith("dataFileOf"):
+                    rtype = "DATA_FILE_OF"
+                elif rtype.endswith("testCaseOf"):
+                    rtype = "TEST_CASE_OF"
+                elif rtype.endswith("buildToolOf"):
+                    rtype = "BUILD_TOOL_OF"
+                elif rtype.endswith("devToolOf"):
+                    rtype = "DEV_TOOL_OF"
+                elif rtype.endswith("testOf"):
+                    rtype = "TEST_OF"
+                elif rtype.endswith("testToolOf"):
+                    rtype = "TEST_TOOL_OF"
+                elif rtype.endswith("documentationOf"):
+                    rtype = "DOCUMENTATION_OF"
+                elif rtype.endswith("optionalComponentOf"):
+                    rtype = "OPTIONAL_COMPONENT_OF"
+                elif rtype.endswith("metafileOf"):
+                    rtype = "METAFILE_OF"
+                elif rtype.endswith("packageOf"):
+                    rtype = "PACKAGE_OF"
+                elif rtype.endswith("amends"):
+                    rtype = "AMENDS"
+                elif rtype.endswith("prerequisiteFor"):
+                    rtype = "PREREQUISITE_FOR"
+                elif rtype.endswith("hasPrerequisite"):
+                    rtype = "HAS_PREREQUISITE"
+                elif rtype.endswith("other"):
+                    rtype = "OTHER"
 
-            try:
-                if related_element == None:
-                    return self.builder.create_entity(self.doc, six.text_type(relation_subject + " " + rtype))
-                else:
-                    return  self.builder.create_entity(self.doc, six.text_type(relation_subject + " " + rtype + " " + related_element))
-            
             except SPDXValueError:
-                self.value_error('RELATIONSHIP_VALUE', relation_subject + " " + rtype)
+                self.value_error("RELATIONSHIP", rtype)
 
+        try:
+            for sub, pre, rel_ele in self.graph.triples(
+                (relation_term, self.spdx_namespace["relatedSpdxElement"], None)
+            ):
+                related_element = six.text_type(rel_ele.split("#")[1])
+        except:
+            related_element = None
 
-        def relationship_comment(self, relation_term):
-            """
-            Returns relationship comment or None if found none or more than one.
-            Reports errors.
-            """
-
-            comment_list = list(self.graph.triples((relation_term, RDFS.comment, None)))
-            if len(comment_list) == 0:
-                return None
+        try:
+            if related_element == None:
+                return six.text_type(relation_subject + " " + rtype)
             else:
-                if len(comment_list) > 1:
-                    self.error = True
-                    msg = "Relationship can have at most one comment."
-                    self.logger.log(msg)
-                    return
-                else:
-                    return six.text_type(comment_list[0][2])
+                return six.text_type(
+                    relation_subject + " " + rtype + " " + related_element
+                )
+
+        except SPDXValueError:
+            self.value_error("RELATIONSHIP_VALUE", relation_subject + " " + rtype)
+
+    def get_relationship_comment(self, relation_term):
+        """
+        Returns relationship comment or None if found none or more than one.
+        Reports errors.
+        """
+
+        comment_list = list(self.graph.triples((relation_term, RDFS.comment, None)))
+        if len(comment_list) == 0:
+            return None
+        else:
+            if len(comment_list) > 1:
+                self.error = True
+                msg = "Relationship can have at most one comment."
+                self.logger.log(msg)
+                return
+            else:
+                return six.text_type(comment_list[0][2])
 
 
 class Parser(

--- a/spdx/parsers/rdfbuilders.py
+++ b/spdx/parsers/rdfbuilders.py
@@ -1,4 +1,3 @@
-
 # Copyright (c) 2014 Ahmed H. Ismail
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -28,7 +27,7 @@ from spdx.parsers import validations
 
 
 class DocBuilder(object):
-    VERS_STR_REGEX = re.compile(r'SPDX-(\d+)\.(\d+)', re.UNICODE)
+    VERS_STR_REGEX = re.compile(r"SPDX-(\d+)\.(\d+)", re.UNICODE)
 
     def __init__(self):
         # FIXME: this state does not make sense
@@ -44,13 +43,14 @@ class DocBuilder(object):
             self.doc_version_set = True
             m = self.VERS_STR_REGEX.match(value)
             if m is None:
-                raise SPDXValueError('Document::Version')
+                raise SPDXValueError("Document::Version")
             else:
-                doc.version = version.Version(major=int(m.group(1)),
-                                              minor=int(m.group(2)))
+                doc.version = version.Version(
+                    major=int(m.group(1)), minor=int(m.group(2))
+                )
                 return True
         else:
-            raise CardinalityError('Document::Version')
+            raise CardinalityError("Document::Version")
 
     def set_doc_data_lic(self, doc, res):
         """
@@ -61,14 +61,14 @@ class DocBuilder(object):
         if not self.doc_data_lics_set:
             self.doc_data_lics_set = True
             # TODO: what is this split?
-            res_parts = res.split('/')
+            res_parts = res.split("/")
             if len(res_parts) != 0:
                 identifier = res_parts[-1]
                 doc.data_license = document.License.from_identifier(identifier)
             else:
-                raise SPDXValueError('Document::License')
+                raise SPDXValueError("Document::License")
         else:
-            raise CardinalityError('Document::License')
+            raise CardinalityError("Document::License")
 
     def set_doc_name(self, doc, name):
         """
@@ -80,7 +80,7 @@ class DocBuilder(object):
             self.doc_name_set = True
             return True
         else:
-            raise CardinalityError('Document::Name')
+            raise CardinalityError("Document::Name")
 
     def set_doc_spdx_id(self, doc, doc_spdx_id_line):
         """
@@ -94,9 +94,9 @@ class DocBuilder(object):
                 self.doc_spdx_id_set = True
                 return True
             else:
-                raise SPDXValueError('Document::SPDXID')
+                raise SPDXValueError("Document::SPDXID")
         else:
-            raise CardinalityError('Document::SPDXID')
+            raise CardinalityError("Document::SPDXID")
 
     def set_doc_comment(self, doc, comment):
         """
@@ -107,7 +107,7 @@ class DocBuilder(object):
             self.doc_comment_set = True
             doc.comment = comment
         else:
-            raise CardinalityError('Document::Comment')
+            raise CardinalityError("Document::Comment")
 
     def set_doc_namespace(self, doc, namespace):
         """
@@ -121,9 +121,9 @@ class DocBuilder(object):
                 doc.namespace = namespace
                 return True
             else:
-                raise SPDXValueError('Document::Namespace')
+                raise SPDXValueError("Document::Namespace")
         else:
-            raise CardinalityError('Document::Comment')
+            raise CardinalityError("Document::Comment")
 
     def reset_document(self):
         """
@@ -139,7 +139,6 @@ class DocBuilder(object):
 
 
 class ExternalDocumentRefBuilder(tagvaluebuilders.ExternalDocumentRefBuilder):
-
     def set_chksum(self, doc, chk_sum):
         """
         Set the external document reference's check sum, if not already set.
@@ -147,13 +146,13 @@ class ExternalDocumentRefBuilder(tagvaluebuilders.ExternalDocumentRefBuilder):
         """
         if chk_sum:
             doc.ext_document_references[-1].check_sum = checksum.Algorithm(
-                'SHA1', chk_sum)
+                "SHA1", chk_sum
+            )
         else:
-            raise SPDXValueError('ExternalDocumentRef::Checksum')
+            raise SPDXValueError("ExternalDocumentRef::Checksum")
 
 
 class EntityBuilder(tagvaluebuilders.EntityBuilder):
-
     def __init__(self):
         super(EntityBuilder, self).__init__()
 
@@ -165,11 +164,10 @@ class EntityBuilder(tagvaluebuilders.EntityBuilder):
         elif self.org_re.match(value):
             return self.build_org(doc, value)
         else:
-            raise SPDXValueError('Entity')
+            raise SPDXValueError("Entity")
 
 
 class CreationInfoBuilder(tagvaluebuilders.CreationInfoBuilder):
-
     def __init__(self):
         super(CreationInfoBuilder, self).__init__()
 
@@ -184,11 +182,10 @@ class CreationInfoBuilder(tagvaluebuilders.CreationInfoBuilder):
             doc.creation_info.comment = comment
             return True
         else:
-            raise CardinalityError('CreationInfo::Comment')
+            raise CardinalityError("CreationInfo::Comment")
 
 
 class PackageBuilder(tagvaluebuilders.PackageBuilder):
-
     def __init__(self):
         super(PackageBuilder, self).__init__()
 
@@ -202,9 +199,9 @@ class PackageBuilder(tagvaluebuilders.PackageBuilder):
         self.assert_package_exists()
         if not self.package_chk_sum_set:
             self.package_chk_sum_set = True
-            doc.package.check_sum = checksum.Algorithm('SHA1', chk_sum)
+            doc.package.check_sum = checksum.Algorithm("SHA1", chk_sum)
         else:
-            raise CardinalityError('Package::CheckSum')
+            raise CardinalityError("Package::CheckSum")
 
     def set_pkg_source_info(self, doc, text):
         """
@@ -219,7 +216,7 @@ class PackageBuilder(tagvaluebuilders.PackageBuilder):
             doc.package.source_info = text
             return True
         else:
-            raise CardinalityError('Package::SourceInfo')
+            raise CardinalityError("Package::SourceInfo")
 
     def set_pkg_verif_code(self, doc, code):
         """
@@ -233,7 +230,7 @@ class PackageBuilder(tagvaluebuilders.PackageBuilder):
             self.package_verif_set = True
             doc.package.verif_code = code
         else:
-            raise CardinalityError('Package::VerificationCode')
+            raise CardinalityError("Package::VerificationCode")
 
     def set_pkg_excl_file(self, doc, filename):
         """
@@ -255,7 +252,7 @@ class PackageBuilder(tagvaluebuilders.PackageBuilder):
             doc.package.license_comment = text
             return True
         else:
-            raise CardinalityError('Package::LicenseComment')
+            raise CardinalityError("Package::LicenseComment")
 
     def set_pkg_cr_text(self, doc, text):
         """
@@ -268,7 +265,7 @@ class PackageBuilder(tagvaluebuilders.PackageBuilder):
             self.package_cr_text_set = True
             doc.package.cr_text = text
         else:
-            raise CardinalityError('Package::CopyrightText')
+            raise CardinalityError("Package::CopyrightText")
 
     def set_pkg_summary(self, doc, text):
         """
@@ -281,7 +278,7 @@ class PackageBuilder(tagvaluebuilders.PackageBuilder):
             self.package_summary_set = True
             doc.package.summary = text
         else:
-            raise CardinalityError('Package::Summary')
+            raise CardinalityError("Package::Summary")
 
     def set_pkg_desc(self, doc, text):
         """
@@ -294,7 +291,7 @@ class PackageBuilder(tagvaluebuilders.PackageBuilder):
             self.package_desc_set = True
             doc.package.description = text
         else:
-            raise CardinalityError('Package::Description')
+            raise CardinalityError("Package::Description")
 
     def set_pkg_comment(self, doc, text):
         """
@@ -307,7 +304,7 @@ class PackageBuilder(tagvaluebuilders.PackageBuilder):
             self.package_comment_set = True
             doc.package.comment = text
         else:
-            raise CardinalityError('Package::Comment')
+            raise CardinalityError("Package::Comment")
 
     def set_pkg_ext_ref_category(self, doc, category):
         """
@@ -316,20 +313,23 @@ class PackageBuilder(tagvaluebuilders.PackageBuilder):
         Raise SPDXValueError if malformed value.
         """
         self.assert_package_exists()
-        category = category.split('_')[-1]
+        category = category.split("_")[-1]
 
-        if category.lower() == 'packagemanager':
-            category = 'PACKAGE-MANAGER'
+        if category.lower() == "packagemanager":
+            category = "PACKAGE-MANAGER"
 
         if validations.validate_pkg_ext_ref_category(category):
-            if (len(doc.package.pkg_ext_refs) and
-                    doc.package.pkg_ext_refs[-1].category is None):
+            if (
+                len(doc.package.pkg_ext_refs)
+                and doc.package.pkg_ext_refs[-1].category is None
+            ):
                 doc.package.pkg_ext_refs[-1].category = category
             else:
                 doc.package.add_pkg_ext_refs(
-                    package.ExternalPackageRef(category=category))
+                    package.ExternalPackageRef(category=category)
+                )
         else:
-            raise SPDXValueError('ExternalRef::Category')
+            raise SPDXValueError("ExternalRef::Category")
 
     def set_pkg_ext_ref_type(self, doc, typ):
         """
@@ -338,20 +338,23 @@ class PackageBuilder(tagvaluebuilders.PackageBuilder):
         Raise SPDXValueError if malformed value.
         """
         self.assert_package_exists()
-        if '#' in typ:
-            typ = typ.split('#')[-1]
+        if "#" in typ:
+            typ = typ.split("#")[-1]
         else:
-            typ = typ.split('/')[-1]
+            typ = typ.split("/")[-1]
 
         if validations.validate_pkg_ext_ref_type(typ):
-            if (len(doc.package.pkg_ext_refs) and
-                    doc.package.pkg_ext_refs[-1].pkg_ext_ref_type is None):
+            if (
+                len(doc.package.pkg_ext_refs)
+                and doc.package.pkg_ext_refs[-1].pkg_ext_ref_type is None
+            ):
                 doc.package.pkg_ext_refs[-1].pkg_ext_ref_type = typ
             else:
                 doc.package.add_pkg_ext_refs(
-                    package.ExternalPackageRef(pkg_ext_ref_type=typ))
+                    package.ExternalPackageRef(pkg_ext_ref_type=typ)
+                )
         else:
-            raise SPDXValueError('ExternalRef::Type')
+            raise SPDXValueError("ExternalRef::Type")
 
     def set_pkg_ext_ref_comment(self, doc, comment):
         """
@@ -361,17 +364,16 @@ class PackageBuilder(tagvaluebuilders.PackageBuilder):
         """
         self.assert_package_exists()
         if not len(doc.package.pkg_ext_refs):
-            raise OrderError('Package::ExternalRef')
+            raise OrderError("Package::ExternalRef")
         if not self.pkg_ext_comment_set:
             self.pkg_ext_comment_set = True
             doc.package.pkg_ext_refs[-1].comment = comment
             return True
         else:
-            raise CardinalityError('ExternalRef::Comment')
+            raise CardinalityError("ExternalRef::Comment")
 
 
 class FileBuilder(tagvaluebuilders.FileBuilder):
-
     def __init__(self):
         super(FileBuilder, self).__init__()
 
@@ -385,12 +387,12 @@ class FileBuilder(tagvaluebuilders.FileBuilder):
         if self.has_package(doc) and self.has_file(doc):
             if not self.file_chksum_set:
                 self.file_chksum_set = True
-                self.file(doc).chk_sum = checksum.Algorithm('SHA1', chk_sum)
+                self.file(doc).chk_sum = checksum.Algorithm("SHA1", chk_sum)
                 return True
             else:
-                raise CardinalityError('File::CheckSum')
+                raise CardinalityError("File::CheckSum")
         else:
-            raise OrderError('File::CheckSum')
+            raise OrderError("File::CheckSum")
 
     def set_file_license_comment(self, doc, text):
         """
@@ -403,9 +405,9 @@ class FileBuilder(tagvaluebuilders.FileBuilder):
                 self.file(doc).license_comment = text
                 return True
             else:
-                raise CardinalityError('File::LicenseComment')
+                raise CardinalityError("File::LicenseComment")
         else:
-            raise OrderError('File::LicenseComment')
+            raise OrderError("File::LicenseComment")
 
     def set_file_copyright(self, doc, text):
         """
@@ -418,9 +420,9 @@ class FileBuilder(tagvaluebuilders.FileBuilder):
                 self.file(doc).copyright = text
                 return True
             else:
-                raise CardinalityError('File::CopyRight')
+                raise CardinalityError("File::CopyRight")
         else:
-            raise OrderError('File::CopyRight')
+            raise OrderError("File::CopyRight")
 
     def set_file_comment(self, doc, text):
         """
@@ -433,9 +435,9 @@ class FileBuilder(tagvaluebuilders.FileBuilder):
                 self.file(doc).comment = text
                 return True
             else:
-                raise CardinalityError('File::Comment')
+                raise CardinalityError("File::Comment")
         else:
-            raise OrderError('File::Comment')
+            raise OrderError("File::Comment")
 
     def set_file_notice(self, doc, text):
         """
@@ -448,13 +450,12 @@ class FileBuilder(tagvaluebuilders.FileBuilder):
                 self.file(doc).notice = tagvaluebuilders.str_from_text(text)
                 return True
             else:
-                raise CardinalityError('File::Notice')
+                raise CardinalityError("File::Notice")
         else:
-            raise OrderError('File::Notice')
+            raise OrderError("File::Notice")
 
 
 class SnippetBuilder(tagvaluebuilders.SnippetBuilder):
-
     def __init__(self):
         super(SnippetBuilder, self).__init__()
 
@@ -469,7 +470,7 @@ class SnippetBuilder(tagvaluebuilders.SnippetBuilder):
             self.snippet_lic_comment_set = True
             doc.snippet[-1].license_comment = lic_comment
         else:
-            CardinalityError('Snippet::licenseComments')
+            CardinalityError("Snippet::licenseComments")
 
     def set_snippet_comment(self, doc, comment):
         """
@@ -483,7 +484,7 @@ class SnippetBuilder(tagvaluebuilders.SnippetBuilder):
             doc.snippet[-1].comment = comment
             return True
         else:
-            raise CardinalityError('Snippet::comment')
+            raise CardinalityError("Snippet::comment")
 
     def set_snippet_copyright(self, doc, copyright):
         """
@@ -496,11 +497,10 @@ class SnippetBuilder(tagvaluebuilders.SnippetBuilder):
             self.snippet_copyright_set = True
             doc.snippet[-1].copyright = copyright
         else:
-            raise CardinalityError('Snippet::copyrightText')
+            raise CardinalityError("Snippet::copyrightText")
 
 
 class ReviewBuilder(tagvaluebuilders.ReviewBuilder):
-
     def __init__(self):
         super(ReviewBuilder, self).__init__()
 
@@ -516,13 +516,12 @@ class ReviewBuilder(tagvaluebuilders.ReviewBuilder):
                 doc.reviews[-1].comment = comment
                 return True
             else:
-                raise CardinalityError('ReviewComment')
+                raise CardinalityError("ReviewComment")
         else:
-            raise OrderError('ReviewComment')
+            raise OrderError("ReviewComment")
 
 
 class AnnotationBuilder(tagvaluebuilders.AnnotationBuilder):
-
     def __init__(self):
         super(AnnotationBuilder, self).__init__()
 
@@ -538,9 +537,9 @@ class AnnotationBuilder(tagvaluebuilders.AnnotationBuilder):
                 doc.annotations[-1].comment = comment
                 return True
             else:
-                raise CardinalityError('AnnotationComment')
+                raise CardinalityError("AnnotationComment")
         else:
-            raise OrderError('AnnotationComment')
+            raise OrderError("AnnotationComment")
 
     def add_annotation_type(self, doc, annotation_type):
         """
@@ -550,26 +549,55 @@ class AnnotationBuilder(tagvaluebuilders.AnnotationBuilder):
         """
         if len(doc.annotations) != 0:
             if not self.annotation_type_set:
-                if annotation_type.endswith('annotationType_other'):
+                if annotation_type.endswith("annotationType_other"):
                     self.annotation_type_set = True
-                    doc.annotations[-1].annotation_type = 'OTHER'
+                    doc.annotations[-1].annotation_type = "OTHER"
                     return True
-                elif annotation_type.endswith('annotationType_review'):
+                elif annotation_type.endswith("annotationType_review"):
                     self.annotation_type_set = True
-                    doc.annotations[-1].annotation_type = 'REVIEW'
+                    doc.annotations[-1].annotation_type = "REVIEW"
                     return True
                 else:
-                    raise SPDXValueError('Annotation::AnnotationType')
+                    raise SPDXValueError("Annotation::AnnotationType")
             else:
-                raise CardinalityError('Annotation::AnnotationType')
+                raise CardinalityError("Annotation::AnnotationType")
         else:
-            raise OrderError('Annotation::AnnotationType')
+            raise OrderError("Annotation::AnnotationType")
 
 
-class Builder(DocBuilder, EntityBuilder, CreationInfoBuilder, PackageBuilder,
-              FileBuilder, SnippetBuilder, ReviewBuilder, ExternalDocumentRefBuilder,
-              AnnotationBuilder):
+class RelationshipBuilder(tagvaluebuilders.RelationshipBuilder):
+    def __init__(self):
+        super(RelationshipBuilder, self).__init__()
 
+    def add_relationship_comment(self, doc, comment):
+        """
+        Set the relationship comment.
+        Raise CardinalityError if already set.
+        Raise OrderError if no annotator defined before.
+        """
+        if len(doc.relationships) != 0:
+            if not self.relationship_comment_set:
+                self.relationship_comment_set = True
+                doc.relationships[-1].comment = comment
+                return True
+            else:
+                raise CardinalityError("RelationshipComment")
+        else:
+            raise OrderError("RelationshipComment")
+
+
+class Builder(
+    DocBuilder,
+    EntityBuilder,
+    CreationInfoBuilder,
+    PackageBuilder,
+    FileBuilder,
+    SnippetBuilder,
+    ReviewBuilder,
+    ExternalDocumentRefBuilder,
+    AnnotationBuilder,
+    RelationshipBuilder,
+):
     def __init__(self):
         super(Builder, self).__init__()
         # FIXME: this state does not make sense
@@ -587,3 +615,4 @@ class Builder(DocBuilder, EntityBuilder, CreationInfoBuilder, PackageBuilder,
         self.reset_file_stat()
         self.reset_reviews()
         self.reset_annotations()
+        self.reset_relationship()

--- a/spdx/parsers/tagvalue.py
+++ b/spdx/parsers/tagvalue.py
@@ -1,4 +1,3 @@
-
 # Copyright (c) 2014 Ahmed H. Ismail
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -29,100 +28,101 @@ from spdx import document
 
 
 ERROR_MESSAGES = {
-    'TOOL_VALUE': 'Invalid tool value {0} at line: {1}',
-    'ORG_VALUE': 'Invalid organization value {0} at line: {1}',
-    'PERSON_VALUE': 'Invalid person value {0} at line: {1}',
-    'CREATED_VALUE_TYPE': 'Created value must be date in ISO 8601 format, line: {0}',
-    'MORE_THAN_ONE': 'Only one {0} allowed, extra at line: {1}',
-    'CREATOR_COMMENT_VALUE_TYPE': 'CreatorComment value must be free form text between <text></text> tags, line:{0}',
-    'DOC_LICENSE_VALUE': 'Invalid DataLicense value \'{0}\', line:{1} must be CC0-1.0',
-    'DOC_LICENSE_VALUE_TYPE': 'DataLicense must be CC0-1.0, line: {0}',
-    'DOC_VERSION_VALUE': 'Invalid SPDXVersion \'{0}\' must be SPDX-M.N where M and N are numbers. Line: {1}',
-    'DOC_VERSION_VALUE_TYPE': 'Invalid SPDXVersion value, must be SPDX-M.N where M and N are numbers. Line: {0}',
-    'DOC_NAME_VALUE': 'DocumentName must be single line of text, line: {0}',
-    'DOC_SPDX_ID_VALUE': 'Invalid SPDXID value, SPDXID must be SPDXRef-DOCUMENT, line: {0}',
-    'EXT_DOC_REF_VALUE': 'ExternalDocumentRef must contain External Document ID, SPDX Document URI and Checksum'
-                         'in the standard format, line:{0}.',
-    'DOC_COMMENT_VALUE_TYPE': 'DocumentComment value must be free form text between <text></text> tags, line:{0}',
-    'DOC_NAMESPACE_VALUE': 'Invalid DocumentNamespace value {0}, must contain a scheme (e.g. "https:") '
-                           'and should not contain the "#" delimiter, line:{1}',
-    'DOC_NAMESPACE_VALUE_TYPE': 'Invalid DocumentNamespace value, must contain a scheme (e.g. "https:") '
-                                'and should not contain the "#" delimiter, line: {0}',
-    'REVIEWER_VALUE_TYPE': 'Invalid Reviewer value must be a Person, Organization or Tool. Line: {0}',
-    'CREATOR_VALUE_TYPE': 'Invalid Reviewer value must be a Person, Organization or Tool. Line: {0}',
-    'REVIEW_DATE_VALUE_TYPE': 'ReviewDate value must be date in ISO 8601 format, line: {0}',
-    'REVIEW_COMMENT_VALUE_TYPE': 'ReviewComment value must be free form text between <text></text> tags, line:{0}',
-    'ANNOTATOR_VALUE_TYPE': 'Invalid Annotator value must be a Person, Organization or Tool. Line: {0}',
-    'ANNOTATION_DATE_VALUE_TYPE': 'AnnotationDate value must be date in ISO 8601 format, line: {0}',
-    'ANNOTATION_COMMENT_VALUE_TYPE': 'AnnotationComment value must be free form text between <text></text> tags, line:{0}',
-    'ANNOTATION_TYPE_VALUE': 'AnnotationType must be "REVIEW" or "OTHER". Line: {0}',
-    'ANNOTATION_SPDX_ID_VALUE': 'SPDXREF must be ["DocumentRef-"[idstring]":"]SPDXID where'
-                                '["DocumentRef-"[idstring]":"] is an optional reference to an external SPDX document and'
-                                'SPDXID is a unique string containing letters, numbers, ".","-".',
-    'A_BEFORE_B': '{0} Can not appear before {1}, line: {2}',
-    'PACKAGE_NAME_VALUE': 'PackageName must be single line of text, line: {0}',
-    'PKG_SPDX_ID_VALUE': 'SPDXID must be "SPDXRef-[idstring]" where [idstring] is a unique string containing '
-                             'letters, numbers, ".", "-".',
-    'PKG_VERSION_VALUE': 'PackageVersion must be single line of text, line: {0}',
-    'PKG_FILE_NAME_VALUE': 'PackageFileName must be single line of text, line: {0}',
-    'PKG_SUPPL_VALUE': 'PackageSupplier must be Organization, Person or NOASSERTION, line: {0}',
-    'PKG_ORIG_VALUE': 'PackageOriginator must be Organization, Person or NOASSERTION, line: {0}',
-    'PKG_DOWN_VALUE': 'PackageDownloadLocation must be a url or NONE or NOASSERTION, line: {0}',
-    'PKG_FILES_ANALYZED_VALUE': 'FilesAnalyzed must be a boolean value, line: {0}',
-    'PKG_HOME_VALUE': 'PackageHomePage must be a url or NONE or NOASSERTION, line: {0}',
-    'PKG_SRC_INFO_VALUE': 'PackageSourceInfo must be free form text, line: {0}',
-    'PKG_CHKSUM_VALUE': 'PackageChecksum must be a single line of text, line: {0}',
-    'PKG_LICS_CONC_VALUE': 'PackageLicenseConcluded must be NOASSERTION, NONE, license identifier or license list, line: {0}',
-    'PKG_LIC_FFILE_VALUE': 'PackageLicenseInfoFromFiles must be, line: {0}',
-    'PKG_LICS_DECL_VALUE': 'PackageLicenseDeclared must be NOASSERTION, NONE, license identifier or license list, line: {0}',
-    'PKG_LICS_COMMENT_VALUE': 'PackageLicenseComments must be free form text, line: {0}',
-    'PKG_SUM_VALUE': 'PackageSummary must be free form text, line: {0}',
-    'PKG_DESC_VALUE': 'PackageDescription must be free form text, line: {0}',
-    'PKG_COMMENT_VALUE': 'PackageComment must be free form text, line: {0}',
-    'PKG_EXT_REF_VALUE': 'ExternalRef must contain category, type, and locator in the standard format, line:{0}.',
-    'PKG_EXT_REF_COMMENT_VALUE' : 'ExternalRefComment must be free form text, line:{0}',
-    'FILE_NAME_VALUE': 'FileName must be a single line of text, line: {0}',
-    'FILE_COMMENT_VALUE': 'FileComment must be free form text, line:{0}',
-    'FILE_TYPE_VALUE': 'FileType must be one of OTHER, BINARY, SOURCE or ARCHIVE, line: {0}',
-    'FILE_SPDX_ID_VALUE': 'SPDXID must be "SPDXRef-[idstring]" where [idstring] is a unique string containing '
-                          'letters, numbers, ".", "-".',
-    'FILE_CHKSUM_VALUE': 'FileChecksum must be a single line of text starting with \'SHA1:\', line:{0}',
-    'FILE_LICS_CONC_VALUE': 'LicenseConcluded must be NOASSERTION, NONE, license identifier or license list, line:{0}',
-    'FILE_LICS_INFO_VALUE': 'LicenseInfoInFile must be NOASSERTION, NONE or license identifier, line: {0}',
-    'FILE_LICS_COMMENT_VALUE': 'LicenseComments must be free form lext, line: {0}',
-    'FILE_CR_TEXT_VALUE': 'FileCopyrightText must be one of NOASSERTION, NONE or free form text, line: {0}',
-    'FILE_NOTICE_VALUE': 'FileNotice must be free form text, line: {0}',
-    'FILE_CONTRIB_VALUE': 'FileContributor must be a single line, line: {0}',
-    'FILE_DEP_VALUE': 'FileDependency must be a single line, line: {0}',
-    'ART_PRJ_NAME_VALUE' : 'ArtifactOfProjectName must be a single line, line: {0}',
-    'FILE_ART_OPT_ORDER' : 'ArtificatOfProjectHomePage and ArtificatOfProjectURI must immediatly follow ArtifactOfProjectName, line: {0}',
-    'ART_PRJ_HOME_VALUE' : 'ArtificatOfProjectHomePage must be a URL or UNKNOWN, line: {0}',
-    'ART_PRJ_URI_VALUE' : 'ArtificatOfProjectURI must be a URI or UNKNOWN, line: {0}',
-    'UNKNOWN_TAG' : 'Found unknown tag : {0} at line: {1}',
-    'LICS_ID_VALUE' : 'LicenseID must start with \'LicenseRef-\', line: {0}',
-    'LICS_TEXT_VALUE' : 'ExtractedText must be free form text, line: {0}',
-    'LICS_NAME_VALE' : 'LicenseName must be single line of text or NOASSERTION, line: {0}',
-    'LICS_COMMENT_VALUE' : 'LicenseComment must be free form text, line: {0}',
-    'LICS_CRS_REF_VALUE' : 'LicenseCrossReference must be uri as single line of text, line: {0}',
-    'PKG_CPY_TEXT_VALUE' : 'Package copyright text must be free form text, line: {0}',
-    'SNIP_SPDX_ID_VALUE' : 'SPDXID must be "SPDXRef-[idstring]" where [idstring] is a unique string '
-                           'containing letters, numbers, ".", "-".',
-    'SNIPPET_NAME_VALUE' : 'SnippetName must be a single line of text, line: {0}',
-    'SNIP_COMMENT_VALUE' : 'SnippetComment must be free form text, line: {0}',
-    'SNIP_COPYRIGHT_VALUE' : 'SnippetCopyrightText must be one of NOASSERTION, NONE or free form text, line: {0}',
-    'SNIP_LICS_COMMENT_VALUE' : 'SnippetLicenseComments must be free form text, line: {0}',
-    'SNIP_FILE_SPDXID_VALUE' : 'SnippetFromFileSPDXID must be ["DocumentRef-"[idstring]":"] SPDXID '
-                               'where DocumentRef-[idstring]: is an optional reference to an external'
-                               'SPDX Document and SPDXID is a string containing letters, '
-                               'numbers, ".", "-".',
-    'SNIP_LICS_CONC_VALUE': 'SnippetLicenseConcluded must be NOASSERTION, NONE, license identifier '
-                            'or license list, line:{0}',
-    'SNIP_LICS_INFO_VALUE': 'LicenseInfoInSnippet must be NOASSERTION, NONE or license identifier, line: {0}',
+    "TOOL_VALUE": "Invalid tool value {0} at line: {1}",
+    "ORG_VALUE": "Invalid organization value {0} at line: {1}",
+    "PERSON_VALUE": "Invalid person value {0} at line: {1}",
+    "CREATED_VALUE_TYPE": "Created value must be date in ISO 8601 format, line: {0}",
+    "MORE_THAN_ONE": "Only one {0} allowed, extra at line: {1}",
+    "CREATOR_COMMENT_VALUE_TYPE": "CreatorComment value must be free form text between <text></text> tags, line:{0}",
+    "DOC_LICENSE_VALUE": "Invalid DataLicense value '{0}', line:{1} must be CC0-1.0",
+    "DOC_LICENSE_VALUE_TYPE": "DataLicense must be CC0-1.0, line: {0}",
+    "DOC_VERSION_VALUE": "Invalid SPDXVersion '{0}' must be SPDX-M.N where M and N are numbers. Line: {1}",
+    "DOC_VERSION_VALUE_TYPE": "Invalid SPDXVersion value, must be SPDX-M.N where M and N are numbers. Line: {0}",
+    "DOC_NAME_VALUE": "DocumentName must be single line of text, line: {0}",
+    "DOC_SPDX_ID_VALUE": "Invalid SPDXID value, SPDXID must be SPDXRef-DOCUMENT, line: {0}",
+    "EXT_DOC_REF_VALUE": "ExternalDocumentRef must contain External Document ID, SPDX Document URI and Checksum"
+    "in the standard format, line:{0}.",
+    "DOC_COMMENT_VALUE_TYPE": "DocumentComment value must be free form text between <text></text> tags, line:{0}",
+    "DOC_NAMESPACE_VALUE": 'Invalid DocumentNamespace value {0}, must contain a scheme (e.g. "https:") '
+    'and should not contain the "#" delimiter, line:{1}',
+    "DOC_NAMESPACE_VALUE_TYPE": 'Invalid DocumentNamespace value, must contain a scheme (e.g. "https:") '
+    'and should not contain the "#" delimiter, line: {0}',
+    "REVIEWER_VALUE_TYPE": "Invalid Reviewer value must be a Person, Organization or Tool. Line: {0}",
+    "CREATOR_VALUE_TYPE": "Invalid Reviewer value must be a Person, Organization or Tool. Line: {0}",
+    "REVIEW_DATE_VALUE_TYPE": "ReviewDate value must be date in ISO 8601 format, line: {0}",
+    "REVIEW_COMMENT_VALUE_TYPE": "ReviewComment value must be free form text between <text></text> tags, line:{0}",
+    "ANNOTATOR_VALUE_TYPE": "Invalid Annotator value must be a Person, Organization or Tool. Line: {0}",
+    "ANNOTATION_DATE_VALUE_TYPE": "AnnotationDate value must be date in ISO 8601 format, line: {0}",
+    "ANNOTATION_COMMENT_VALUE_TYPE": "AnnotationComment value must be free form text between <text></text> tags, line:{0}",
+    "ANNOTATION_TYPE_VALUE": 'AnnotationType must be "REVIEW" or "OTHER". Line: {0}',
+    "ANNOTATION_SPDX_ID_VALUE": 'SPDXREF must be ["DocumentRef-"[idstring]":"]SPDXID where'
+    '["DocumentRef-"[idstring]":"] is an optional reference to an external SPDX document and'
+    'SPDXID is a unique string containing letters, numbers, ".","-".',
+    "A_BEFORE_B": "{0} Can not appear before {1}, line: {2}",
+    "PACKAGE_NAME_VALUE": "PackageName must be single line of text, line: {0}",
+    "PKG_SPDX_ID_VALUE": 'SPDXID must be "SPDXRef-[idstring]" where [idstring] is a unique string containing '
+    'letters, numbers, ".", "-".',
+    "PKG_VERSION_VALUE": "PackageVersion must be single line of text, line: {0}",
+    "PKG_FILE_NAME_VALUE": "PackageFileName must be single line of text, line: {0}",
+    "PKG_SUPPL_VALUE": "PackageSupplier must be Organization, Person or NOASSERTION, line: {0}",
+    "PKG_ORIG_VALUE": "PackageOriginator must be Organization, Person or NOASSERTION, line: {0}",
+    "PKG_DOWN_VALUE": "PackageDownloadLocation must be a url or NONE or NOASSERTION, line: {0}",
+    "PKG_FILES_ANALYZED_VALUE": "FilesAnalyzed must be a boolean value, line: {0}",
+    "PKG_HOME_VALUE": "PackageHomePage must be a url or NONE or NOASSERTION, line: {0}",
+    "PKG_SRC_INFO_VALUE": "PackageSourceInfo must be free form text, line: {0}",
+    "PKG_CHKSUM_VALUE": "PackageChecksum must be a single line of text, line: {0}",
+    "PKG_LICS_CONC_VALUE": "PackageLicenseConcluded must be NOASSERTION, NONE, license identifier or license list, line: {0}",
+    "PKG_LIC_FFILE_VALUE": "PackageLicenseInfoFromFiles must be, line: {0}",
+    "PKG_LICS_DECL_VALUE": "PackageLicenseDeclared must be NOASSERTION, NONE, license identifier or license list, line: {0}",
+    "PKG_LICS_COMMENT_VALUE": "PackageLicenseComments must be free form text, line: {0}",
+    "PKG_SUM_VALUE": "PackageSummary must be free form text, line: {0}",
+    "PKG_DESC_VALUE": "PackageDescription must be free form text, line: {0}",
+    "PKG_COMMENT_VALUE": "PackageComment must be free form text, line: {0}",
+    "PKG_EXT_REF_VALUE": "ExternalRef must contain category, type, and locator in the standard format, line:{0}.",
+    "PKG_EXT_REF_COMMENT_VALUE": "ExternalRefComment must be free form text, line:{0}",
+    "FILE_NAME_VALUE": "FileName must be a single line of text, line: {0}",
+    "FILE_COMMENT_VALUE": "FileComment must be free form text, line:{0}",
+    "FILE_TYPE_VALUE": "FileType must be one of OTHER, BINARY, SOURCE or ARCHIVE, line: {0}",
+    "FILE_SPDX_ID_VALUE": 'SPDXID must be "SPDXRef-[idstring]" where [idstring] is a unique string containing '
+    'letters, numbers, ".", "-".',
+    "FILE_CHKSUM_VALUE": "FileChecksum must be a single line of text starting with 'SHA1:', line:{0}",
+    "FILE_LICS_CONC_VALUE": "LicenseConcluded must be NOASSERTION, NONE, license identifier or license list, line:{0}",
+    "FILE_LICS_INFO_VALUE": "LicenseInfoInFile must be NOASSERTION, NONE or license identifier, line: {0}",
+    "FILE_LICS_COMMENT_VALUE": "LicenseComments must be free form lext, line: {0}",
+    "FILE_CR_TEXT_VALUE": "FileCopyrightText must be one of NOASSERTION, NONE or free form text, line: {0}",
+    "FILE_NOTICE_VALUE": "FileNotice must be free form text, line: {0}",
+    "FILE_CONTRIB_VALUE": "FileContributor must be a single line, line: {0}",
+    "FILE_DEP_VALUE": "FileDependency must be a single line, line: {0}",
+    "ART_PRJ_NAME_VALUE": "ArtifactOfProjectName must be a single line, line: {0}",
+    "FILE_ART_OPT_ORDER": "ArtificatOfProjectHomePage and ArtificatOfProjectURI must immediatly follow ArtifactOfProjectName, line: {0}",
+    "ART_PRJ_HOME_VALUE": "ArtificatOfProjectHomePage must be a URL or UNKNOWN, line: {0}",
+    "ART_PRJ_URI_VALUE": "ArtificatOfProjectURI must be a URI or UNKNOWN, line: {0}",
+    "UNKNOWN_TAG": "Found unknown tag : {0} at line: {1}",
+    "LICS_ID_VALUE": "LicenseID must start with 'LicenseRef-', line: {0}",
+    "LICS_TEXT_VALUE": "ExtractedText must be free form text, line: {0}",
+    "LICS_NAME_VALE": "LicenseName must be single line of text or NOASSERTION, line: {0}",
+    "LICS_COMMENT_VALUE": "LicenseComment must be free form text, line: {0}",
+    "LICS_CRS_REF_VALUE": "LicenseCrossReference must be uri as single line of text, line: {0}",
+    "RELATIONSHIP_VALUE": "Relationship types must be one of the defined types, line: {0}",
+    "RELATIONSHIP_COMMENT_VALUE": "RelationshipComment value must be free form text between <text></text> tags, line:{0}",
+    "PKG_CPY_TEXT_VALUE": "Package copyright text must be free form text, line: {0}",
+    "SNIP_SPDX_ID_VALUE": 'SPDXID must be "SPDXRef-[idstring]" where [idstring] is a unique string '
+    'containing letters, numbers, ".", "-".',
+    "SNIPPET_NAME_VALUE": "SnippetName must be a single line of text, line: {0}",
+    "SNIP_COMMENT_VALUE": "SnippetComment must be free form text, line: {0}",
+    "SNIP_COPYRIGHT_VALUE": "SnippetCopyrightText must be one of NOASSERTION, NONE or free form text, line: {0}",
+    "SNIP_LICS_COMMENT_VALUE": "SnippetLicenseComments must be free form text, line: {0}",
+    "SNIP_FILE_SPDXID_VALUE": 'SnippetFromFileSPDXID must be ["DocumentRef-"[idstring]":"] SPDXID '
+    "where DocumentRef-[idstring]: is an optional reference to an external"
+    "SPDX Document and SPDXID is a string containing letters, "
+    'numbers, ".", "-".',
+    "SNIP_LICS_CONC_VALUE": "SnippetLicenseConcluded must be NOASSERTION, NONE, license identifier "
+    "or license list, line:{0}",
+    "SNIP_LICS_INFO_VALUE": "LicenseInfoInSnippet must be NOASSERTION, NONE or license identifier, line: {0}",
 }
 
 
 class Parser(object):
-
     def __init__(self, builder, logger):
         self.tokens = Lexer.tokens
         self.builder = builder
@@ -132,11 +132,11 @@ class Parser(object):
         self.license_list_parser.build(write_tables=0, debug=0)
 
     def p_start_1(self, p):
-        'start : start attrib '
+        "start : start attrib "
         pass
 
     def p_start_2(self, p):
-        'start : attrib '
+        "start : attrib "
         pass
 
     def p_attrib(self, p):
@@ -159,6 +159,8 @@ class Parser(object):
                   | annotation_comment
                   | annotation_type
                   | annotation_spdx_id
+                  | relationship
+                  | relationship_comment
                   | package_name
                   | package_version
                   | pkg_down_location
@@ -211,7 +213,7 @@ class Parser(object):
 
     def more_than_one_error(self, tag, line):
         self.error = True
-        msg = ERROR_MESSAGES['MORE_THAN_ONE'].format(tag, line)
+        msg = ERROR_MESSAGES["MORE_THAN_ONE"].format(tag, line)
         self.logger.log(msg)
 
     def order_error(self, first_tag, second_tag, line):
@@ -219,43 +221,43 @@ class Parser(object):
         first_tag came before second_tag.
         """
         self.error = True
-        msg = ERROR_MESSAGES['A_BEFORE_B'].format(first_tag, second_tag, line)
+        msg = ERROR_MESSAGES["A_BEFORE_B"].format(first_tag, second_tag, line)
         self.logger.log(msg)
 
     def p_lic_xref_1(self, p):
         """lic_xref : LICS_CRS_REF LINE"""
         try:
             if six.PY2:
-                value = p[2].decode(encoding='utf-8')
+                value = p[2].decode(encoding="utf-8")
             else:
                 value = p[2]
             self.builder.add_lic_xref(self.document, value)
         except OrderError:
-            self.order_error('LicenseCrossReference', 'LicenseName', p.lineno(1))
+            self.order_error("LicenseCrossReference", "LicenseName", p.lineno(1))
 
     def p_lic_xref_2(self, p):
         """lic_xref : LICS_CRS_REF error"""
         self.error = True
-        msg = ERROR_MESSAGES['LICS_CRS_REF_VALUE'].format(p.lineno(1))
+        msg = ERROR_MESSAGES["LICS_CRS_REF_VALUE"].format(p.lineno(1))
         self.logger.log(msg)
 
     def p_lic_comment_1(self, p):
         """lic_comment : LICS_COMMENT TEXT"""
         try:
             if six.PY2:
-                value = p[2].decode(encoding='utf-8')
+                value = p[2].decode(encoding="utf-8")
             else:
                 value = p[2]
             self.builder.set_lic_comment(self.document, value)
         except OrderError:
-            self.order_error('LicenseComment', 'LicenseID', p.lineno(1))
+            self.order_error("LicenseComment", "LicenseID", p.lineno(1))
         except CardinalityError:
-            self.more_than_one_error('LicenseComment', p.lineno(1))
+            self.more_than_one_error("LicenseComment", p.lineno(1))
 
     def p_lic_comment_2(self, p):
         """lic_comment : LICS_COMMENT error"""
         self.error = True
-        msg = ERROR_MESSAGES['LICS_COMMENT_VALUE'].format(p.lineno(1))
+        msg = ERROR_MESSAGES["LICS_COMMENT_VALUE"].format(p.lineno(1))
         self.logger.log(msg)
 
     def p_extr_lic_name_1(self, p):
@@ -263,20 +265,20 @@ class Parser(object):
         try:
             self.builder.set_lic_name(self.document, p[2])
         except OrderError:
-            self.order_error('LicenseName', 'LicenseID', p.lineno(1))
+            self.order_error("LicenseName", "LicenseID", p.lineno(1))
         except CardinalityError:
-            self.more_than_one_error('LicenseName', p.lineno(1))
+            self.more_than_one_error("LicenseName", p.lineno(1))
 
     def p_extr_lic_name_2(self, p):
         """extr_lic_name : LICS_NAME error"""
         self.error = True
-        msg = ERROR_MESSAGES['LICS_NAME_VALE'].format(p.lineno(1))
+        msg = ERROR_MESSAGES["LICS_NAME_VALE"].format(p.lineno(1))
         self.logger.log(msg)
 
     def p_extr_lic_name_value_1(self, p):
         """extr_lic_name_value : LINE"""
         if six.PY2:
-            p[0] = p[1].decode(encoding='utf-8')
+            p[0] = p[1].decode(encoding="utf-8")
         else:
             p[0] = p[1]
 
@@ -288,44 +290,44 @@ class Parser(object):
         """extr_lic_text : LICS_TEXT TEXT"""
         try:
             if six.PY2:
-                value = p[2].decode(encoding='utf-8')
+                value = p[2].decode(encoding="utf-8")
             else:
                 value = p[2]
             self.builder.set_lic_text(self.document, value)
         except OrderError:
-            self.order_error('ExtractedText', 'LicenseID', p.lineno(1))
+            self.order_error("ExtractedText", "LicenseID", p.lineno(1))
         except CardinalityError:
-            self.more_than_one_error('ExtractedText', p.lineno(1))
+            self.more_than_one_error("ExtractedText", p.lineno(1))
 
     def p_extr_lic_text_2(self, p):
         """extr_lic_text : LICS_TEXT error"""
         self.error = True
-        msg = ERROR_MESSAGES['LICS_TEXT_VALUE'].format(p.lineno(1))
+        msg = ERROR_MESSAGES["LICS_TEXT_VALUE"].format(p.lineno(1))
         self.logger.log(msg)
 
     def p_extr_lic_id_1(self, p):
         """extr_lic_id : LICS_ID LINE"""
         try:
             if six.PY2:
-                value = p[2].decode(encoding='utf-8')
+                value = p[2].decode(encoding="utf-8")
             else:
                 value = p[2]
             self.builder.set_lic_id(self.document, value)
         except SPDXValueError:
             self.error = True
-            msg = ERROR_MESSAGES['LICS_ID_VALUE'].format(p.lineno(1))
+            msg = ERROR_MESSAGES["LICS_ID_VALUE"].format(p.lineno(1))
             self.logger.log(msg)
 
     def p_extr_lic_id_2(self, p):
         """extr_lic_id : LICS_ID error"""
         self.error = True
-        msg = ERROR_MESSAGES['LICS_ID_VALUE'].format(p.lineno(1))
+        msg = ERROR_MESSAGES["LICS_ID_VALUE"].format(p.lineno(1))
         self.logger.log(msg)
 
     def p_uknown_tag(self, p):
         """unknown_tag : UNKNOWN_TAG LINE"""
         self.error = True
-        msg = ERROR_MESSAGES['UNKNOWN_TAG'].format(p[1], p.lineno(1))
+        msg = ERROR_MESSAGES["UNKNOWN_TAG"].format(p[1], p.lineno(1))
         self.logger.log(msg)
 
     def p_file_artifact_1(self, p):
@@ -337,7 +339,7 @@ class Parser(object):
     def p_file_artificat_2(self, p):
         """file_artifact : prj_name_art error"""
         self.error = True
-        msg = ERROR_MESSAGES['FILE_ART_OPT_ORDER'].format(p.lineno(2))
+        msg = ERROR_MESSAGES["FILE_ART_OPT_ORDER"].format(p.lineno(2))
         self.logger.log(msg)
 
     def p_file_art_rest(self, p):
@@ -351,117 +353,119 @@ class Parser(object):
     def p_prj_uri_art_1(self, p):
         """prj_uri_art : ART_PRJ_URI UN_KNOWN"""
         try:
-            self.builder.set_file_atrificat_of_project(self.document,
-                'uri', utils.UnKnown())
+            self.builder.set_file_atrificat_of_project(
+                self.document, "uri", utils.UnKnown()
+            )
         except OrderError:
-            self.order_error('ArtificatOfProjectURI', 'FileName', p.lineno(1))
+            self.order_error("ArtificatOfProjectURI", "FileName", p.lineno(1))
 
     def p_prj_uri_art_2(self, p):
         """prj_uri_art : ART_PRJ_URI LINE"""
         try:
             if six.PY2:
-                value = p[2].decode(encoding='utf-8')
+                value = p[2].decode(encoding="utf-8")
             else:
                 value = p[2]
-            self.builder.set_file_atrificat_of_project(self.document, 'uri', value)
+            self.builder.set_file_atrificat_of_project(self.document, "uri", value)
         except OrderError:
-            self.order_error('ArtificatOfProjectURI', 'FileName', p.lineno(1))
+            self.order_error("ArtificatOfProjectURI", "FileName", p.lineno(1))
 
     def p_prj_uri_art_3(self, p):
         """prj_uri_art : ART_PRJ_URI error"""
         self.error = True
-        msg = ERROR_MESSAGES['ART_PRJ_URI_VALUE'].format(p.lineno(1))
+        msg = ERROR_MESSAGES["ART_PRJ_URI_VALUE"].format(p.lineno(1))
         self.logger.log(msg)
 
     def p_prj_home_art_1(self, p):
         """prj_home_art : ART_PRJ_HOME LINE"""
         try:
-            self.builder.set_file_atrificat_of_project(self.document, 'home', p[2])
+            self.builder.set_file_atrificat_of_project(self.document, "home", p[2])
         except OrderError:
-            self.order_error('ArtificatOfProjectHomePage', 'FileName', p.lineno(1))
+            self.order_error("ArtificatOfProjectHomePage", "FileName", p.lineno(1))
 
     def p_prj_home_art_2(self, p):
         """prj_home_art : ART_PRJ_HOME UN_KNOWN"""
         try:
-            self.builder.set_file_atrificat_of_project(self.document,
-                'home', utils.UnKnown())
+            self.builder.set_file_atrificat_of_project(
+                self.document, "home", utils.UnKnown()
+            )
         except OrderError:
-            self.order_error('ArtifactOfProjectName', 'FileName', p.lineno(1))
+            self.order_error("ArtifactOfProjectName", "FileName", p.lineno(1))
 
     def p_prj_home_art_3(self, p):
         """prj_home_art : ART_PRJ_HOME error"""
         self.error = True
-        msg = ERROR_MESSAGES['ART_PRJ_HOME_VALUE'].format(p.lineno(1))
+        msg = ERROR_MESSAGES["ART_PRJ_HOME_VALUE"].format(p.lineno(1))
         self.logger.log(msg)
 
     def p_prj_name_art_1(self, p):
         """prj_name_art : ART_PRJ_NAME LINE"""
         try:
             if six.PY2:
-                value = p[2].decode(encoding='utf-8')
+                value = p[2].decode(encoding="utf-8")
             else:
                 value = p[2]
-            self.builder.set_file_atrificat_of_project(self.document, 'name', value)
+            self.builder.set_file_atrificat_of_project(self.document, "name", value)
         except OrderError:
-            self.order_error('ArtifactOfProjectName', 'FileName', p.lineno(1))
+            self.order_error("ArtifactOfProjectName", "FileName", p.lineno(1))
 
     def p_prj_name_art_2(self, p):
         """prj_name_art : ART_PRJ_NAME error"""
         self.error = True
-        msg = ERROR_MESSAGES['ART_PRJ_NAME_VALUE'].format(p.lineno())
+        msg = ERROR_MESSAGES["ART_PRJ_NAME_VALUE"].format(p.lineno())
         self.logger.log(msg)
 
     def p_file_dep_1(self, p):
         """file_dep : FILE_DEP LINE"""
         try:
             if six.PY2:
-                value = p[2].decode(encoding='utf-8')
+                value = p[2].decode(encoding="utf-8")
             else:
                 value = p[2]
             self.builder.add_file_dep(self.document, value)
         except OrderError:
-            self.order_error('FileDependency', 'FileName', p.lineno(1))
+            self.order_error("FileDependency", "FileName", p.lineno(1))
 
     def p_file_dep_2(self, p):
         """file_dep : FILE_DEP error"""
         self.error = True
-        msg = ERROR_MESSAGES['FILE_DEP_VALUE'].format(p.lineno(1))
+        msg = ERROR_MESSAGES["FILE_DEP_VALUE"].format(p.lineno(1))
         self.logger.log(msg)
 
     def p_file_contrib_1(self, p):
         """file_contrib : FILE_CONTRIB LINE"""
         try:
             if six.PY2:
-                value = p[2].decode(encoding='utf-8')
+                value = p[2].decode(encoding="utf-8")
             else:
                 value = p[2]
             self.builder.add_file_contribution(self.document, value)
         except OrderError:
-            self.order_error('FileContributor', 'FileName', p.lineno(1))
+            self.order_error("FileContributor", "FileName", p.lineno(1))
 
     def p_file_contrib_2(self, p):
         """file_contrib : FILE_CONTRIB error"""
         self.error = True
-        msg = ERROR_MESSAGES['FILE_CONTRIB_VALUE'].format(p.lineno(1))
+        msg = ERROR_MESSAGES["FILE_CONTRIB_VALUE"].format(p.lineno(1))
         self.logger.log(msg)
 
     def p_file_notice_1(self, p):
         """file_notice : FILE_NOTICE TEXT"""
         try:
             if six.PY2:
-                value = p[2].decode(encoding='utf-8')
+                value = p[2].decode(encoding="utf-8")
             else:
                 value = p[2]
             self.builder.set_file_notice(self.document, value)
         except OrderError:
-            self.order_error('FileNotice', 'FileName', p.lineno(1))
+            self.order_error("FileNotice", "FileName", p.lineno(1))
         except CardinalityError:
-            self.more_than_one_error('FileNotice', p.lineno(1))
+            self.more_than_one_error("FileNotice", p.lineno(1))
 
     def p_file_notice_2(self, p):
         """file_notice : FILE_NOTICE error"""
         self.error = True
-        msg = ERROR_MESSAGES['FILE_NOTICE_VALUE'].format(p.lineno(1))
+        msg = ERROR_MESSAGES["FILE_NOTICE_VALUE"].format(p.lineno(1))
         self.logger.log(msg)
 
     def p_file_cr_text_1(self, p):
@@ -469,20 +473,20 @@ class Parser(object):
         try:
             self.builder.set_file_copyright(self.document, p[2])
         except OrderError:
-            self.order_error('FileCopyrightText', 'FileName', p.lineno(1))
+            self.order_error("FileCopyrightText", "FileName", p.lineno(1))
         except CardinalityError:
-            self.more_than_one_error('FileCopyrightText', p.lineno(1))
+            self.more_than_one_error("FileCopyrightText", p.lineno(1))
 
     def p_file_cr_text_2(self, p):
         """file_cr_text : FILE_CR_TEXT error"""
         self.error = True
-        msg = ERROR_MESSAGES['FILE_CR_TEXT_VALUE'].format(p.lineno(1))
+        msg = ERROR_MESSAGES["FILE_CR_TEXT_VALUE"].format(p.lineno(1))
         self.logger.log(msg)
 
     def p_file_cr_value_1(self, p):
         """file_cr_value : TEXT"""
         if six.PY2:
-            p[0] = p[1].decode(encoding='utf-8')
+            p[0] = p[1].decode(encoding="utf-8")
         else:
             p[0] = p[1]
 
@@ -498,19 +502,19 @@ class Parser(object):
         """file_lics_comment : FILE_LICS_COMMENT TEXT"""
         try:
             if six.PY2:
-                value = p[2].decode(encoding='utf-8')
+                value = p[2].decode(encoding="utf-8")
             else:
                 value = p[2]
             self.builder.set_file_license_comment(self.document, value)
         except OrderError:
-            self.order_error('LicenseComments', 'FileName', p.lineno(1))
+            self.order_error("LicenseComments", "FileName", p.lineno(1))
         except CardinalityError:
-            self.more_than_one_error('LicenseComments', p.lineno(1))
+            self.more_than_one_error("LicenseComments", p.lineno(1))
 
     def p_file_lics_comment_2(self, p):
         """file_lics_comment : FILE_LICS_COMMENT error"""
         self.error = True
-        msg = ERROR_MESSAGES['FILE_LICS_COMMENT_VALUE'].format(p.lineno(1))
+        msg = ERROR_MESSAGES["FILE_LICS_COMMENT_VALUE"].format(p.lineno(1))
         self.logger.log(msg)
 
     def p_file_lics_info_1(self, p):
@@ -518,16 +522,16 @@ class Parser(object):
         try:
             self.builder.set_file_license_in_file(self.document, p[2])
         except OrderError:
-            self.order_error('LicenseInfoInFile', 'FileName', p.lineno(1))
+            self.order_error("LicenseInfoInFile", "FileName", p.lineno(1))
         except SPDXValueError:
             self.error = True
-            msg = ERROR_MESSAGES['FILE_LICS_INFO_VALUE'].format(p.lineno(1))
+            msg = ERROR_MESSAGES["FILE_LICS_INFO_VALUE"].format(p.lineno(1))
             self.logger.log(msg)
 
     def p_file_lics_info_2(self, p):
         """file_lics_info : FILE_LICS_INFO error"""
         self.error = True
-        msg = ERROR_MESSAGES['FILE_LICS_INFO_VALUE'].format(p.lineno(1))
+        msg = ERROR_MESSAGES["FILE_LICS_INFO_VALUE"].format(p.lineno(1))
         self.logger.log(msg)
 
     def p_file_lic_info_value_1(self, p):
@@ -542,7 +546,7 @@ class Parser(object):
     def p_file_lic_info_value_3(self, p):
         """file_lic_info_value : LINE"""
         if six.PY2:
-            value = p[1].decode(encoding='utf-8')
+            value = p[1].decode(encoding="utf-8")
         else:
             value = p[1]
         p[0] = document.License.from_identifier(value)
@@ -558,10 +562,10 @@ class Parser(object):
     def p_conc_license_3(self, p):
         """conc_license : LINE"""
         if six.PY2:
-            value = p[1].decode(encoding='utf-8')
+            value = p[1].decode(encoding="utf-8")
         else:
             value = p[1]
-        ref_re = re.compile('LicenseRef-.+', re.UNICODE)
+        ref_re = re.compile("LicenseRef-.+", re.UNICODE)
         if (p[1] in config.LICENSE_MAP.keys()) or (ref_re.match(p[1]) is not None):
             p[0] = document.License.from_identifier(value)
         else:
@@ -571,23 +575,23 @@ class Parser(object):
         """file_name : FILE_NAME LINE"""
         try:
             if six.PY2:
-                value = p[2].decode(encoding='utf-8')
+                value = p[2].decode(encoding="utf-8")
             else:
                 value = p[2]
             self.builder.set_file_name(self.document, value)
         except OrderError:
-            self.order_error('FileName', 'PackageName', p.lineno(1))
+            self.order_error("FileName", "PackageName", p.lineno(1))
 
     def p_file_name_2(self, p):
         """file_name : FILE_NAME error"""
         self.error = True
-        msg = ERROR_MESSAGES['FILE_NAME_VALUE'].format(p.lineno(1))
+        msg = ERROR_MESSAGES["FILE_NAME_VALUE"].format(p.lineno(1))
         self.logger.log(msg)
 
     def p_spdx_id(self, p):
         """spdx_id : SPDX_ID LINE"""
         if six.PY2:
-            value = p[2].decode(encoding='utf-8')
+            value = p[2].decode(encoding="utf-8")
         else:
             value = p[2]
         if not self.builder.doc_spdx_id_set:
@@ -601,19 +605,19 @@ class Parser(object):
         """file_comment : FILE_COMMENT TEXT"""
         try:
             if six.PY2:
-                value = p[2].decode(encoding='utf-8')
+                value = p[2].decode(encoding="utf-8")
             else:
                 value = p[2]
             self.builder.set_file_comment(self.document, value)
         except OrderError:
-            self.order_error('FileComment', 'FileName', p.lineno(1))
+            self.order_error("FileComment", "FileName", p.lineno(1))
         except CardinalityError:
-            self.more_than_one_error('FileComment', p.lineno(1))
+            self.more_than_one_error("FileComment", p.lineno(1))
 
     def p_file_comment_2(self, p):
         """file_comment : FILE_COMMENT error"""
         self.error = True
-        msg = ERROR_MESSAGES['FILE_COMMENT_VALUE'].format(p.lineno(1))
+        msg = ERROR_MESSAGES["FILE_COMMENT_VALUE"].format(p.lineno(1))
         self.logger.log(msg)
 
     def p_file_type_1(self, p):
@@ -621,33 +625,33 @@ class Parser(object):
         try:
             self.builder.set_file_type(self.document, p[2])
         except OrderError:
-            self.order_error('FileType', 'FileName', p.lineno(1))
+            self.order_error("FileType", "FileName", p.lineno(1))
         except CardinalityError:
-            self.more_than_one_error('FileType', p.lineno(1))
+            self.more_than_one_error("FileType", p.lineno(1))
 
     def p_file_type_2(self, p):
         """file_type : FILE_TYPE error"""
         self.error = True
-        msg = ERROR_MESSAGES['FILE_TYPE_VALUE'].format(p.lineno(1))
+        msg = ERROR_MESSAGES["FILE_TYPE_VALUE"].format(p.lineno(1))
         self.logger.log(msg)
 
     def p_file_chksum_1(self, p):
         """file_chksum : FILE_CHKSUM CHKSUM"""
         try:
             if six.PY2:
-                value = p[2].decode(encoding='utf-8')
+                value = p[2].decode(encoding="utf-8")
             else:
                 value = p[2]
             self.builder.set_file_chksum(self.document, value)
         except OrderError:
-            self.order_error('FileChecksum', 'FileName', p.lineno(1))
+            self.order_error("FileChecksum", "FileName", p.lineno(1))
         except CardinalityError:
-            self.more_than_one_error('FileChecksum', p.lineno(1))
+            self.more_than_one_error("FileChecksum", p.lineno(1))
 
     def p_file_chksum_2(self, p):
         """file_chksum : FILE_CHKSUM error"""
         self.error = True
-        msg = ERROR_MESSAGES['FILE_CHKSUM_VALUE'].format(p.lineno(1))
+        msg = ERROR_MESSAGES["FILE_CHKSUM_VALUE"].format(p.lineno(1))
         self.logger.log(msg)
 
     def p_file_conc_1(self, p):
@@ -656,17 +660,17 @@ class Parser(object):
             self.builder.set_concluded_license(self.document, p[2])
         except SPDXValueError:
             self.error = True
-            msg = ERROR_MESSAGES['FILE_LICS_CONC_VALUE'].format(p.lineno(1))
+            msg = ERROR_MESSAGES["FILE_LICS_CONC_VALUE"].format(p.lineno(1))
             self.logger.log(msg)
         except OrderError:
-            self.order_error('LicenseConcluded', 'FileName', p.lineno(1))
+            self.order_error("LicenseConcluded", "FileName", p.lineno(1))
         except CardinalityError:
-            self.more_than_one_error('LicenseConcluded', p.lineno(1))
+            self.more_than_one_error("LicenseConcluded", p.lineno(1))
 
     def p_file_conc_2(self, p):
         """file_conc : FILE_LICS_CONC error"""
         self.error = True
-        msg = ERROR_MESSAGES['FILE_LICS_CONC_VALUE'].format(p.lineno(1))
+        msg = ERROR_MESSAGES["FILE_LICS_CONC_VALUE"].format(p.lineno(1))
         self.logger.log(msg)
 
     def p_file_type_value(self, p):
@@ -676,7 +680,7 @@ class Parser(object):
                            | BINARY
         """
         if six.PY2:
-            p[0] = p[1].decode(encoding='utf-8')
+            p[0] = p[1].decode(encoding="utf-8")
         else:
             p[0] = p[1]
 
@@ -684,58 +688,57 @@ class Parser(object):
         """pkg_desc : PKG_DESC TEXT"""
         try:
             if six.PY2:
-                value = p[2].decode(encoding='utf-8')
+                value = p[2].decode(encoding="utf-8")
             else:
                 value = p[2]
             self.builder.set_pkg_desc(self.document, value)
         except CardinalityError:
-            self.more_than_one_error('PackageDescription', p.lineno(1))
+            self.more_than_one_error("PackageDescription", p.lineno(1))
         except OrderError:
-            self.order_error('PackageDescription', 'PackageFileName', p.lineno(1))
+            self.order_error("PackageDescription", "PackageFileName", p.lineno(1))
 
     def p_pkg_desc_2(self, p):
         """pkg_desc : PKG_DESC error"""
         self.error = True
-        msg = ERROR_MESSAGES['PKG_DESC_VALUE'].format(p.lineno(1))
+        msg = ERROR_MESSAGES["PKG_DESC_VALUE"].format(p.lineno(1))
         self.logger.log(msg)
 
     def p_pkg_comment_1(self, p):
         """pkg_comment : PKG_COMMENT TEXT"""
         try:
             if six.PY2:
-                value = p[2].decode(encoding='utf-8')
+                value = p[2].decode(encoding="utf-8")
             else:
                 value = p[2]
             self.builder.set_pkg_comment(self.document, value)
         except CardinalityError:
-            self.more_than_one_error('PackageComment', p.lineno(1))
+            self.more_than_one_error("PackageComment", p.lineno(1))
         except OrderError:
-            self.order_error('PackageComment', 'PackageFileName',
-                             p.lineno(1))
+            self.order_error("PackageComment", "PackageFileName", p.lineno(1))
 
     def p_pkg_comment_2(self, p):
         """pkg_comment : PKG_COMMENT error"""
         self.error = True
-        msg = ERROR_MESSAGES['PKG_COMMENT_VALUE'].format(p.lineno(1))
+        msg = ERROR_MESSAGES["PKG_COMMENT_VALUE"].format(p.lineno(1))
         self.logger.log(msg)
 
     def p_pkg_summary_1(self, p):
         """pkg_summary : PKG_SUM TEXT"""
         try:
             if six.PY2:
-                value = p[2].decode(encoding='utf-8')
+                value = p[2].decode(encoding="utf-8")
             else:
                 value = p[2]
             self.builder.set_pkg_summary(self.document, value)
         except OrderError:
-            self.order_error('PackageSummary', 'PackageFileName', p.lineno(1))
+            self.order_error("PackageSummary", "PackageFileName", p.lineno(1))
         except CardinalityError:
-            self.more_than_one_error('PackageSummary', p.lineno(1))
+            self.more_than_one_error("PackageSummary", p.lineno(1))
 
     def p_pkg_summary_2(self, p):
         """pkg_summary : PKG_SUM error"""
         self.error = True
-        msg = ERROR_MESSAGES['PKG_SUM_VALUE'].format(p.lineno(1))
+        msg = ERROR_MESSAGES["PKG_SUM_VALUE"].format(p.lineno(1))
         self.logger.log(msg)
 
     def p_pkg_cr_text_1(self, p):
@@ -743,61 +746,62 @@ class Parser(object):
         try:
             self.builder.set_pkg_cr_text(self.document, p[2])
         except OrderError:
-            self.order_error('PackageCopyrightText', 'PackageFileName', p.lineno(1))
+            self.order_error("PackageCopyrightText", "PackageFileName", p.lineno(1))
         except CardinalityError:
-            self.more_than_one_error('PackageCopyrightText', p.lineno(1))
+            self.more_than_one_error("PackageCopyrightText", p.lineno(1))
 
     def p_pkg_cr_text_2(self, p):
         """pkg_cr_text : PKG_CPY_TEXT error"""
         self.error = True
-        msg = ERROR_MESSAGES['PKG_CPY_TEXT_VALUE'].format(p.lineno(1))
+        msg = ERROR_MESSAGES["PKG_CPY_TEXT_VALUE"].format(p.lineno(1))
         self.logger.log(msg)
 
     def p_pkg_ext_refs_1(self, p):
         """pkg_ext_ref : PKG_EXT_REF LINE"""
         try:
             if six.PY2:
-                pkg_ext_info = p[2].decode(encoding='utf-8')
+                pkg_ext_info = p[2].decode(encoding="utf-8")
             else:
                 pkg_ext_info = p[2]
             if len(pkg_ext_info.split()) != 3:
                 raise SPDXValueError
             else:
                 pkg_ext_category, pkg_ext_type, pkg_ext_locator = pkg_ext_info.split()
-            self.builder.add_pkg_ext_refs(self.document, pkg_ext_category,
-                                          pkg_ext_type, pkg_ext_locator)
+            self.builder.add_pkg_ext_refs(
+                self.document, pkg_ext_category, pkg_ext_type, pkg_ext_locator
+            )
         except SPDXValueError:
             self.error = True
-            msg = ERROR_MESSAGES['PKG_EXT_REF_VALUE'].format(p.lineno(2))
+            msg = ERROR_MESSAGES["PKG_EXT_REF_VALUE"].format(p.lineno(2))
             self.logger.log(msg)
 
     def p_pkg_ext_refs_2(self, p):
         """pkg_ext_ref : PKG_EXT_REF error"""
         self.error = True
-        msg = ERROR_MESSAGES['PKG_EXT_REF_VALUE'].format(p.lineno(1))
+        msg = ERROR_MESSAGES["PKG_EXT_REF_VALUE"].format(p.lineno(1))
         self.logger.log(msg)
 
     def p_pkg_ext_ref_comment_1(self, p):
         """pkg_ext_ref_comment : PKG_EXT_REF_COMMENT TEXT"""
         try:
             if six.PY2:
-                value = p[2].decode(encoding='utf-8')
+                value = p[2].decode(encoding="utf-8")
             else:
                 value = p[2]
             self.builder.add_pkg_ext_ref_comment(self.document, value)
         except CardinalityError:
-            self.more_than_one_error('ExternalRefComment', p.lineno(1))
+            self.more_than_one_error("ExternalRefComment", p.lineno(1))
 
     def p_pkg_ext_ref_comment_2(self, p):
         """pkg_ext_ref_comment : PKG_EXT_REF_COMMENT error"""
         self.error = True
-        msg = ERROR_MESSAGES['PKG_EXT_REF_COMMENT_VALUE'].format(p.lineno(1))
+        msg = ERROR_MESSAGES["PKG_EXT_REF_COMMENT_VALUE"].format(p.lineno(1))
         self.logger.log(msg)
 
     def p_pkg_cr_text_value_1(self, p):
         """pkg_cr_text_value : TEXT"""
         if six.PY2:
-            p[0] = p[1].decode(encoding='utf-8')
+            p[0] = p[1].decode(encoding="utf-8")
         else:
             p[0] = p[1]
 
@@ -813,19 +817,19 @@ class Parser(object):
         """pkg_lic_comment : PKG_LICS_COMMENT TEXT"""
         try:
             if six.PY2:
-                value = p[2].decode(encoding='utf-8')
+                value = p[2].decode(encoding="utf-8")
             else:
                 value = p[2]
             self.builder.set_pkg_license_comment(self.document, value)
         except OrderError:
-            self.order_error('PackageLicenseComments', 'PackageFileName', p.lineno(1))
+            self.order_error("PackageLicenseComments", "PackageFileName", p.lineno(1))
         except CardinalityError:
-            self.more_than_one_error('PackageLicenseComments', p.lineno(1))
+            self.more_than_one_error("PackageLicenseComments", p.lineno(1))
 
     def p_pkg_lic_comment_2(self, p):
         """pkg_lic_comment : PKG_LICS_COMMENT error"""
         self.error = True
-        msg = ERROR_MESSAGES['PKG_LICS_COMMENT_VALUE'].format(p.lineno(1))
+        msg = ERROR_MESSAGES["PKG_LICS_COMMENT_VALUE"].format(p.lineno(1))
         self.logger.log(msg)
 
     def p_pkg_lic_decl_1(self, p):
@@ -833,18 +837,18 @@ class Parser(object):
         try:
             self.builder.set_pkg_license_declared(self.document, p[2])
         except OrderError:
-            self.order_error('PackageLicenseDeclared', 'PackageName', p.lineno(1))
+            self.order_error("PackageLicenseDeclared", "PackageName", p.lineno(1))
         except CardinalityError:
-            self.more_than_one_error('PackageLicenseDeclared', p.lineno(1))
+            self.more_than_one_error("PackageLicenseDeclared", p.lineno(1))
         except SPDXValueError:
             self.error = True
-            msg = ERROR_MESSAGES['PKG_LICS_DECL_VALUE'].format(p.lineno(1))
+            msg = ERROR_MESSAGES["PKG_LICS_DECL_VALUE"].format(p.lineno(1))
             self.logger.log(msg)
 
     def p_pkg_lic_decl_2(self, p):
         """pkg_lic_decl : PKG_LICS_DECL error"""
         self.error = True
-        msg = ERROR_MESSAGES['PKG_LICS_DECL_VALUE'].format(p.lineno(1))
+        msg = ERROR_MESSAGES["PKG_LICS_DECL_VALUE"].format(p.lineno(1))
         self.logger.log(msg)
 
     def p_pkg_lic_ff_1(self, p):
@@ -852,10 +856,10 @@ class Parser(object):
         try:
             self.builder.set_pkg_license_from_file(self.document, p[2])
         except OrderError:
-            self.order_error('PackageLicenseInfoFromFiles', 'PackageName', p.lineno(1))
+            self.order_error("PackageLicenseInfoFromFiles", "PackageName", p.lineno(1))
         except SPDXValueError:
             self.error = True
-            msg = ERROR_MESSAGES['PKG_LIC_FFILE_VALUE'].format(p.lineno(1))
+            msg = ERROR_MESSAGES["PKG_LIC_FFILE_VALUE"].format(p.lineno(1))
             self.logger.log(msg)
 
     def p_pkg_lic_ff_value_1(self, p):
@@ -869,7 +873,7 @@ class Parser(object):
     def p_pkg_lic_ff_value_3(self, p):
         """pkg_lic_ff_value : LINE"""
         if six.PY2:
-            value = p[1].decode(encoding='utf-8')
+            value = p[1].decode(encoding="utf-8")
         else:
             value = p[1]
         p[0] = document.License.from_identifier(value)
@@ -877,7 +881,7 @@ class Parser(object):
     def p_pkg_lic_ff_2(self, p):
         """pkg_lic_ff : PKG_LICS_FFILE error"""
         self.error = True
-        msg = ERROR_MESSAGES['PKG_LIC_FFILE_VALUE'].format(p.lineno(1))
+        msg = ERROR_MESSAGES["PKG_LIC_FFILE_VALUE"].format(p.lineno(1))
         self.logger.log(msg)
 
     def p_pkg_lic_conc_1(self, p):
@@ -885,79 +889,79 @@ class Parser(object):
         try:
             self.builder.set_pkg_licenses_concluded(self.document, p[2])
         except CardinalityError:
-            self.more_than_one_error('PackageLicenseConcluded', p.lineno(1))
+            self.more_than_one_error("PackageLicenseConcluded", p.lineno(1))
         except OrderError:
-            self.order_error('PackageLicenseConcluded', 'PackageFileName', p.lineno(1))
+            self.order_error("PackageLicenseConcluded", "PackageFileName", p.lineno(1))
         except SPDXValueError:
             self.error = True
-            msg = ERROR_MESSAGES['PKG_LICS_CONC_VALUE'].format(p.lineno(1))
+            msg = ERROR_MESSAGES["PKG_LICS_CONC_VALUE"].format(p.lineno(1))
             self.logger.log(msg)
 
     def p_pkg_lic_conc_2(self, p):
         """pkg_lic_conc : PKG_LICS_CONC error"""
         self.error = True
-        msg = ERROR_MESSAGES['PKG_LICS_CONC_VALUE'].format(p.lineno(1))
+        msg = ERROR_MESSAGES["PKG_LICS_CONC_VALUE"].format(p.lineno(1))
         self.logger.log(msg)
 
     def p_pkg_src_info_1(self, p):
         """pkg_src_info : PKG_SRC_INFO TEXT"""
         try:
             if six.PY2:
-                value = p[2].decode(encoding='utf-8')
+                value = p[2].decode(encoding="utf-8")
             else:
                 value = p[2]
             self.builder.set_pkg_source_info(self.document, value)
         except CardinalityError:
-            self.more_than_one_error('PackageSourceInfo', p.lineno(1))
+            self.more_than_one_error("PackageSourceInfo", p.lineno(1))
         except OrderError:
-            self.order_error('PackageSourceInfo', 'PackageFileName', p.lineno(1))
+            self.order_error("PackageSourceInfo", "PackageFileName", p.lineno(1))
 
     def p_pkg_src_info_2(self, p):
         """pkg_src_info : PKG_SRC_INFO error"""
         self.error = True
-        msg = ERROR_MESSAGES['PKG_SRC_INFO_VALUE'].format(p.lineno(1))
+        msg = ERROR_MESSAGES["PKG_SRC_INFO_VALUE"].format(p.lineno(1))
         self.logger.log(msg)
 
     def p_pkg_chksum_1(self, p):
         """pkg_chksum : PKG_CHKSUM CHKSUM"""
         try:
             if six.PY2:
-                value = p[2].decode(encoding='utf-8')
+                value = p[2].decode(encoding="utf-8")
             else:
                 value = p[2]
             self.builder.set_pkg_chk_sum(self.document, value)
         except OrderError:
-            self.order_error('PackageChecksum', 'PackageFileName', p.lineno(1))
+            self.order_error("PackageChecksum", "PackageFileName", p.lineno(1))
         except CardinalityError:
-            self.more_than_one_error('PackageChecksum', p.lineno(1))
+            self.more_than_one_error("PackageChecksum", p.lineno(1))
 
     def p_pkg_chksum_2(self, p):
         """pkg_chksum : PKG_CHKSUM error"""
         self.error = True
-        msg = ERROR_MESSAGES['PKG_CHKSUM_VALUE'].format(p.lineno(1))
+        msg = ERROR_MESSAGES["PKG_CHKSUM_VALUE"].format(p.lineno(1))
         self.logger.log(msg)
 
     def p_pkg_verif_1(self, p):
         """pkg_verif : PKG_VERF_CODE LINE"""
         try:
             if six.PY2:
-                value = p[2].decode(encoding='utf-8')
+                value = p[2].decode(encoding="utf-8")
             else:
                 value = p[2]
             self.builder.set_pkg_verif_code(self.document, value)
         except OrderError:
-            self.order_error('PackageVerificationCode', 'PackageName', p.lineno(1))
+            self.order_error("PackageVerificationCode", "PackageName", p.lineno(1))
         except CardinalityError:
-            self.more_than_one_error('PackageVerificationCode', p.lineno(1))
+            self.more_than_one_error("PackageVerificationCode", p.lineno(1))
         except SPDXValueError:
             self.error = True
-            msg = ERROR_MESSAGES['PKG_VERF_CODE_VALUE'].format(p.lineno(1))
+            msg = ERROR_MESSAGES["PKG_VERF_CODE_VALUE"].format(p.lineno(1))
             self.logger.log(msg)
 
     def p_pkg_verif_2(self, p):
         """pkg_verif : PKG_VERF_CODE error"""
         self.error = True
-        msg = ERROR_MESSAGES['PKG_VERF_CODE_VALUE'].format(p.lineno(1))
+        msg = ERROR_MESSAGES["PKG_VERF_CODE_VALUE"].format(p.lineno(1))
         self.logger.log(msg)
 
     def p_pkg_home_1(self, p):
@@ -965,20 +969,20 @@ class Parser(object):
         try:
             self.builder.set_pkg_home(self.document, p[2])
         except OrderError:
-            self.order_error('PackageHomePage', 'PackageName', p.lineno(1))
+            self.order_error("PackageHomePage", "PackageName", p.lineno(1))
         except CardinalityError:
-            self.more_than_one_error('PackageHomePage', p.lineno(1))
+            self.more_than_one_error("PackageHomePage", p.lineno(1))
 
     def p_pkg_home_2(self, p):
         """pkg_home : PKG_HOME error"""
         self.error = True
-        msg = ERROR_MESSAGES['PKG_HOME_VALUE']
+        msg = ERROR_MESSAGES["PKG_HOME_VALUE"]
         self.logger.log(msg)
 
     def p_pkg_home_value_1(self, p):
         """pkg_home_value : LINE"""
         if six.PY2:
-            p[0] = p[1].decode(encoding='utf-8')
+            p[0] = p[1].decode(encoding="utf-8")
         else:
             p[0] = p[1]
 
@@ -995,41 +999,41 @@ class Parser(object):
         try:
             self.builder.set_pkg_down_location(self.document, p[2])
         except OrderError:
-            self.order_error('PackageDownloadLocation', 'PackageName', p.lineno(1))
+            self.order_error("PackageDownloadLocation", "PackageName", p.lineno(1))
         except CardinalityError:
-            self.more_than_one_error('PackageDownloadLocation', p.lineno(1))
+            self.more_than_one_error("PackageDownloadLocation", p.lineno(1))
 
     def p_pkg_down_location_2(self, p):
         """pkg_down_location : PKG_DOWN error"""
         self.error = True
-        msg = ERROR_MESSAGES['PKG_DOWN_VALUE'].format(p.lineno(1))
+        msg = ERROR_MESSAGES["PKG_DOWN_VALUE"].format(p.lineno(1))
         self.logger.log(msg)
 
     def p_pkg_files_analyzed_1(self, p):
         """pkg_files_analyzed : PKG_FILES_ANALYZED LINE"""
         try:
             if six.PY2:
-                value = p[2].decode(encoding='utf-8')
+                value = p[2].decode(encoding="utf-8")
             else:
                 value = p[2]
             self.builder.set_pkg_files_analyzed(self.document, value)
         except CardinalityError:
-            self.more_than_one_error('FilesAnalyzed', p.lineno(1))
+            self.more_than_one_error("FilesAnalyzed", p.lineno(1))
         except SPDXValueError:
             self.error = True
-            msg = ERROR_MESSAGES['PKG_FILES_ANALYZED_VALUE'].format(p.lineno(1))
+            msg = ERROR_MESSAGES["PKG_FILES_ANALYZED_VALUE"].format(p.lineno(1))
             self.logger.log(msg)
 
     def p_pkg_files_analyzed_2(self, p):
         """pkg_files_analyzed : PKG_FILES_ANALYZED error"""
         self.error = True
-        msg = ERROR_MESSAGES['PKG_FILES_ANALYZED_VALUE'].format(p.lineno(1))
+        msg = ERROR_MESSAGES["PKG_FILES_ANALYZED_VALUE"].format(p.lineno(1))
         self.logger.log(msg)
 
     def p_pkg_down_value_1(self, p):
         """pkg_down_value : LINE """
         if six.PY2:
-            p[0] = p[1].decode(encoding='utf-8')
+            p[0] = p[1].decode(encoding="utf-8")
         else:
             p[0] = p[1]
 
@@ -1046,18 +1050,18 @@ class Parser(object):
         try:
             self.builder.set_pkg_originator(self.document, p[2])
         except OrderError:
-            self.order_error('PackageOriginator', 'PackageName', p.lineno(1))
+            self.order_error("PackageOriginator", "PackageName", p.lineno(1))
         except SPDXValueError:
             self.error = True
-            msg = ERROR_MESSAGES['PKG_ORIG_VALUE'].format(p.lineno(1))
+            msg = ERROR_MESSAGES["PKG_ORIG_VALUE"].format(p.lineno(1))
             self.logger.log(msg)
         except CardinalityError:
-            self.more_than_one_error('PackageOriginator', p.lineno(1))
+            self.more_than_one_error("PackageOriginator", p.lineno(1))
 
     def p_pkg_orig_2(self, p):
         """pkg_orig : PKG_ORIG error"""
         self.error = True
-        msg = ERROR_MESSAGES['PKG_ORIG_VALUE'].format(p.lineno(1))
+        msg = ERROR_MESSAGES["PKG_ORIG_VALUE"].format(p.lineno(1))
         self.logger.log(msg)
 
     def p_pkg_supplier_1(self, p):
@@ -1065,18 +1069,18 @@ class Parser(object):
         try:
             self.builder.set_pkg_supplier(self.document, p[2])
         except OrderError:
-            self.order_error('PackageSupplier', 'PackageName', p.lineno(1))
+            self.order_error("PackageSupplier", "PackageName", p.lineno(1))
         except CardinalityError:
-            self.more_than_one_error('PackageSupplier', p.lineno(1))
+            self.more_than_one_error("PackageSupplier", p.lineno(1))
         except SPDXValueError:
             self.error = True
-            msg = ERROR_MESSAGES['PKG_SUPPL_VALUE'].format(p.lineno(1))
+            msg = ERROR_MESSAGES["PKG_SUPPL_VALUE"].format(p.lineno(1))
             self.logger.log(msg)
 
     def p_pkg_supplier_2(self, p):
         """pkg_supplier : PKG_SUPPL error"""
         self.error = True
-        msg = ERROR_MESSAGES['PKG_SUPPL_VALUE'].format(p.lineno(1))
+        msg = ERROR_MESSAGES["PKG_SUPPL_VALUE"].format(p.lineno(1))
         self.logger.log(msg)
 
     def p_pkg_supplier_values_1(self, p):
@@ -1091,116 +1095,116 @@ class Parser(object):
         """pkg_file_name : PKG_FILE_NAME LINE"""
         try:
             if six.PY2:
-                value = p[2].decode(encoding='utf-8')
+                value = p[2].decode(encoding="utf-8")
             else:
                 value = p[2]
             self.builder.set_pkg_file_name(self.document, value)
         except OrderError:
-            self.order_error('PackageFileName', 'PackageName', p.lineno(1))
+            self.order_error("PackageFileName", "PackageName", p.lineno(1))
         except CardinalityError:
-            self.more_than_one_error('PackageFileName', p.lineno(1))
+            self.more_than_one_error("PackageFileName", p.lineno(1))
 
     def p_pkg_file_name_1(self, p):
         """pkg_file_name : PKG_FILE_NAME error"""
         self.error = True
-        msg = ERROR_MESSAGES['PKG_FILE_NAME_VALUE'].format(p.lineno(1))
+        msg = ERROR_MESSAGES["PKG_FILE_NAME_VALUE"].format(p.lineno(1))
         self.logger.log(msg)
 
     def p_package_version_1(self, p):
         """package_version : PKG_VERSION LINE"""
         try:
             if six.PY2:
-                value = p[2].decode(encoding='utf-8')
+                value = p[2].decode(encoding="utf-8")
             else:
                 value = p[2]
             self.builder.set_pkg_vers(self.document, value)
         except OrderError:
-            self.order_error('PackageVersion', 'PackageName', p.lineno(1))
+            self.order_error("PackageVersion", "PackageName", p.lineno(1))
         except CardinalityError:
-            self.more_than_one_error('PackageVersion', p.lineno(1))
+            self.more_than_one_error("PackageVersion", p.lineno(1))
 
     def p_package_version_2(self, p):
         """package_version : PKG_VERSION error"""
         self.error = True
-        msg = ERROR_MESSAGES['PKG_VERSION_VALUE'].format(p.lineno(1))
+        msg = ERROR_MESSAGES["PKG_VERSION_VALUE"].format(p.lineno(1))
         self.logger.log(msg)
 
     def p_package_name(self, p):
         """package_name : PKG_NAME LINE"""
         try:
             if six.PY2:
-                value = p[2].decode(encoding='utf-8')
+                value = p[2].decode(encoding="utf-8")
             else:
                 value = p[2]
             self.builder.create_package(self.document, value)
         except CardinalityError:
-            self.more_than_one_error('PackageName', p.lineno(1))
+            self.more_than_one_error("PackageName", p.lineno(1))
 
     def p_package_name_1(self, p):
         """package_name : PKG_NAME error"""
         self.error = True
-        msg = ERROR_MESSAGES['PACKAGE_NAME_VALUE'].format(p.lineno(1))
+        msg = ERROR_MESSAGES["PACKAGE_NAME_VALUE"].format(p.lineno(1))
         self.logger.log(msg)
 
     def p_snip_spdx_id(self, p):
         """snip_spdx_id : SNIPPET_SPDX_ID LINE"""
         try:
             if six.PY2:
-                value = p[2].decode(encoding='utf-8')
+                value = p[2].decode(encoding="utf-8")
             else:
                 value = p[2]
             self.builder.create_snippet(self.document, value)
         except SPDXValueError:
             self.error = True
-            msg = ERROR_MESSAGES['SNIP_SPDX_ID_VALUE'].format(p.lineno(2))
+            msg = ERROR_MESSAGES["SNIP_SPDX_ID_VALUE"].format(p.lineno(2))
             self.logger.log(msg)
 
     def p_snip_spdx_id_1(self, p):
         """snip_spdx_id : SNIPPET_SPDX_ID error"""
         self.error = True
-        msg = ERROR_MESSAGES['SNIP_SPDX_ID_VALUE'].format(p.lineno(1))
+        msg = ERROR_MESSAGES["SNIP_SPDX_ID_VALUE"].format(p.lineno(1))
         self.logger.log(msg)
 
     def p_snippet_name(self, p):
         """snip_name : SNIPPET_NAME LINE"""
         try:
             if six.PY2:
-                value = p[2].decode(encoding='utf-8')
+                value = p[2].decode(encoding="utf-8")
             else:
                 value = p[2]
             self.builder.set_snippet_name(self.document, value)
         except OrderError:
-            self.order_error('SnippetName', 'SnippetSPDXID', p.lineno(1))
+            self.order_error("SnippetName", "SnippetSPDXID", p.lineno(1))
         except CardinalityError:
-            self.more_than_one_error('SnippetName', p.lineno(1))
+            self.more_than_one_error("SnippetName", p.lineno(1))
 
     def p_snippet_name_1(self, p):
         """snip_name : SNIPPET_NAME error"""
         self.error = True
-        msg = ERROR_MESSAGES['SNIPPET_NAME_VALUE'].format(p.lineno(1))
+        msg = ERROR_MESSAGES["SNIPPET_NAME_VALUE"].format(p.lineno(1))
         self.logger.log(msg)
 
     def p_snippet_comment(self, p):
         """snip_comment : SNIPPET_COMMENT TEXT"""
         try:
             if six.PY2:
-                value = p[2].decode(encoding='utf-8')
+                value = p[2].decode(encoding="utf-8")
             else:
                 value = p[2]
             self.builder.set_snippet_comment(self.document, value)
         except OrderError:
-            self.order_error('SnippetComment', 'SnippetSPDXID', p.lineno(1))
+            self.order_error("SnippetComment", "SnippetSPDXID", p.lineno(1))
         except SPDXValueError:
             self.error = True
-            msg = ERROR_MESSAGES['SNIP_COMMENT_VALUE'].format(p.lineno(2))
+            msg = ERROR_MESSAGES["SNIP_COMMENT_VALUE"].format(p.lineno(2))
             self.logger.log(msg)
         except CardinalityError:
-            self.more_than_one_error('SnippetComment', p.lineno(1))
+            self.more_than_one_error("SnippetComment", p.lineno(1))
 
     def p_snippet_comment_1(self, p):
         """snip_comment : SNIPPET_COMMENT error"""
         self.error = True
-        msg = ERROR_MESSAGES['SNIP_COMMENT_VALUE'].format(p.lineno(1))
+        msg = ERROR_MESSAGES["SNIP_COMMENT_VALUE"].format(p.lineno(1))
         self.logger.log(msg)
 
     def p_snippet_cr_text(self, p):
@@ -1208,24 +1212,24 @@ class Parser(object):
         try:
             self.builder.set_snippet_copyright(self.document, p[2])
         except OrderError:
-            self.order_error('SnippetCopyrightText', 'SnippetSPDXID', p.lineno(1))
+            self.order_error("SnippetCopyrightText", "SnippetSPDXID", p.lineno(1))
         except SPDXValueError:
             self.error = True
-            msg = ERROR_MESSAGES['SNIP_COPYRIGHT_VALUE'].format(p.lineno(2))
+            msg = ERROR_MESSAGES["SNIP_COPYRIGHT_VALUE"].format(p.lineno(2))
             self.logger.log(msg)
         except CardinalityError:
-            self.more_than_one_error('SnippetCopyrightText', p.lineno(1))
+            self.more_than_one_error("SnippetCopyrightText", p.lineno(1))
 
     def p_snippet_cr_text_1(self, p):
         """snip_cr_text : SNIPPET_CR_TEXT error"""
         self.error = True
-        msg = ERROR_MESSAGES['SNIP_COPYRIGHT_VALUE'].format(p.lineno(1))
+        msg = ERROR_MESSAGES["SNIP_COPYRIGHT_VALUE"].format(p.lineno(1))
         self.logger.log(msg)
 
     def p_snippet_cr_value_1(self, p):
         """snip_cr_value : TEXT"""
         if six.PY2:
-            p[0] = p[1].decode(encoding='utf-8')
+            p[0] = p[1].decode(encoding="utf-8")
         else:
             p[0] = p[1]
 
@@ -1241,46 +1245,46 @@ class Parser(object):
         """snip_lic_comment : SNIPPET_LICS_COMMENT TEXT"""
         try:
             if six.PY2:
-                value = p[2].decode(encoding='utf-8')
+                value = p[2].decode(encoding="utf-8")
             else:
                 value = p[2]
             self.builder.set_snippet_lic_comment(self.document, value)
         except OrderError:
-            self.order_error('SnippetLicenseComments', 'SnippetSPDXID', p.lineno(1))
+            self.order_error("SnippetLicenseComments", "SnippetSPDXID", p.lineno(1))
         except SPDXValueError:
             self.error = True
-            msg = ERROR_MESSAGES['SNIP_LICS_COMMENT_VALUE'].format(p.lineno(2))
+            msg = ERROR_MESSAGES["SNIP_LICS_COMMENT_VALUE"].format(p.lineno(2))
             self.logger.log(msg)
         except CardinalityError:
-            self.more_than_one_error('SnippetLicenseComments', p.lineno(1))
+            self.more_than_one_error("SnippetLicenseComments", p.lineno(1))
 
     def p_snippet_lic_comment_1(self, p):
         """snip_lic_comment : SNIPPET_LICS_COMMENT error"""
         self.error = True
-        msg = ERROR_MESSAGES['SNIP_LICS_COMMENT_VALUE'].format(p.lineno(1))
+        msg = ERROR_MESSAGES["SNIP_LICS_COMMENT_VALUE"].format(p.lineno(1))
         self.logger.log(msg)
 
     def p_snip_from_file_spdxid(self, p):
         """snip_file_spdx_id : SNIPPET_FILE_SPDXID LINE"""
         try:
             if six.PY2:
-                value = p[2].decode(encoding='utf-8')
+                value = p[2].decode(encoding="utf-8")
             else:
                 value = p[2]
             self.builder.set_snip_from_file_spdxid(self.document, value)
         except OrderError:
-            self.order_error('SnippetFromFileSPDXID', 'SnippetSPDXID', p.lineno(1))
+            self.order_error("SnippetFromFileSPDXID", "SnippetSPDXID", p.lineno(1))
         except SPDXValueError:
             self.error = True
-            msg = ERROR_MESSAGES['SNIP_FILE_SPDXID_VALUE'].format(p.lineno(2))
+            msg = ERROR_MESSAGES["SNIP_FILE_SPDXID_VALUE"].format(p.lineno(2))
             self.logger.log(msg)
         except CardinalityError:
-            self.more_than_one_error('SnippetFromFileSPDXID', p.lineno(1))
+            self.more_than_one_error("SnippetFromFileSPDXID", p.lineno(1))
 
     def p_snip_from_file_spdxid_1(self, p):
         """snip_file_spdx_id : SNIPPET_FILE_SPDXID error"""
         self.error = True
-        msg = ERROR_MESSAGES['SNIP_FILE_SPDXID_VALUE'].format(p.lineno(1))
+        msg = ERROR_MESSAGES["SNIP_FILE_SPDXID_VALUE"].format(p.lineno(1))
         self.logger.log(msg)
 
     def p_snippet_concluded_license(self, p):
@@ -1289,18 +1293,17 @@ class Parser(object):
             self.builder.set_snip_concluded_license(self.document, p[2])
         except SPDXValueError:
             self.error = True
-            msg = ERROR_MESSAGES['SNIP_LICS_CONC_VALUE'].format(p.lineno(1))
+            msg = ERROR_MESSAGES["SNIP_LICS_CONC_VALUE"].format(p.lineno(1))
             self.logger.log(msg)
         except OrderError:
-            self.order_error('SnippetLicenseConcluded',
-                             'SnippetSPDXID', p.lineno(1))
+            self.order_error("SnippetLicenseConcluded", "SnippetSPDXID", p.lineno(1))
         except CardinalityError:
-            self.more_than_one_error('SnippetLicenseConcluded', p.lineno(1))
+            self.more_than_one_error("SnippetLicenseConcluded", p.lineno(1))
 
     def p_snippet_concluded_license_1(self, p):
         """snip_lics_conc : SNIPPET_LICS_CONC error"""
         self.error = True
-        msg = ERROR_MESSAGES['SNIP_LICS_CONC_VALUE'].format(p.lineno(1))
+        msg = ERROR_MESSAGES["SNIP_LICS_CONC_VALUE"].format(p.lineno(1))
         self.logger.log(msg)
 
     def p_snippet_lics_info(self, p):
@@ -1308,17 +1311,16 @@ class Parser(object):
         try:
             self.builder.set_snippet_lics_info(self.document, p[2])
         except OrderError:
-            self.order_error(
-                'LicenseInfoInSnippet', 'SnippetSPDXID', p.lineno(1))
+            self.order_error("LicenseInfoInSnippet", "SnippetSPDXID", p.lineno(1))
         except SPDXValueError:
             self.error = True
-            msg = ERROR_MESSAGES['SNIP_LICS_INFO_VALUE'].format(p.lineno(1))
+            msg = ERROR_MESSAGES["SNIP_LICS_INFO_VALUE"].format(p.lineno(1))
             self.logger.log(msg)
 
     def p_snippet_lics_info_1(self, p):
         """snip_lics_info : SNIPPET_LICS_INFO error"""
         self.error = True
-        msg = ERROR_MESSAGES['SNIP_LICS_INFO_VALUE'].format(p.lineno(1))
+        msg = ERROR_MESSAGES["SNIP_LICS_INFO_VALUE"].format(p.lineno(1))
         self.logger.log(msg)
 
     def p_snip_lic_info_value_1(self, p):
@@ -1332,7 +1334,7 @@ class Parser(object):
     def p_snip_lic_info_value_3(self, p):
         """snip_lic_info_value : LINE"""
         if six.PY2:
-            value = p[1].decode(encoding='utf-8')
+            value = p[1].decode(encoding="utf-8")
         else:
             value = p[1]
         p[0] = document.License.from_identifier(value)
@@ -1344,45 +1346,45 @@ class Parser(object):
     def p_reviewer_2(self, p):
         """reviewer : REVIEWER error"""
         self.error = True
-        msg = ERROR_MESSAGES['REVIEWER_VALUE_TYPE'].format(p.lineno(1))
+        msg = ERROR_MESSAGES["REVIEWER_VALUE_TYPE"].format(p.lineno(1))
         self.logger.log(msg)
 
     def p_review_date_1(self, p):
         """review_date : REVIEW_DATE DATE"""
         try:
             if six.PY2:
-                value = p[2].decode(encoding='utf-8')
+                value = p[2].decode(encoding="utf-8")
             else:
                 value = p[2]
             self.builder.add_review_date(self.document, value)
         except CardinalityError:
-            self.more_than_one_error('ReviewDate', p.lineno(1))
+            self.more_than_one_error("ReviewDate", p.lineno(1))
         except OrderError:
-            self.order_error('ReviewDate', 'Reviewer', p.lineno(1))
+            self.order_error("ReviewDate", "Reviewer", p.lineno(1))
 
     def p_review_date_2(self, p):
         """review_date : REVIEW_DATE error"""
         self.error = True
-        msg = ERROR_MESSAGES['REVIEW_DATE_VALUE_TYPE'].format(p.lineno(1))
+        msg = ERROR_MESSAGES["REVIEW_DATE_VALUE_TYPE"].format(p.lineno(1))
         self.logger.log(msg)
 
     def p_review_comment_1(self, p):
         """review_comment : REVIEW_COMMENT TEXT"""
         try:
             if six.PY2:
-                value = p[2].decode(encoding='utf-8')
+                value = p[2].decode(encoding="utf-8")
             else:
                 value = p[2]
             self.builder.add_review_comment(self.document, value)
         except CardinalityError:
-            self.more_than_one_error('ReviewComment', p.lineno(1))
+            self.more_than_one_error("ReviewComment", p.lineno(1))
         except OrderError:
-            self.order_error('ReviewComment', 'Reviewer', p.lineno(1))
+            self.order_error("ReviewComment", "Reviewer", p.lineno(1))
 
     def p_review_comment_2(self, p):
         """review_comment : REVIEW_COMMENT error"""
         self.error = True
-        msg = ERROR_MESSAGES['REVIEW_COMMENT_VALUE_TYPE'].format(p.lineno(1))
+        msg = ERROR_MESSAGES["REVIEW_COMMENT_VALUE_TYPE"].format(p.lineno(1))
         self.logger.log(msg)
 
     def p_annotator_1(self, p):
@@ -1392,250 +1394,288 @@ class Parser(object):
     def p_annotator_2(self, p):
         """annotator : ANNOTATOR error"""
         self.error = True
-        msg = ERROR_MESSAGES['ANNOTATOR_VALUE_TYPE'].format(p.lineno(1))
+        msg = ERROR_MESSAGES["ANNOTATOR_VALUE_TYPE"].format(p.lineno(1))
         self.logger.log(msg)
 
     def p_annotation_date_1(self, p):
         """annotation_date : ANNOTATION_DATE DATE"""
         try:
             if six.PY2:
-                value = p[2].decode(encoding='utf-8')
+                value = p[2].decode(encoding="utf-8")
             else:
                 value = p[2]
             self.builder.add_annotation_date(self.document, value)
         except CardinalityError:
-            self.more_than_one_error('AnnotationDate', p.lineno(1))
+            self.more_than_one_error("AnnotationDate", p.lineno(1))
         except OrderError:
-            self.order_error('AnnotationDate', 'Annotator', p.lineno(1))
+            self.order_error("AnnotationDate", "Annotator", p.lineno(1))
 
     def p_annotation_date_2(self, p):
         """annotation_date : ANNOTATION_DATE error"""
         self.error = True
-        msg = ERROR_MESSAGES['ANNOTATION_DATE_VALUE_TYPE'].format(p.lineno(1))
+        msg = ERROR_MESSAGES["ANNOTATION_DATE_VALUE_TYPE"].format(p.lineno(1))
         self.logger.log(msg)
 
     def p_annotation_comment_1(self, p):
         """annotation_comment : ANNOTATION_COMMENT TEXT"""
         try:
             if six.PY2:
-                value = p[2].decode(encoding='utf-8')
+                value = p[2].decode(encoding="utf-8")
             else:
                 value = p[2]
             self.builder.add_annotation_comment(self.document, value)
         except CardinalityError:
-            self.more_than_one_error('AnnotationComment', p.lineno(1))
+            self.more_than_one_error("AnnotationComment", p.lineno(1))
         except OrderError:
-            self.order_error('AnnotationComment', 'Annotator', p.lineno(1))
+            self.order_error("AnnotationComment", "Annotator", p.lineno(1))
 
     def p_annotation_comment_2(self, p):
         """annotation_comment : ANNOTATION_COMMENT error"""
         self.error = True
-        msg = ERROR_MESSAGES['ANNOTATION_COMMENT_VALUE_TYPE'].format(p.lineno(1))
+        msg = ERROR_MESSAGES["ANNOTATION_COMMENT_VALUE_TYPE"].format(p.lineno(1))
         self.logger.log(msg)
 
     def p_annotation_type_1(self, p):
         """annotation_type : ANNOTATION_TYPE LINE"""
         try:
             if six.PY2:
-                value = p[2].decode(encoding='utf-8')
+                value = p[2].decode(encoding="utf-8")
             else:
                 value = p[2]
             self.builder.add_annotation_type(self.document, value)
         except CardinalityError:
-            self.more_than_one_error('AnnotationType', p.lineno(1))
+            self.more_than_one_error("AnnotationType", p.lineno(1))
         except SPDXValueError:
             self.error = True
-            msg = ERROR_MESSAGES['ANNOTATION_TYPE_VALUE'].format(p.lineno(1))
+            msg = ERROR_MESSAGES["ANNOTATION_TYPE_VALUE"].format(p.lineno(1))
             self.logger.log(msg)
         except OrderError:
-            self.order_error('AnnotationType', 'Annotator', p.lineno(1))
+            self.order_error("AnnotationType", "Annotator", p.lineno(1))
 
     def p_annotation_type_2(self, p):
         """annotation_type : ANNOTATION_TYPE error"""
         self.error = True
-        msg = ERROR_MESSAGES['ANNOTATION_TYPE_VALUE'].format(
-            p.lineno(1))
+        msg = ERROR_MESSAGES["ANNOTATION_TYPE_VALUE"].format(p.lineno(1))
         self.logger.log(msg)
 
     def p_annotation_spdx_id_1(self, p):
         """annotation_spdx_id : ANNOTATION_SPDX_ID LINE"""
         try:
             if six.PY2:
-                value = p[2].decode(encoding='utf-8')
+                value = p[2].decode(encoding="utf-8")
             else:
                 value = p[2]
             self.builder.set_annotation_spdx_id(self.document, value)
         except CardinalityError:
-            self.more_than_one_error('SPDXREF', p.lineno(1))
+            self.more_than_one_error("SPDXREF", p.lineno(1))
         except OrderError:
-            self.order_error('SPDXREF', 'Annotator', p.lineno(1))
+            self.order_error("SPDXREF", "Annotator", p.lineno(1))
 
     def p_annotation_spdx_id_2(self, p):
         """annotation_spdx_id : ANNOTATION_SPDX_ID error"""
         self.error = True
-        msg = ERROR_MESSAGES['ANNOTATION_SPDX_ID_VALUE'].format(
-            p.lineno(1))
+        msg = ERROR_MESSAGES["ANNOTATION_SPDX_ID_VALUE"].format(p.lineno(1))
+        self.logger.log(msg)
+
+    def p_relationship_1(self, p):
+        """relationship : RELATIONSHIP LINE"""
+        try:
+            if six.PY2:
+                value = p[2].decode(encoding="utf-8")
+            else:
+                value = p[2]
+            self.builder.add_relationship(self.document, value)
+        except SPDXValueError:
+            self.error = True
+            msg = ERROR_MESSAGES["RELATIONSHIP_VALUE"].format(p.lineno(1))
+            self.logger.log(msg)
+        except OrderError:
+            self.order_error("Relationship_type", "Relationship", p.lineno(1))
+
+    def p_relationship_2(self, p):
+        """relationship : RELATIONSHIP error"""
+        self.error = True
+        msg = ERROR_MESSAGES["RELATIONSHIP_VALUE"].format(p.lineno(1))
+        self.logger.log(msg)
+
+    def p_relationship_comment_1(self, p):
+        """relationship_comment : RELATIONSHIP_COMMENT TEXT"""
+        try:
+            if six.PY2:
+                value = p[2].decode(encoding="utf-8")
+            else:
+                value = p[2]
+            self.builder.add_relationship_comment(self.document, value)
+        except OrderError:
+            self.order_error("RelationshipComment", "Relationship", p.lineno(1))
+        except CardinalityError:
+            self.more_than_one_error("RelationshipComment", p.lineno(1))
+
+    def p_relationship_comment_2(self, p):
+        """relationship_comment : RELATIONSHIP_COMMENT error"""
+        self.error = True
+        msg = ERROR_MESSAGES["RELATIONSHIP_COMMENT_VALUE"].format(p.lineno(1))
         self.logger.log(msg)
 
     def p_lics_list_ver_1(self, p):
         """locs_list_ver : LIC_LIST_VER LINE"""
         try:
             if six.PY2:
-                value = p[2].decode(encoding='utf-8')
+                value = p[2].decode(encoding="utf-8")
             else:
                 value = p[2]
             self.builder.set_lics_list_ver(self.document, value)
         except SPDXValueError:
             self.error = True
-            msg = ERROR_MESSAGES['LIC_LIST_VER_VALUE'].format(
-                p[2], p.lineno(2))
+            msg = ERROR_MESSAGES["LIC_LIST_VER_VALUE"].format(p[2], p.lineno(2))
             self.logger.log(msg)
         except CardinalityError:
-            self.more_than_one_error('LicenseListVersion', p.lineno(1))
+            self.more_than_one_error("LicenseListVersion", p.lineno(1))
 
     def p_lics_list_ver_2(self, p):
         """locs_list_ver : LIC_LIST_VER error"""
         self.error = True
-        msg = ERROR_MESSAGES['LIC_LIST_VER_VALUE_TYPE'].format(p.lineno(1))
+        msg = ERROR_MESSAGES["LIC_LIST_VER_VALUE_TYPE"].format(p.lineno(1))
         self.logger.log(msg)
 
     def p_doc_comment_1(self, p):
         """doc_comment : DOC_COMMENT TEXT"""
         try:
             if six.PY2:
-                value = p[2].decode(encoding='utf-8')
+                value = p[2].decode(encoding="utf-8")
             else:
                 value = p[2]
             self.builder.set_doc_comment(self.document, value)
         except CardinalityError:
-            self.more_than_one_error('DocumentComment', p.lineno(1))
+            self.more_than_one_error("DocumentComment", p.lineno(1))
 
     def p_doc_comment_2(self, p):
         """doc_comment : DOC_COMMENT error"""
         self.error = True
-        msg = ERROR_MESSAGES['DOC_COMMENT_VALUE_TYPE'].format(p.lineno(1))
+        msg = ERROR_MESSAGES["DOC_COMMENT_VALUE_TYPE"].format(p.lineno(1))
         self.logger.log(msg)
 
     def p_doc_namespace_1(self, p):
         """doc_namespace : DOC_NAMESPACE LINE"""
         try:
             if six.PY2:
-                value = p[2].decode(encoding='utf-8')
+                value = p[2].decode(encoding="utf-8")
             else:
                 value = p[2]
             self.builder.set_doc_namespace(self.document, value)
         except SPDXValueError:
             self.error = True
-            msg = ERROR_MESSAGES['DOC_NAMESPACE_VALUE'].format(p[2], p.lineno(2))
+            msg = ERROR_MESSAGES["DOC_NAMESPACE_VALUE"].format(p[2], p.lineno(2))
             self.logger.log(msg)
         except CardinalityError:
-            self.more_than_one_error('DocumentNamespace', p.lineno(1))
+            self.more_than_one_error("DocumentNamespace", p.lineno(1))
 
     def p_doc_namespace_2(self, p):
         """doc_namespace : DOC_NAMESPACE error"""
         self.error = True
-        msg = ERROR_MESSAGES['DOC_NAMESPACE_VALUE_TYPE'].format(p.lineno(1))
+        msg = ERROR_MESSAGES["DOC_NAMESPACE_VALUE_TYPE"].format(p.lineno(1))
         self.logger.log(msg)
 
     def p_data_license_1(self, p):
         """data_lics : DOC_LICENSE LINE"""
         try:
             if six.PY2:
-                value = p[2].decode(encoding='utf-8')
+                value = p[2].decode(encoding="utf-8")
             else:
                 value = p[2]
             self.builder.set_doc_data_lics(self.document, value)
         except SPDXValueError:
             self.error = True
-            msg = ERROR_MESSAGES['DOC_LICENSE_VALUE'].format(p[2], p.lineno(2))
+            msg = ERROR_MESSAGES["DOC_LICENSE_VALUE"].format(p[2], p.lineno(2))
             self.logger.log(msg)
         except CardinalityError:
-            self.more_than_one_error('DataLicense', p.lineno(1))
+            self.more_than_one_error("DataLicense", p.lineno(1))
 
     def p_data_license_2(self, p):
         """data_lics : DOC_LICENSE error"""
         self.error = True
-        msg = ERROR_MESSAGES['DOC_LICENSE_VALUE_TYPE'].format(p.lineno(1))
+        msg = ERROR_MESSAGES["DOC_LICENSE_VALUE_TYPE"].format(p.lineno(1))
         self.logger.log(msg)
 
     def p_doc_name_1(self, p):
         """doc_name : DOC_NAME LINE"""
         try:
             if six.PY2:
-                value = p[2].decode(encoding='utf-8')
+                value = p[2].decode(encoding="utf-8")
             else:
                 value = p[2]
             self.builder.set_doc_name(self.document, value)
         except CardinalityError:
-            self.more_than_one_error('DocumentName', p.lineno(1))
+            self.more_than_one_error("DocumentName", p.lineno(1))
 
     def p_doc_name_2(self, p):
         """doc_name : DOC_NAME error"""
         self.error = True
-        msg = ERROR_MESSAGES['DOC_NAME_VALUE'].format(p.lineno(1))
+        msg = ERROR_MESSAGES["DOC_NAME_VALUE"].format(p.lineno(1))
         self.logger.log(msg)
 
     def p_ext_doc_refs_1(self, p):
         """ext_doc_ref : EXT_DOC_REF DOC_REF_ID DOC_URI EXT_DOC_REF_CHKSUM"""
         try:
             if six.PY2:
-                doc_ref_id = p[2].decode(encoding='utf-8')
-                doc_uri = p[3].decode(encoding='utf-8')
-                ext_doc_chksum = p[4].decode(encoding='utf-8')
+                doc_ref_id = p[2].decode(encoding="utf-8")
+                doc_uri = p[3].decode(encoding="utf-8")
+                ext_doc_chksum = p[4].decode(encoding="utf-8")
             else:
                 doc_ref_id = p[2]
                 doc_uri = p[3]
                 ext_doc_chksum = p[4]
 
-            self.builder.add_ext_doc_refs(self.document, doc_ref_id, doc_uri,
-                                          ext_doc_chksum)
+            self.builder.add_ext_doc_refs(
+                self.document, doc_ref_id, doc_uri, ext_doc_chksum
+            )
         except SPDXValueError:
             self.error = True
-            msg = ERROR_MESSAGES['EXT_DOC_REF_VALUE'].format(p.lineno(2))
+            msg = ERROR_MESSAGES["EXT_DOC_REF_VALUE"].format(p.lineno(2))
             self.logger.log(msg)
 
     def p_ext_doc_refs_2(self, p):
         """ext_doc_ref : EXT_DOC_REF error"""
         self.error = True
-        msg = ERROR_MESSAGES['EXT_DOC_REF_VALUE'].format(p.lineno(1))
+        msg = ERROR_MESSAGES["EXT_DOC_REF_VALUE"].format(p.lineno(1))
         self.logger.log(msg)
 
     def p_spdx_version_1(self, p):
         """spdx_version : DOC_VERSION LINE"""
         try:
             if six.PY2:
-                value = p[2].decode(encoding='utf-8')
+                value = p[2].decode(encoding="utf-8")
             else:
                 value = p[2]
             self.builder.set_doc_version(self.document, value)
         except CardinalityError:
-            self.more_than_one_error('SPDXVersion', p.lineno(1))
+            self.more_than_one_error("SPDXVersion", p.lineno(1))
         except SPDXValueError:
             self.error = True
-            msg = ERROR_MESSAGES['DOC_VERSION_VALUE'].format(p[2], p.lineno(1))
+            msg = ERROR_MESSAGES["DOC_VERSION_VALUE"].format(p[2], p.lineno(1))
             self.logger.log(msg)
 
     def p_spdx_version_2(self, p):
         """spdx_version : DOC_VERSION error"""
         self.error = True
-        msg = ERROR_MESSAGES['DOC_VERSION_VALUE_TYPE'].format(p.lineno(1))
+        msg = ERROR_MESSAGES["DOC_VERSION_VALUE_TYPE"].format(p.lineno(1))
         self.logger.log(msg)
 
     def p_creator_comment_1(self, p):
         """creator_comment : CREATOR_COMMENT TEXT"""
         try:
             if six.PY2:
-                value = p[2].decode(encoding='utf-8')
+                value = p[2].decode(encoding="utf-8")
             else:
                 value = p[2]
             self.builder.set_creation_comment(self.document, value)
         except CardinalityError:
-            self.more_than_one_error('CreatorComment', p.lineno(1))
+            self.more_than_one_error("CreatorComment", p.lineno(1))
 
     def p_creator_comment_2(self, p):
         """creator_comment : CREATOR_COMMENT error"""
         self.error = True
-        msg = ERROR_MESSAGES['CREATOR_COMMENT_VALUE_TYPE'].format(p.lineno(1))
+        msg = ERROR_MESSAGES["CREATOR_COMMENT_VALUE_TYPE"].format(p.lineno(1))
         self.logger.log(msg)
 
     def p_creator_1(self, p):
@@ -1645,24 +1685,24 @@ class Parser(object):
     def p_creator_2(self, p):
         """creator : CREATOR error"""
         self.error = True
-        msg = ERROR_MESSAGES['CREATOR_VALUE_TYPE'].format(p.lineno(1))
+        msg = ERROR_MESSAGES["CREATOR_VALUE_TYPE"].format(p.lineno(1))
         self.logger.log(msg)
 
     def p_created_1(self, p):
         """created : CREATED DATE"""
         try:
             if six.PY2:
-                value = p[2].decode(encoding='utf-8')
+                value = p[2].decode(encoding="utf-8")
             else:
                 value = p[2]
             self.builder.set_created_date(self.document, value)
         except CardinalityError:
-            self.more_than_one_error('Created', p.lineno(1))
+            self.more_than_one_error("Created", p.lineno(1))
 
     def p_created_2(self, p):
         """created : CREATED error"""
         self.error = True
-        msg = ERROR_MESSAGES['CREATED_VALUE_TYPE'].format(p.lineno(1))
+        msg = ERROR_MESSAGES["CREATED_VALUE_TYPE"].format(p.lineno(1))
         self.logger.log(msg)
 
     def p_entity_1(self, p):
@@ -1670,12 +1710,12 @@ class Parser(object):
         """
         try:
             if six.PY2:
-                value = p[1].decode(encoding='utf-8')
+                value = p[1].decode(encoding="utf-8")
             else:
                 value = p[1]
             p[0] = self.builder.build_tool(self.document, value)
         except SPDXValueError:
-            msg = ERROR_MESSAGES['TOOL_VALUE'].format(p[1], p.lineno(1))
+            msg = ERROR_MESSAGES["TOOL_VALUE"].format(p[1], p.lineno(1))
             self.logger.log(msg)
             self.error = True
             p[0] = None
@@ -1685,12 +1725,12 @@ class Parser(object):
         """
         try:
             if six.PY2:
-                value = p[1].decode(encoding='utf-8')
+                value = p[1].decode(encoding="utf-8")
             else:
                 value = p[1]
             p[0] = self.builder.build_org(self.document, value)
         except SPDXValueError:
-            msg = ERROR_MESSAGES['ORG_VALUE'].format(p[1], p.lineno(1))
+            msg = ERROR_MESSAGES["ORG_VALUE"].format(p[1], p.lineno(1))
             self.logger.log(msg)
             self.error = True
             p[0] = None
@@ -1700,12 +1740,12 @@ class Parser(object):
         """
         try:
             if six.PY2:
-                value = p[1].decode(encoding='utf-8')
+                value = p[1].decode(encoding="utf-8")
             else:
                 value = p[1]
             p[0] = self.builder.build_person(self.document, value)
         except SPDXValueError:
-            msg = ERROR_MESSAGES['PERSON_VALUE'].format(p[1], p.lineno(1))
+            msg = ERROR_MESSAGES["PERSON_VALUE"].format(p[1], p.lineno(1))
             self.logger.log(msg)
             self.error = True
             p[0] = None

--- a/spdx/parsers/tagvaluebuilders.py
+++ b/spdx/parsers/tagvaluebuilders.py
@@ -1,4 +1,3 @@
-
 # Copyright (c) 2014 Ahmed H. Ismail
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -24,6 +23,7 @@ from spdx import creationinfo
 from spdx import document
 from spdx import file
 from spdx import package
+from spdx import relationship
 from spdx import review
 from spdx import snippet
 from spdx import utils
@@ -42,10 +42,10 @@ def checksum_from_sha1(value):
     checksum or None if does not match CHECKSUM_RE.
     """
     # More constrained regex at lexer level
-    CHECKSUM_RE = re.compile('SHA1:\\s*([\\S]+)', re.UNICODE)
+    CHECKSUM_RE = re.compile("SHA1:\\s*([\\S]+)", re.UNICODE)
     match = CHECKSUM_RE.match(value)
     if match:
-        return checksum.Algorithm(identifier='SHA1', value=match.group(1))
+        return checksum.Algorithm(identifier="SHA1", value=match.group(1))
     else:
         return None
 
@@ -54,7 +54,7 @@ def str_from_text(text):
     """
     Return content of a free form text block as a string.
     """
-    REGEX = re.compile('<text>((.|\n)+)</text>', re.UNICODE)
+    REGEX = re.compile("<text>((.|\n)+)</text>", re.UNICODE)
     match = REGEX.match(text)
     if match:
         return match.group(1)
@@ -66,7 +66,8 @@ class DocBuilder(object):
     """
     Set the fields of the top level document model.
     """
-    VERS_STR_REGEX = re.compile(r'SPDX-(\d+)\.(\d+)', re.UNICODE)
+
+    VERS_STR_REGEX = re.compile(r"SPDX-(\d+)\.(\d+)", re.UNICODE)
 
     def __init__(self):
         # FIXME: this state does not make sense
@@ -82,13 +83,14 @@ class DocBuilder(object):
             self.doc_version_set = True
             m = self.VERS_STR_REGEX.match(value)
             if m is None:
-                raise SPDXValueError('Document::Version')
+                raise SPDXValueError("Document::Version")
             else:
-                doc.version = version.Version(major=int(m.group(1)),
-                                              minor=int(m.group(2)))
+                doc.version = version.Version(
+                    major=int(m.group(1)), minor=int(m.group(2))
+                )
                 return True
         else:
-            raise CardinalityError('Document::Version')
+            raise CardinalityError("Document::Version")
 
     def set_doc_data_lics(self, doc, lics):
         """
@@ -102,9 +104,9 @@ class DocBuilder(object):
                 doc.data_license = document.License.from_identifier(lics)
                 return True
             else:
-                raise SPDXValueError('Document::DataLicense')
+                raise SPDXValueError("Document::DataLicense")
         else:
-            raise CardinalityError('Document::DataLicense')
+            raise CardinalityError("Document::DataLicense")
 
     def set_doc_name(self, doc, name):
         """
@@ -116,7 +118,7 @@ class DocBuilder(object):
             self.doc_name_set = True
             return True
         else:
-            raise CardinalityError('Document::Name')
+            raise CardinalityError("Document::Name")
 
     def set_doc_spdx_id(self, doc, doc_spdx_id_line):
         """
@@ -125,14 +127,14 @@ class DocBuilder(object):
         Raise CardinalityError if already defined.
         """
         if not self.doc_spdx_id_set:
-            if doc_spdx_id_line == 'SPDXRef-DOCUMENT':
+            if doc_spdx_id_line == "SPDXRef-DOCUMENT":
                 doc.spdx_id = doc_spdx_id_line
                 self.doc_spdx_id_set = True
                 return True
             else:
-                raise SPDXValueError('Document::SPDXID')
+                raise SPDXValueError("Document::SPDXID")
         else:
-            raise CardinalityError('Document::SPDXID')
+            raise CardinalityError("Document::SPDXID")
 
     def set_doc_comment(self, doc, comment):
         """
@@ -146,9 +148,9 @@ class DocBuilder(object):
                 doc.comment = str_from_text(comment)
                 return True
             else:
-                raise SPDXValueError('Document::Comment')
+                raise SPDXValueError("Document::Comment")
         else:
-            raise CardinalityError('Document::Comment')
+            raise CardinalityError("Document::Comment")
 
     def set_doc_namespace(self, doc, namespace):
         """
@@ -162,9 +164,9 @@ class DocBuilder(object):
                 doc.namespace = namespace
                 return True
             else:
-                raise SPDXValueError('Document::Namespace')
+                raise SPDXValueError("Document::Namespace")
         else:
-            raise CardinalityError('Document::Comment')
+            raise CardinalityError("Document::Comment")
 
     def reset_document(self):
         """
@@ -180,14 +182,13 @@ class DocBuilder(object):
 
 
 class ExternalDocumentRefBuilder(object):
-
     def set_ext_doc_id(self, doc, ext_doc_id):
         """
         Set the `external_document_id` attribute of the `ExternalDocumentRef` object.
         """
         doc.add_ext_document_reference(
-            ExternalDocumentRef(
-                external_document_id=ext_doc_id))
+            ExternalDocumentRef(external_document_id=ext_doc_id)
+        )
 
     def set_spdx_doc_uri(self, doc, spdx_doc_uri):
         """
@@ -196,14 +197,13 @@ class ExternalDocumentRefBuilder(object):
         if validations.validate_doc_namespace(spdx_doc_uri):
             doc.ext_document_references[-1].spdx_document_uri = spdx_doc_uri
         else:
-            raise SPDXValueError('Document::ExternalDocumentRef')
+            raise SPDXValueError("Document::ExternalDocumentRef")
 
     def set_chksum(self, doc, chksum):
         """
         Set the `check_sum` attribute of the `ExternalDocumentRef` object.
         """
-        doc.ext_document_references[-1].check_sum = checksum_from_sha1(
-            chksum)
+        doc.ext_document_references[-1].check_sum = checksum_from_sha1(chksum)
 
     def add_ext_doc_refs(self, doc, ext_doc_id, spdx_doc_uri, chksum):
         self.set_ext_doc_id(doc, ext_doc_id)
@@ -213,9 +213,9 @@ class ExternalDocumentRefBuilder(object):
 
 class EntityBuilder(object):
 
-    tool_re = re.compile(r'Tool:\s*(.+)', re.UNICODE)
-    person_re = re.compile(r'Person:\s*(([^(])+)(\((.*)\))?', re.UNICODE)
-    org_re = re.compile(r'Organization:\s*(([^(])+)(\((.*)\))?', re.UNICODE)
+    tool_re = re.compile(r"Tool:\s*(.+)", re.UNICODE)
+    person_re = re.compile(r"Person:\s*(([^(])+)(\((.*)\))?", re.UNICODE)
+    org_re = re.compile(r"Organization:\s*(([^(])+)(\((.*)\))?", re.UNICODE)
     PERSON_NAME_GROUP = 1
     PERSON_EMAIL_GROUP = 4
     ORG_NAME_GROUP = 1
@@ -233,7 +233,7 @@ class EntityBuilder(object):
             name = match.group(self.TOOL_NAME_GROUP)
             return creationinfo.Tool(name)
         else:
-            raise SPDXValueError('Failed to extract tool name')
+            raise SPDXValueError("Failed to extract tool name")
 
     def build_org(self, doc, entity):
         """
@@ -250,7 +250,7 @@ class EntityBuilder(object):
             else:
                 return creationinfo.Organization(name=name, email=None)
         else:
-            raise SPDXValueError('Failed to extract Organization name')
+            raise SPDXValueError("Failed to extract Organization name")
 
     def build_person(self, doc, entity):
         """
@@ -258,7 +258,9 @@ class EntityBuilder(object):
         Return built organization. Raise SPDXValueError if failed to extract name.
         """
         match = self.person_re.match(entity)
-        if match and validations.validate_person_name(match.group(self.PERSON_NAME_GROUP)):
+        if match and validations.validate_person_name(
+            match.group(self.PERSON_NAME_GROUP)
+        ):
             name = match.group(self.PERSON_NAME_GROUP).strip()
             email = match.group(self.PERSON_EMAIL_GROUP)
             if (email is not None) and (len(email) != 0):
@@ -266,11 +268,10 @@ class EntityBuilder(object):
             else:
                 return creationinfo.Person(name=name, email=None)
         else:
-            raise SPDXValueError('Failed to extract person name')
+            raise SPDXValueError("Failed to extract person name")
 
 
 class CreationInfoBuilder(object):
-
     def __init__(self):
         # FIXME: this state does not make sense
         self.reset_creation_info()
@@ -286,7 +287,7 @@ class CreationInfoBuilder(object):
             doc.creation_info.add_creator(creator)
             return True
         else:
-            raise SPDXValueError('CreationInfo::Creator')
+            raise SPDXValueError("CreationInfo::Creator")
 
     def set_created_date(self, doc, created):
         """
@@ -301,9 +302,9 @@ class CreationInfoBuilder(object):
                 doc.creation_info.created = date
                 return True
             else:
-                raise SPDXValueError('CreationInfo::Date')
+                raise SPDXValueError("CreationInfo::Date")
         else:
-            raise CardinalityError('CreationInfo::Created')
+            raise CardinalityError("CreationInfo::Created")
 
     def set_creation_comment(self, doc, comment):
         """
@@ -317,9 +318,9 @@ class CreationInfoBuilder(object):
                 doc.creation_info.comment = str_from_text(comment)
                 return True
             else:
-                raise SPDXValueError('CreationInfo::Comment')
+                raise SPDXValueError("CreationInfo::Comment")
         else:
-            raise CardinalityError('CreationInfo::Comment')
+            raise CardinalityError("CreationInfo::Comment")
 
     def set_lics_list_ver(self, doc, value):
         """
@@ -334,9 +335,9 @@ class CreationInfoBuilder(object):
                 doc.creation_info.license_list_version = vers
                 return True
             else:
-                raise SPDXValueError('CreationInfo::LicenseListVersion')
+                raise SPDXValueError("CreationInfo::LicenseListVersion")
         else:
-            raise CardinalityError('CreationInfo::LicenseListVersion')
+            raise CardinalityError("CreationInfo::LicenseListVersion")
 
     def reset_creation_info(self):
         """
@@ -349,7 +350,6 @@ class CreationInfoBuilder(object):
 
 
 class ReviewBuilder(object):
-
     def __init__(self):
         # FIXME: this state does not make sense
         self.reset_reviews()
@@ -375,7 +375,7 @@ class ReviewBuilder(object):
             doc.add_review(review.Review(reviewer=reviewer))
             return True
         else:
-            raise SPDXValueError('Review::Reviewer')
+            raise SPDXValueError("Review::Reviewer")
 
     def add_review_date(self, doc, reviewed):
         """
@@ -392,11 +392,11 @@ class ReviewBuilder(object):
                     doc.reviews[-1].review_date = date
                     return True
                 else:
-                    raise SPDXValueError('Review::ReviewDate')
+                    raise SPDXValueError("Review::ReviewDate")
             else:
-                raise CardinalityError('Review::ReviewDate')
+                raise CardinalityError("Review::ReviewDate")
         else:
-            raise OrderError('Review::ReviewDate')
+            raise OrderError("Review::ReviewDate")
 
     def add_review_comment(self, doc, comment):
         """
@@ -412,15 +412,14 @@ class ReviewBuilder(object):
                     doc.reviews[-1].comment = str_from_text(comment)
                     return True
                 else:
-                    raise SPDXValueError('ReviewComment::Comment')
+                    raise SPDXValueError("ReviewComment::Comment")
             else:
-                raise CardinalityError('ReviewComment')
+                raise CardinalityError("ReviewComment")
         else:
-            raise OrderError('ReviewComment')
+            raise OrderError("ReviewComment")
 
 
 class AnnotationBuilder(object):
-
     def __init__(self):
         # FIXME: this state does not make sense
         self.reset_annotations()
@@ -448,7 +447,7 @@ class AnnotationBuilder(object):
             doc.add_annotation(annotation.Annotation(annotator=annotator))
             return True
         else:
-            raise SPDXValueError('Annotation::Annotator')
+            raise SPDXValueError("Annotation::Annotator")
 
     def add_annotation_date(self, doc, annotation_date):
         """
@@ -465,11 +464,11 @@ class AnnotationBuilder(object):
                     doc.annotations[-1].annotation_date = date
                     return True
                 else:
-                    raise SPDXValueError('Annotation::AnnotationDate')
+                    raise SPDXValueError("Annotation::AnnotationDate")
             else:
-                raise CardinalityError('Annotation::AnnotationDate')
+                raise CardinalityError("Annotation::AnnotationDate")
         else:
-            raise OrderError('Annotation::AnnotationDate')
+            raise OrderError("Annotation::AnnotationDate")
 
     def add_annotation_comment(self, doc, comment):
         """
@@ -485,11 +484,11 @@ class AnnotationBuilder(object):
                     doc.annotations[-1].comment = str_from_text(comment)
                     return True
                 else:
-                    raise SPDXValueError('AnnotationComment::Comment')
+                    raise SPDXValueError("AnnotationComment::Comment")
             else:
-                raise CardinalityError('AnnotationComment::Comment')
+                raise CardinalityError("AnnotationComment::Comment")
         else:
-            raise OrderError('AnnotationComment::Comment')
+            raise OrderError("AnnotationComment::Comment")
 
     def add_annotation_type(self, doc, annotation_type):
         """
@@ -505,11 +504,11 @@ class AnnotationBuilder(object):
                     doc.annotations[-1].annotation_type = annotation_type
                     return True
                 else:
-                    raise SPDXValueError('Annotation::AnnotationType')
+                    raise SPDXValueError("Annotation::AnnotationType")
             else:
-                raise CardinalityError('Annotation::AnnotationType')
+                raise CardinalityError("Annotation::AnnotationType")
         else:
-            raise OrderError('Annotation::AnnotationType')
+            raise OrderError("Annotation::AnnotationType")
 
     def set_annotation_spdx_id(self, doc, spdx_id):
         """
@@ -523,9 +522,50 @@ class AnnotationBuilder(object):
                 doc.annotations[-1].spdx_id = spdx_id
                 return True
             else:
-                raise CardinalityError('Annotation::SPDXREF')
+                raise CardinalityError("Annotation::SPDXREF")
         else:
-            raise OrderError('Annotation::SPDXREF')
+            raise OrderError("Annotation::SPDXREF")
+
+
+class RelationshipBuilder(object):
+    def __init__(self):
+        # FIXME: this state does not make sense
+        self.reset_relationship()
+
+    def reset_relationship(self):
+        """
+        Reset the builder's state to allow building new relationships.
+        """
+        # FIXME: this state does not make sense
+        self.relationship_comment_set = False
+
+    def add_relationship(self, doc, relationship):
+        """
+        Raise SPDXValueError if type is unknown.
+        """
+        self.reset_relationship()
+        doc.add_relationship(relationship.Relationship(relationship=relationship))
+        return True
+
+    def add_relationship_comment(self, doc, comment):
+        """
+        Set the annotation comment.
+        Raise CardinalityError if already set.
+        Raise OrderError if no relationship defined before it.
+        Raise SPDXValueError if comment is not free form text.
+        """
+        if len(doc.relationships) != 0:
+            if not self.relationship_comment_set:
+                self.relationship_comment_set = True
+                if validations.validate_relationship_comment(comment):
+                    doc.relationships[-1].comment = str_from_text(comment)
+                    return True
+                else:
+                    raise SPDXValueError("RelationshipComment::Comment")
+            else:
+                raise CardinalityError("RelationshipComment::Comment")
+        else:
+            raise OrderError("RelationshipComment::Comment")
 
 
 class PackageBuilder(object):
@@ -572,7 +612,7 @@ class PackageBuilder(object):
             doc.package = package.Package(name=name)
             return True
         else:
-            raise CardinalityError('Package::Name')
+            raise CardinalityError("Package::Name")
 
     def set_pkg_spdx_id(self, doc, spdx_id):
         """
@@ -587,9 +627,9 @@ class PackageBuilder(object):
                 self.package_spdx_id_set = True
                 return True
             else:
-                raise SPDXValueError('Package::SPDXID')
+                raise SPDXValueError("Package::SPDXID")
         else:
-            raise CardinalityError('Package::SPDXID')
+            raise CardinalityError("Package::SPDXID")
 
     def set_pkg_vers(self, doc, version):
         """
@@ -604,7 +644,7 @@ class PackageBuilder(object):
             doc.package.version = version
             return True
         else:
-            raise CardinalityError('Package::Version')
+            raise CardinalityError("Package::Version")
 
     def set_pkg_file_name(self, doc, name):
         """
@@ -619,7 +659,7 @@ class PackageBuilder(object):
             doc.package.file_name = name
             return True
         else:
-            raise CardinalityError('Package::FileName')
+            raise CardinalityError("Package::FileName")
 
     def set_pkg_supplier(self, doc, entity):
         """
@@ -635,9 +675,9 @@ class PackageBuilder(object):
                 doc.package.supplier = entity
                 return True
             else:
-                raise SPDXValueError('Package::Supplier')
+                raise SPDXValueError("Package::Supplier")
         else:
-            raise CardinalityError('Package::Supplier')
+            raise CardinalityError("Package::Supplier")
 
     def set_pkg_originator(self, doc, entity):
         """
@@ -653,9 +693,9 @@ class PackageBuilder(object):
                 doc.package.originator = entity
                 return True
             else:
-                raise SPDXValueError('Package::Originator')
+                raise SPDXValueError("Package::Originator")
         else:
-            raise CardinalityError('Package::Originator')
+            raise CardinalityError("Package::Originator")
 
     def set_pkg_down_location(self, doc, location):
         """
@@ -670,7 +710,7 @@ class PackageBuilder(object):
             doc.package.download_location = location
             return True
         else:
-            raise CardinalityError('Package::DownloadLocation')
+            raise CardinalityError("Package::DownloadLocation")
 
     def set_pkg_files_analyzed(self, doc, files_analyzed):
         """
@@ -687,9 +727,9 @@ class PackageBuilder(object):
                     print(doc.package.files_analyzed)
                     return True
                 else:
-                    raise SPDXValueError('Package::FilesAnalyzed')
+                    raise SPDXValueError("Package::FilesAnalyzed")
         else:
-            raise CardinalityError('Package::FilesAnalyzed')
+            raise CardinalityError("Package::FilesAnalyzed")
 
     def set_pkg_home(self, doc, location):
         """Set the package homepage location if not already set.
@@ -705,9 +745,9 @@ class PackageBuilder(object):
                 doc.package.homepage = location
                 return True
             else:
-                raise SPDXValueError('Package::HomePage')
+                raise SPDXValueError("Package::HomePage")
         else:
-            raise CardinalityError('Package::HomePage')
+            raise CardinalityError("Package::HomePage")
 
     def set_pkg_verif_code(self, doc, code):
         """
@@ -724,12 +764,14 @@ class PackageBuilder(object):
             if match:
                 doc.package.verif_code = match.group(self.VERIF_CODE_CODE_GRP)
                 if match.group(self.VERIF_CODE_EXC_FILES_GRP) is not None:
-                    doc.package.verif_exc_files = match.group(self.VERIF_CODE_EXC_FILES_GRP).split(',')
+                    doc.package.verif_exc_files = match.group(
+                        self.VERIF_CODE_EXC_FILES_GRP
+                    ).split(",")
                 return True
             else:
-                raise SPDXValueError('Package::VerificationCode')
+                raise SPDXValueError("Package::VerificationCode")
         else:
-            raise CardinalityError('Package::VerificationCode')
+            raise CardinalityError("Package::VerificationCode")
 
     def set_pkg_chk_sum(self, doc, chk_sum):
         """
@@ -744,7 +786,7 @@ class PackageBuilder(object):
             doc.package.check_sum = checksum_from_sha1(chk_sum)
             return True
         else:
-            raise CardinalityError('Package::CheckSum')
+            raise CardinalityError("Package::CheckSum")
 
     def set_pkg_source_info(self, doc, text):
         """
@@ -761,9 +803,9 @@ class PackageBuilder(object):
                 doc.package.source_info = str_from_text(text)
                 return True
             else:
-                raise SPDXValueError('Pacckage::SourceInfo')
+                raise SPDXValueError("Pacckage::SourceInfo")
         else:
-            raise CardinalityError('Package::SourceInfo')
+            raise CardinalityError("Package::SourceInfo")
 
     def set_pkg_licenses_concluded(self, doc, licenses):
         """
@@ -780,9 +822,9 @@ class PackageBuilder(object):
                 doc.package.conc_lics = licenses
                 return True
             else:
-                raise SPDXValueError('Package::ConcludedLicenses')
+                raise SPDXValueError("Package::ConcludedLicenses")
         else:
-            raise CardinalityError('Package::ConcludedLicenses')
+            raise CardinalityError("Package::ConcludedLicenses")
 
     def set_pkg_license_from_file(self, doc, lic):
         """
@@ -795,7 +837,7 @@ class PackageBuilder(object):
             doc.package.licenses_from_files.append(lic)
             return True
         else:
-            raise SPDXValueError('Package::LicensesFromFile')
+            raise SPDXValueError("Package::LicensesFromFile")
 
     def set_pkg_license_declared(self, doc, lic):
         """
@@ -811,9 +853,9 @@ class PackageBuilder(object):
                 doc.package.license_declared = lic
                 return True
             else:
-                raise SPDXValueError('Package::LicenseDeclared')
+                raise SPDXValueError("Package::LicenseDeclared")
         else:
-            raise CardinalityError('Package::LicenseDeclared')
+            raise CardinalityError("Package::LicenseDeclared")
 
     def set_pkg_license_comment(self, doc, text):
         """
@@ -829,9 +871,9 @@ class PackageBuilder(object):
                 doc.package.license_comment = str_from_text(text)
                 return True
             else:
-                raise SPDXValueError('Package::LicenseComment')
+                raise SPDXValueError("Package::LicenseComment")
         else:
-            raise CardinalityError('Package::LicenseComment')
+            raise CardinalityError("Package::LicenseComment")
 
     def set_pkg_cr_text(self, doc, text):
         """
@@ -849,9 +891,9 @@ class PackageBuilder(object):
                 else:
                     doc.package.cr_text = text  # None or NoAssert
             else:
-                raise SPDXValueError('Package::CopyrightText')
+                raise SPDXValueError("Package::CopyrightText")
         else:
-            raise CardinalityError('Package::CopyrightText')
+            raise CardinalityError("Package::CopyrightText")
 
     def set_pkg_summary(self, doc, text):
         """
@@ -866,9 +908,9 @@ class PackageBuilder(object):
             if validations.validate_pkg_summary(text):
                 doc.package.summary = str_from_text(text)
             else:
-                raise SPDXValueError('Package::Summary')
+                raise SPDXValueError("Package::Summary")
         else:
-            raise CardinalityError('Package::Summary')
+            raise CardinalityError("Package::Summary")
 
     def set_pkg_desc(self, doc, text):
         """
@@ -883,9 +925,9 @@ class PackageBuilder(object):
             if validations.validate_pkg_desc(text):
                 doc.package.description = str_from_text(text)
             else:
-                raise SPDXValueError('Package::Description')
+                raise SPDXValueError("Package::Description")
         else:
-            raise CardinalityError('Package::Description')
+            raise CardinalityError("Package::Description")
 
     def set_pkg_comment(self, doc, text):
         """
@@ -900,9 +942,9 @@ class PackageBuilder(object):
             if validations.validate_pkg_comment(text):
                 doc.package.comment = str_from_text(text)
             else:
-                raise SPDXValueError('Package::Comment')
+                raise SPDXValueError("Package::Comment")
         else:
-            raise CardinalityError('Package::Comment')
+            raise CardinalityError("Package::Comment")
 
     def set_pkg_ext_ref_category(self, doc, category):
         """
@@ -910,14 +952,17 @@ class PackageBuilder(object):
         """
         self.assert_package_exists()
         if validations.validate_pkg_ext_ref_category(category):
-            if (len(doc.package.pkg_ext_refs) and
-                    doc.package.pkg_ext_refs[-1].category is None):
+            if (
+                len(doc.package.pkg_ext_refs)
+                and doc.package.pkg_ext_refs[-1].category is None
+            ):
                 doc.package.pkg_ext_refs[-1].category = category
             else:
                 doc.package.add_pkg_ext_refs(
-                    package.ExternalPackageRef(category=category))
+                    package.ExternalPackageRef(category=category)
+                )
         else:
-            raise SPDXValueError('ExternalRef::Category')
+            raise SPDXValueError("ExternalRef::Category")
 
     def set_pkg_ext_ref_type(self, doc, pkg_ext_ref_type):
         """
@@ -925,26 +970,30 @@ class PackageBuilder(object):
         """
         self.assert_package_exists()
         if validations.validate_pkg_ext_ref_type(pkg_ext_ref_type):
-            if (len(doc.package.pkg_ext_refs) and
-                    doc.package.pkg_ext_refs[-1].pkg_ext_ref_type is None):
+            if (
+                len(doc.package.pkg_ext_refs)
+                and doc.package.pkg_ext_refs[-1].pkg_ext_ref_type is None
+            ):
                 doc.package.pkg_ext_refs[-1].pkg_ext_ref_type = pkg_ext_ref_type
             else:
-                doc.package.add_pkg_ext_refs(package.ExternalPackageRef(
-                    pkg_ext_ref_type=pkg_ext_ref_type))
+                doc.package.add_pkg_ext_refs(
+                    package.ExternalPackageRef(pkg_ext_ref_type=pkg_ext_ref_type)
+                )
         else:
-            raise SPDXValueError('ExternalRef::Type')
+            raise SPDXValueError("ExternalRef::Type")
 
     def set_pkg_ext_ref_locator(self, doc, locator):
         """
         Set the `locator` attribute of the `ExternalPackageRef` object.
         """
         self.assert_package_exists()
-        if (len(doc.package.pkg_ext_refs) and
-                doc.package.pkg_ext_refs[-1].locator is None):
+        if (
+            len(doc.package.pkg_ext_refs)
+            and doc.package.pkg_ext_refs[-1].locator is None
+        ):
             doc.package.pkg_ext_refs[-1].locator = locator
         else:
-            doc.package.add_pkg_ext_refs(package.ExternalPackageRef(
-                locator=locator))
+            doc.package.add_pkg_ext_refs(package.ExternalPackageRef(locator=locator))
 
     def add_pkg_ext_ref_comment(self, doc, comment):
         """
@@ -952,12 +1001,12 @@ class PackageBuilder(object):
         """
         self.assert_package_exists()
         if not len(doc.package.pkg_ext_refs):
-            raise OrderError('Package::ExternalRef')
+            raise OrderError("Package::ExternalRef")
         else:
             if validations.validate_pkg_ext_ref_comment(comment):
                 doc.package.pkg_ext_refs[-1].comment = str_from_text(comment)
             else:
-                raise SPDXValueError('ExternalRef::Comment')
+                raise SPDXValueError("ExternalRef::Comment")
 
     def add_pkg_ext_refs(self, doc, category, pkg_ext_ref_type, locator):
         self.set_pkg_ext_ref_category(doc, category)
@@ -966,11 +1015,10 @@ class PackageBuilder(object):
 
     def assert_package_exists(self):
         if not self.package_set:
-            raise OrderError('Package')
+            raise OrderError("Package")
 
 
 class FileBuilder(object):
-
     def __init__(self):
         # FIXME: this state does not make sense
         self.reset_file_stat()
@@ -987,7 +1035,7 @@ class FileBuilder(object):
             self.reset_file_stat()
             return True
         else:
-            raise OrderError('File::Name')
+            raise OrderError("File::Name")
 
     def set_file_spdx_id(self, doc, spdx_id):
         """
@@ -1003,11 +1051,11 @@ class FileBuilder(object):
                     self.file(doc).spdx_id = spdx_id
                     return True
                 else:
-                    raise SPDXValueError('File::SPDXID')
+                    raise SPDXValueError("File::SPDXID")
             else:
-                raise CardinalityError('File::SPDXID')
+                raise CardinalityError("File::SPDXID")
         else:
-            raise OrderError('File::SPDXID')
+            raise OrderError("File::SPDXID")
 
     def set_file_comment(self, doc, text):
         """
@@ -1022,11 +1070,11 @@ class FileBuilder(object):
                     self.file(doc).comment = str_from_text(text)
                     return True
                 else:
-                    raise SPDXValueError('File::Comment')
+                    raise SPDXValueError("File::Comment")
             else:
-                raise CardinalityError('File::Comment')
+                raise CardinalityError("File::Comment")
         else:
-            raise OrderError('File::Comment')
+            raise OrderError("File::Comment")
 
     def set_file_type(self, doc, type_value):
         """
@@ -1035,10 +1083,10 @@ class FileBuilder(object):
         Raise SPDXValueError if type is unknown.
         """
         type_dict = {
-            'SOURCE': file.FileType.SOURCE,
-            'BINARY': file.FileType.BINARY,
-            'ARCHIVE': file.FileType.ARCHIVE,
-            'OTHER': file.FileType.OTHER
+            "SOURCE": file.FileType.SOURCE,
+            "BINARY": file.FileType.BINARY,
+            "ARCHIVE": file.FileType.ARCHIVE,
+            "OTHER": file.FileType.OTHER,
         }
         if self.has_package(doc) and self.has_file(doc):
             if not self.file_type_set:
@@ -1047,11 +1095,11 @@ class FileBuilder(object):
                     self.file(doc).type = type_dict[type_value]
                     return True
                 else:
-                    raise SPDXValueError('File::Type')
+                    raise SPDXValueError("File::Type")
             else:
-                raise CardinalityError('File::Type')
+                raise CardinalityError("File::Type")
         else:
-            raise OrderError('File::Type')
+            raise OrderError("File::Type")
 
     def set_file_chksum(self, doc, chksum):
         """
@@ -1064,9 +1112,9 @@ class FileBuilder(object):
                 self.file(doc).chk_sum = checksum_from_sha1(chksum)
                 return True
             else:
-                raise CardinalityError('File::CheckSum')
+                raise CardinalityError("File::CheckSum")
         else:
-            raise OrderError('File::CheckSum')
+            raise OrderError("File::CheckSum")
 
     def set_concluded_license(self, doc, lic):
         """
@@ -1081,11 +1129,11 @@ class FileBuilder(object):
                     self.file(doc).conc_lics = lic
                     return True
                 else:
-                    raise SPDXValueError('File::ConcludedLicense')
+                    raise SPDXValueError("File::ConcludedLicense")
             else:
-                raise CardinalityError('File::ConcludedLicense')
+                raise CardinalityError("File::ConcludedLicense")
         else:
-            raise OrderError('File::ConcludedLicense')
+            raise OrderError("File::ConcludedLicense")
 
     def set_file_license_in_file(self, doc, lic):
         """
@@ -1097,9 +1145,9 @@ class FileBuilder(object):
                 self.file(doc).add_lics(lic)
                 return True
             else:
-                raise SPDXValueError('File::LicenseInFile')
+                raise SPDXValueError("File::LicenseInFile")
         else:
-            raise OrderError('File::LicenseInFile')
+            raise OrderError("File::LicenseInFile")
 
     def set_file_license_comment(self, doc, text):
         """
@@ -1113,11 +1161,11 @@ class FileBuilder(object):
                 if validations.validate_file_lics_comment(text):
                     self.file(doc).license_comment = str_from_text(text)
                 else:
-                    raise SPDXValueError('File::LicenseComment')
+                    raise SPDXValueError("File::LicenseComment")
             else:
-                raise CardinalityError('File::LicenseComment')
+                raise CardinalityError("File::LicenseComment")
         else:
-            raise OrderError('File::LicenseComment')
+            raise OrderError("File::LicenseComment")
 
     def set_file_copyright(self, doc, text):
         """
@@ -1135,11 +1183,11 @@ class FileBuilder(object):
                         self.file(doc).copyright = text  # None or NoAssert
                     return True
                 else:
-                    raise SPDXValueError('File::CopyRight')
+                    raise SPDXValueError("File::CopyRight")
             else:
-                raise CardinalityError('File::CopyRight')
+                raise CardinalityError("File::CopyRight")
         else:
-            raise OrderError('File::CopyRight')
+            raise OrderError("File::CopyRight")
 
     def set_file_notice(self, doc, text):
         """
@@ -1153,11 +1201,11 @@ class FileBuilder(object):
                 if validations.validate_file_notice(text):
                     self.file(doc).notice = str_from_text(text)
                 else:
-                    raise SPDXValueError('File::Notice')
+                    raise SPDXValueError("File::Notice")
             else:
-                raise CardinalityError('File::Notice')
+                raise CardinalityError("File::Notice")
         else:
-            raise OrderError('File::Notice')
+            raise OrderError("File::Notice")
 
     def add_file_contribution(self, doc, value):
         """
@@ -1166,7 +1214,7 @@ class FileBuilder(object):
         if self.has_package(doc) and self.has_file(doc):
             self.file(doc).add_contrib(value)
         else:
-            raise OrderError('File::Contributor')
+            raise OrderError("File::Contributor")
 
     def add_file_dep(self, doc, value):
         """
@@ -1175,7 +1223,7 @@ class FileBuilder(object):
         if self.has_package(doc) and self.has_file(doc):
             self.file(doc).add_depend(value)
         else:
-            raise OrderError('File::Dependency')
+            raise OrderError("File::Dependency")
 
     def set_file_atrificat_of_project(self, doc, symbol, value):
         """
@@ -1185,8 +1233,7 @@ class FileBuilder(object):
         if self.has_package(doc) and self.has_file(doc):
             self.file(doc).add_artifact(symbol, value)
         else:
-            raise OrderError('File::Artificat')
-
+            raise OrderError("File::Artificat")
 
     def file(self, doc):
         """
@@ -1223,7 +1270,6 @@ class FileBuilder(object):
 
 
 class LicenseBuilder(object):
-
     def __init__(self):
         # FIXME: this state does not make sense
         self.reset_extr_lics()
@@ -1248,7 +1294,7 @@ class LicenseBuilder(object):
             doc.add_extr_lic(document.ExtractedLicense(lic_id))
             return True
         else:
-            raise SPDXValueError('ExtractedLicense::id')
+            raise SPDXValueError("ExtractedLicense::id")
 
     def set_lic_text(self, doc, text):
         """
@@ -1263,11 +1309,11 @@ class LicenseBuilder(object):
                     self.extr_lic(doc).text = str_from_text(text)
                     return True
                 else:
-                    raise SPDXValueError('ExtractedLicense::text')
+                    raise SPDXValueError("ExtractedLicense::text")
             else:
-                raise CardinalityError('ExtractedLicense::text')
+                raise CardinalityError("ExtractedLicense::text")
         else:
-            raise OrderError('ExtractedLicense::text')
+            raise OrderError("ExtractedLicense::text")
 
     def set_lic_name(self, doc, name):
         """
@@ -1282,11 +1328,11 @@ class LicenseBuilder(object):
                     self.extr_lic(doc).full_name = name
                     return True
                 else:
-                    raise SPDXValueError('ExtractedLicense::Name')
+                    raise SPDXValueError("ExtractedLicense::Name")
             else:
-                raise CardinalityError('ExtractedLicense::Name')
+                raise CardinalityError("ExtractedLicense::Name")
         else:
-            raise OrderError('ExtractedLicense::Name')
+            raise OrderError("ExtractedLicense::Name")
 
     def set_lic_comment(self, doc, comment):
         """
@@ -1301,11 +1347,11 @@ class LicenseBuilder(object):
                     self.extr_lic(doc).comment = str_from_text(comment)
                     return True
                 else:
-                    raise SPDXValueError('ExtractedLicense::comment')
+                    raise SPDXValueError("ExtractedLicense::comment")
             else:
-                raise CardinalityError('ExtractedLicense::comment')
+                raise CardinalityError("ExtractedLicense::comment")
         else:
-            raise OrderError('ExtractedLicense::comment')
+            raise OrderError("ExtractedLicense::comment")
 
     def add_lic_xref(self, doc, ref):
         """
@@ -1316,7 +1362,7 @@ class LicenseBuilder(object):
             self.extr_lic(doc).add_xref(ref)
             return True
         else:
-            raise OrderError('ExtractedLicense::CrossRef')
+            raise OrderError("ExtractedLicense::CrossRef")
 
     def reset_extr_lics(self):
         # FIXME: this state does not make sense
@@ -1326,7 +1372,6 @@ class LicenseBuilder(object):
 
 
 class SnippetBuilder(object):
-
     def __init__(self):
         # FIXME: this state does not make sense
         self.reset_snippet()
@@ -1339,13 +1384,13 @@ class SnippetBuilder(object):
         Raise SPDXValueError if the data is a malformed value.
         """
         self.reset_snippet()
-        spdx_id = spdx_id.split('#')[-1]
+        spdx_id = spdx_id.split("#")[-1]
         if validations.validate_snippet_spdx_id(spdx_id):
             doc.add_snippet(snippet.Snippet(spdx_id=spdx_id))
             self.snippet_spdx_id_set = True
             return True
         else:
-            raise SPDXValueError('Snippet::SnippetSPDXID')
+            raise SPDXValueError("Snippet::SnippetSPDXID")
 
     def set_snippet_name(self, doc, name):
         """
@@ -1359,7 +1404,7 @@ class SnippetBuilder(object):
             doc.snippet[-1].name = name
             return True
         else:
-            raise CardinalityError('SnippetName')
+            raise CardinalityError("SnippetName")
 
     def set_snippet_comment(self, doc, comment):
         """
@@ -1375,9 +1420,9 @@ class SnippetBuilder(object):
                 doc.snippet[-1].comment = str_from_text(comment)
                 return True
             else:
-                raise SPDXValueError('Snippet::SnippetComment')
+                raise SPDXValueError("Snippet::SnippetComment")
         else:
-            raise CardinalityError('Snippet::SnippetComment')
+            raise CardinalityError("Snippet::SnippetComment")
 
     def set_snippet_copyright(self, doc, text):
         """Set the snippet's copyright text.
@@ -1394,9 +1439,9 @@ class SnippetBuilder(object):
                 else:
                     doc.snippet[-1].copyright = text  # None or NoAssert
             else:
-                raise SPDXValueError('Snippet::SnippetCopyrightText')
+                raise SPDXValueError("Snippet::SnippetCopyrightText")
         else:
-            raise CardinalityError('Snippet::SnippetCopyrightText')
+            raise CardinalityError("Snippet::SnippetCopyrightText")
 
     def set_snippet_lic_comment(self, doc, text):
         """
@@ -1412,9 +1457,9 @@ class SnippetBuilder(object):
                 doc.snippet[-1].license_comment = str_from_text(text)
                 return True
             else:
-                raise SPDXValueError('Snippet::SnippetLicenseComments')
+                raise SPDXValueError("Snippet::SnippetLicenseComments")
         else:
-            raise CardinalityError('Snippet::SnippetLicenseComments')
+            raise CardinalityError("Snippet::SnippetLicenseComments")
 
     def set_snip_from_file_spdxid(self, doc, snip_from_file_spdxid):
         """
@@ -1424,16 +1469,16 @@ class SnippetBuilder(object):
         Raise SPDXValueError if the data is a malformed value.
         """
         self.assert_snippet_exists()
-        snip_from_file_spdxid = snip_from_file_spdxid.split('#')[-1]
+        snip_from_file_spdxid = snip_from_file_spdxid.split("#")[-1]
         if not self.snip_file_spdxid_set:
             self.snip_file_spdxid_set = True
             if validations.validate_snip_file_spdxid(snip_from_file_spdxid):
                 doc.snippet[-1].snip_from_file_spdxid = snip_from_file_spdxid
                 return True
             else:
-                raise SPDXValueError('Snippet::SnippetFromFileSPDXID')
+                raise SPDXValueError("Snippet::SnippetFromFileSPDXID")
         else:
-            raise CardinalityError('Snippet::SnippetFromFileSPDXID')
+            raise CardinalityError("Snippet::SnippetFromFileSPDXID")
 
     def set_snip_concluded_license(self, doc, conc_lics):
         """
@@ -1448,9 +1493,9 @@ class SnippetBuilder(object):
                 doc.snippet[-1].conc_lics = conc_lics
                 return True
             else:
-                raise SPDXValueError('Snippet::SnippetLicenseConcluded')
+                raise SPDXValueError("Snippet::SnippetLicenseConcluded")
         else:
-            raise CardinalityError('Snippet::SnippetLicenseConcluded')
+            raise CardinalityError("Snippet::SnippetLicenseConcluded")
 
     def set_snippet_lics_info(self, doc, lics_info):
         """
@@ -1462,7 +1507,7 @@ class SnippetBuilder(object):
             doc.snippet[-1].add_lics(lics_info)
             return True
         else:
-            raise SPDXValueError('Snippet::LicenseInfoInSnippet')
+            raise SPDXValueError("Snippet::LicenseInfoInSnippet")
 
     def reset_snippet(self):
         # FIXME: this state does not make sense
@@ -1476,12 +1521,22 @@ class SnippetBuilder(object):
 
     def assert_snippet_exists(self):
         if not self.snippet_spdx_id_set:
-            raise OrderError('Snippet')
+            raise OrderError("Snippet")
 
 
-class Builder(DocBuilder, CreationInfoBuilder, EntityBuilder, ReviewBuilder,
-              PackageBuilder, FileBuilder, LicenseBuilder, SnippetBuilder,
-              ExternalDocumentRefBuilder, AnnotationBuilder):
+class Builder(
+    DocBuilder,
+    CreationInfoBuilder,
+    EntityBuilder,
+    ReviewBuilder,
+    PackageBuilder,
+    FileBuilder,
+    LicenseBuilder,
+    SnippetBuilder,
+    ExternalDocumentRefBuilder,
+    AnnotationBuilder,
+    RelationshipBuilder,
+):
 
     """
     SPDX document builder.
@@ -1506,3 +1561,4 @@ class Builder(DocBuilder, CreationInfoBuilder, EntityBuilder, ReviewBuilder,
         self.reset_annotations()
         self.reset_extr_lics()
         self.reset_snippet()
+        self.reset_relationship()

--- a/spdx/parsers/tagvaluebuilders.py
+++ b/spdx/parsers/tagvaluebuilders.py
@@ -539,12 +539,12 @@ class RelationshipBuilder(object):
         # FIXME: this state does not make sense
         self.relationship_comment_set = False
 
-    def add_relationship(self, doc, relationship):
+    def add_relationship(self, doc, relationship_term):
         """
         Raise SPDXValueError if type is unknown.
         """
         self.reset_relationship()
-        doc.add_relationship(relationship.Relationship(relationship=relationship))
+        doc.add_relationship(relationship.Relationship(relationship=relationship_term))
         return True
 
     def add_relationship_comment(self, doc, comment):

--- a/spdx/parsers/tagvaluebuilders.py
+++ b/spdx/parsers/tagvaluebuilders.py
@@ -544,7 +544,7 @@ class RelationshipBuilder(object):
         Raise SPDXValueError if type is unknown.
         """
         self.reset_relationship()
-        doc.add_relationship(relationship.Relationship(relationship=relationship_term))
+        doc.add_relationships(relationship.Relationship(relationship_term))
         return True
 
     def add_relationship_comment(self, doc, comment):

--- a/spdx/parsers/validations.py
+++ b/spdx/parsers/validations.py
@@ -1,4 +1,3 @@
-
 # Copyright (c) 2014 Ahmed H. Ismail
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -25,7 +24,7 @@ from spdx import document
 
 
 def validate_is_free_form_text(value, optional=False):
-    TEXT_RE = re.compile(r'<text>(.|\n)*</text>', re.UNICODE)
+    TEXT_RE = re.compile(r"<text>(.|\n)*</text>", re.UNICODE)
     if value is None:
         return optional
     else:
@@ -52,7 +51,7 @@ def validate_org_name(value, optional=False):
 
 
 def validate_data_lics(value):
-    return value == 'CC0-1.0'
+    return value == "CC0-1.0"
 
 
 def validate_doc_name(value, optional=False):
@@ -62,7 +61,9 @@ def validate_doc_name(value, optional=False):
 def validate_pkg_supplier(value, optional=False):
     if optional and value is None:
         return True
-    elif isinstance(value, (utils.NoAssert, creationinfo.Person, creationinfo.Organization)):
+    elif isinstance(
+        value, (utils.NoAssert, creationinfo.Person, creationinfo.Organization)
+    ):
         return True
     else:
         return False
@@ -105,14 +106,14 @@ def validate_pkg_comment(value, optional=False):
 
 
 def validate_pkg_ext_ref_category(value, optional=False):
-    if value.upper() in ['SECURITY', 'OTHER', 'PACKAGE-MANAGER']:
+    if value.upper() in ["SECURITY", "OTHER", "PACKAGE-MANAGER"]:
         return True
     else:
         return False
 
 
 def validate_pkg_ext_ref_type(value, optional=False):
-    if re.match(r'^[A-Za-z0-9.\-]+$', value) is not None:
+    if re.match(r"^[A-Za-z0-9.\-]+$", value) is not None:
         return True
     else:
         return False
@@ -129,7 +130,7 @@ def validate_doc_comment(value, optional=False):
 def validate_doc_spdx_id(value, optional=False):
     if value is None:
         return optional
-    elif value.endswith('#SPDXRef-DOCUMENT'):
+    elif value.endswith("#SPDXRef-DOCUMENT"):
         return True
     else:
         return False
@@ -138,9 +139,11 @@ def validate_doc_spdx_id(value, optional=False):
 def validate_doc_namespace(value, optional=False):
     if value is None:
         return optional
-    elif ((value.startswith('http://') or value.startswith(
-            'https://') or
-           value.startswith('ftp://')) and ('#' not in value)):
+    elif (
+        value.startswith("http://")
+        or value.startswith("https://")
+        or value.startswith("ftp://")
+    ) and ("#" not in value):
         return True
     else:
         return False
@@ -175,15 +178,19 @@ def validate_annotation_comment(value, optional=False):
 
 def validate_annotation_type(value, optional=False):
     value = value.strip()
-    if value == 'REVIEW' or value == 'OTHER':
+    if value == "REVIEW" or value == "OTHER":
         return True
     else:
         return False
 
 
+def validate_relationship_comment(value, optional=False):
+    return validate_is_free_form_text(value, optional)
+
+
 def validate_pkg_spdx_id(value, optional=False):
-    value = value.split('#')[-1]
-    TEXT_RE = re.compile(r'SPDXRef-([A-Za-z0-9\.\-]+)', re.UNICODE)
+    value = value.split("#")[-1]
+    TEXT_RE = re.compile(r"SPDXRef-([A-Za-z0-9\.\-]+)", re.UNICODE)
     if value is None:
         return optional
     else:
@@ -191,7 +198,7 @@ def validate_pkg_spdx_id(value, optional=False):
 
 
 def validate_pkg_files_analyzed(value, optional=False):
-    if value in ['True', 'true', 'False', 'false']:
+    if value in ["True", "true", "False", "false"]:
         return True
     else:
         return optional
@@ -206,8 +213,8 @@ def validate_pkg_lics_comment(value, optional=False):
 
 
 def validate_file_spdx_id(value, optional=False):
-    value = value.split('#')[-1]
-    TEXT_RE = re.compile(r'SPDXRef-([A-Za-z0-9.\-]+)', re.UNICODE)
+    value = value.split("#")[-1]
+    TEXT_RE = re.compile(r"SPDXRef-([A-Za-z0-9.\-]+)", re.UNICODE)
     if value is None:
         return optional
     else:
@@ -239,6 +246,7 @@ def validate_lics_from_file(value, optional=False):
     else:
         return False
 
+
 def validate_file_notice(value, optional=False):
     return validate_is_free_form_text(value, optional)
 
@@ -265,7 +273,7 @@ def validate_extracted_lic_id(value, optional=False):
     if value is None:
         return optional
     else:
-        return value.startswith('LicenseRef-')
+        return value.startswith("LicenseRef-")
 
 
 def validate_extr_lic_name(value, optional=False):
@@ -276,8 +284,8 @@ def validate_extr_lic_name(value, optional=False):
 
 
 def validate_snippet_spdx_id(value, optional=False):
-    value = value.split('#')[-1]
-    if re.match(r'^SPDXRef[A-Za-z0-9.\-]+$', value) is not None:
+    value = value.split("#")[-1]
+    if re.match(r"^SPDXRef[A-Za-z0-9.\-]+$", value) is not None:
         return True
     else:
         return False
@@ -303,8 +311,10 @@ def validate_snip_lic_comment(value, optional=False):
 
 
 def validate_snip_file_spdxid(value, optional=False):
-    if re.match(
-            r'(DocumentRef[A-Za-z0-9.\-]+:){0,1}SPDXRef[A-Za-z0-9.\-]+', value) is not None:
+    if (
+        re.match(r"(DocumentRef[A-Za-z0-9.\-]+:){0,1}SPDXRef[A-Za-z0-9.\-]+", value)
+        is not None
+    ):
         return True
     else:
         return False

--- a/spdx/parsers/xmlparser.py
+++ b/spdx/parsers/xmlparser.py
@@ -1,4 +1,3 @@
-
 # Copyright (c) Xavier Figueroa
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -27,19 +26,35 @@ class Parser(jsonyamlxml.Parser):
     RDF and TV Parser classes (i.e., spdx.parsers.<format name>.Parser) for XML parser.
     It also avoids to repeat jsonyamlxml.Parser.parse code for JSON, YAML and XML parsers
     """
+
     def __init__(self, builder, logger):
         super(Parser, self).__init__(builder, logger)
         self.LIST_LIKE_FIELDS = {
-            'creators', 'externalDocumentRefs', 'extractedLicenseInfos',
-            'seeAlso', 'annotations', 'snippets', 'licenseInfoFromSnippet', 'reviewers', 'fileTypes',
-            'licenseInfoFromFiles', 'artifactOf', 'fileContributors', 'fileDependencies',
-            'excludedFilesNames', 'files', 'documentDescribes'
+            "creators",
+            "externalDocumentRefs",
+            "extractedLicenseInfos",
+            "seeAlso",
+            "annotations",
+            "relationships",
+            "snippets",
+            "licenseInfoFromSnippet",
+            "reviewers",
+            "fileTypes",
+            "licenseInfoFromFiles",
+            "artifactOf",
+            "fileContributors",
+            "fileDependencies",
+            "excludedFilesNames",
+            "files",
+            "documentDescribes",
         }
 
     def parse(self, file):
-        parsed_xml = xmltodict.parse(file.read(), strip_whitespace=False, encoding='utf-8')
+        parsed_xml = xmltodict.parse(
+            file.read(), strip_whitespace=False, encoding="utf-8"
+        )
         fixed_object = self._set_in_list(parsed_xml, self.LIST_LIKE_FIELDS)
-        self.document_object = fixed_object.get('SpdxDocument').get('Document')
+        self.document_object = fixed_object.get("SpdxDocument").get("Document")
         return super(Parser, self).parse()
 
     def _set_in_list(self, data, keys):

--- a/spdx/relationship.py
+++ b/spdx/relationship.py
@@ -14,10 +14,55 @@ from __future__ import absolute_import
 from __future__ import print_function
 from __future__ import unicode_literals
 
-from functools import total_ordering
+from enum import Enum, auto
 
 
-@total_ordering
+class RelationshipType(Enum):
+    AMENDS = auto()
+    OTHER = auto()
+    COPY_OF = auto()
+    TEST_OF = auto()
+    ANCESTOR_OF = auto()
+    BUILD_DEPENDENCY_OF = auto()
+    BUILD_TOOL_OF = auto()
+    CONTAINED_BY = auto()
+    CONTAINS = auto()
+    DATA_FILE_OF = auto()
+    DEPENDENCY_MANIFEST_OF = auto()
+    DEPENDENCY_OF = auto()
+    DEPENDS_ON = auto()
+    DESCENDANT_OF = auto()
+    DESCRIBED_BY = auto()
+    DESCRIBES = auto()
+    DEV_DEPENDENCY_OF = auto()
+    DEV_TOOL_OF = auto()
+    DISTRIBUTION_ARTIFACT = auto()
+    DOCUMENTATION_OF = auto()
+    DYNAMIC_LINK = auto()
+    EXAMPLE_OF = auto()
+    EXPANDED_FROM_ARCHIVE = auto()
+    FILE_ADDED = auto()
+    FILE_DELETED = auto()
+    FILE_MODIFIED = auto()
+    GENERATED_FROM = auto()
+    GENERATES = auto()
+    HAS_PREREQUISITE = auto()
+    METAFILE_OF = auto()
+    OPTIONAL_COMPONENT_OF = auto()
+    OPTIONAL_DEPENDENCY_OF = auto()
+    PACKAGE_OF = auto()
+    PATCH_APPLIED = auto()
+    PATCH_FOR = auto()
+    PREREQUISITE_FOR = auto()
+    PROVIDED_DEPENDENCY_OF = auto()
+    RUNTIME_DEPENDENCY_OF = auto()
+    STATIC_LINK = auto()
+    TEST_CASE_OF = auto()
+    TEST_DEPENDENCY_OF = auto()
+    TEST_TOOL_OF = auto()
+    VARIANT_OF = auto()
+
+
 class Relationship(object):
     """
     Document relationship information
@@ -29,19 +74,6 @@ class Relationship(object):
     def __init__(self, relationship=None, relationship_comment=None):
         self.relationship = relationship
         self.relationship_comment = relationship_comment
-
-    def __eq__(self, other):
-        return (
-            isinstance(other, Relationship)
-            and self.relationship == other.relationship
-            and self.relationship_comment == other.relationship_comment
-        )
-
-    def __lt__(self, other):
-        return (self.relationship, self.relationship_comment) < (
-            other.relationship,
-            other.relationship_comment,
-        )
 
     @property
     def has_comment(self):
@@ -58,53 +90,7 @@ class Relationship(object):
     def validate_relationship(self, messages):
         messages = messages if messages is not None else []
         r_type = self.relationship.split(" ")[1]
-        if r_type not in [
-            None,
-            "AMENDS",
-            "OTHER",
-            "COPY_OF",
-            "TEST_OF",
-            "ANCESTOR_OF",
-            "BUILD_DEPENDENCY_OF",
-            "BUILD_TOOL_OF",
-            "CONTAINED_BY",
-            "CONTAINS",
-            "DATA_FILE_OF",
-            "DEPENDENCY_MANIFEST_OF",
-            "DEPENDENCY_OF",
-            "DEPENDS_ON",
-            "DESCENDANT_OF",
-            "DESCRIBED_BY",
-            "DESCRIBES",
-            "DEV_DEPENDENCY_OF",
-            "DEV_TOOL_OF",
-            "DISTRIBUTION_ARTIFACT",
-            "DOCUMENTATION_OF",
-            "DYNAMIC_LINK",
-            "EXAMPLE_OF",
-            "EXPANDED_FROM_ARCHIVE",
-            "FILE_ADDED",
-            "FILE_DELETED",
-            "FILE_MODIFIED",
-            "GENERATED_FROM",
-            "GENERATES",
-            "HAS_PREREQUISITE",
-            "METAFILE_OF",
-            "OPTIONAL_COMPONENT_OF",
-            "OPTIONAL_DEPENDENCY_OF",
-            "PACKAGE_OF",
-            "PATCH_APPLIED",
-            "PATCH_FOR",
-            "PREREQUISITE_FOR",
-            "PROVIDED_DEPENDENCY_OF",
-            "RUNTIME_DEPENDENCY_OF",
-            "STATIC_LINK",
-            "TEST_CASE_OF",
-            "TEST_DEPENDENCY_OF",
-            "TEST_TOOL_OF",
-            "VARIANT_OF",
-        ]:
-
+        if r_type not in [name for name, _ in RelationshipType.__members__.items()]:
             messages = messages + [
                 "Relationship type must be one of the constants defined in "
                 "class spdx.relationship.Relationship"

--- a/spdx/relationship.py
+++ b/spdx/relationship.py
@@ -1,0 +1,114 @@
+# Copyright (c) 2020 Yash Varshney
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#    http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import
+from __future__ import print_function
+from __future__ import unicode_literals
+
+from functools import total_ordering
+
+
+@total_ordering
+class Relationship(object):
+    """
+    Document relationship information
+    Fields:
+    - relationship:  provides information about the relationship between two SPDX elements.
+    - relationship_comment :  place for the SPDX file creator to record any general comments. Optional, One
+    """
+
+    def __init__(self, relationship=None, relationship_comment=None):
+        self.relationship = relationship
+        self.relationship_comment = relationship_comment
+
+    def __eq__(self, other):
+        return (
+            isinstance(other, Relationship)
+            and self.relationship == other.relationship
+            and self.relationship_comment == other.relationship_comment
+        )
+
+    def __lt__(self, other):
+        return (self.relationship, self.relationship_comment) < (
+            other.relationship,
+            other.relationship_comment,
+        )
+
+    @property
+    def has_comment(self):
+        return self.relationship_comment is not None
+
+    def validate(self, messages):
+        """Returns True if all the fields are valid.
+        Appends any error messages to messages parameter.
+        """
+        messages = self.validate_relationship(messages)
+
+        return messages
+
+    def validate_relationship(self, messages):
+        messages = messages if messages is not None else []
+        r_type = self.relationship.split(" ")[1]
+        if r_type not in [
+            None,
+            "AMENDS",
+            "OTHER",
+            "COPY_OF",
+            "TEST_OF",
+            "ANCESTOR_OF",
+            "BUILD_DEPENDENCY_OF",
+            "BUILD_TOOL_OF",
+            "CONTAINED_BY",
+            "CONTAINS",
+            "DATA_FILE_OF",
+            "DEPENDENCY_MANIFEST_OF",
+            "DEPENDENCY_OF",
+            "DEPENDS_ON",
+            "DESCENDANT_OF",
+            "DESCRIBED_BY",
+            "DESCRIBES",
+            "DEV_DEPENDENCY_OF",
+            "DEV_TOOL_OF",
+            "DISTRIBUTION_ARTIFACT",
+            "DOCUMENTATION_OF",
+            "DYNAMIC_LINK",
+            "EXAMPLE_OF",
+            "EXPANDED_FROM_ARCHIVE",
+            "FILE_ADDED",
+            "FILE_DELETED",
+            "FILE_MODIFIED",
+            "GENERATED_FROM",
+            "GENERATES",
+            "HAS_PREREQUISITE",
+            "METAFILE_OF",
+            "OPTIONAL_COMPONENT_OF",
+            "OPTIONAL_DEPENDENCY_OF",
+            "PACKAGE_OF",
+            "PATCH_APPLIED",
+            "PATCH_FOR",
+            "PREREQUISITE_FOR",
+            "PROVIDED_DEPENDENCY_OF",
+            "RUNTIME_DEPENDENCY_OF",
+            "STATIC_LINK",
+            "TEST_CASE_OF",
+            "TEST_DEPENDENCY_OF",
+            "TEST_TOOL_OF",
+            "VARIANT_OF",
+        ]:
+
+            messages = messages + [
+                "Relationship type must be one of the constants defined in "
+                "class spdx.relationship.Relationship"
+            ]
+            return messages
+        else:
+            return True

--- a/spdx/relationship.py
+++ b/spdx/relationship.py
@@ -14,7 +14,17 @@ from __future__ import absolute_import
 from __future__ import print_function
 from __future__ import unicode_literals
 
-from enum import Enum, auto
+from enum import Enum
+
+# Implement the auto feature that becomes available in 3.6
+autoinc = 0
+
+
+def auto():
+    global autoinc
+    autoval = autoinc
+    autoinc += 1
+    return autoval
 
 
 class RelationshipType(Enum):

--- a/spdx/relationship.py
+++ b/spdx/relationship.py
@@ -89,6 +89,18 @@ class Relationship(object):
     def has_comment(self):
         return self.relationship_comment is not None
 
+    @property
+    def spdxelementid(self):
+        return self.relationship.split(" ")[0]
+
+    @property
+    def relationshiptype(self):
+        return self.relationship.split(" ")[1]
+
+    @property
+    def relatedspdxelement(self):
+        return self.relationship.split(" ")[2]
+
     def validate(self, messages):
         """Returns True if all the fields are valid.
         Appends any error messages to messages parameter.

--- a/spdx/writers/jsonyamlxml.py
+++ b/spdx/writers/jsonyamlxml.py
@@ -306,14 +306,15 @@ class RelationshipInfoWriter(BaseWriter):
     def create_relationship_info(self):
         relationship_objects = []
 
-        for relationship in self.document.relationships:
+        for relationship_term in self.document.relationships:
             relationship_object = dict()
-            relationship_split = relationship.relationship.split(" ")
-            relationship_object["spdxElementId"] = relationship_split[0]
-            relationship_object["relatedSpdxElement"] = relationship_split[2]
-            relationship_object["relationshipType"] = relationship_split[1]
-            if relationship.has_comment:
-                relationship_object["comment"] = relationship.relationship_comment
+            relationship_object["spdxElementId"] = relationship_term.spdxelementid
+            relationship_object[
+                "relatedSpdxElement"
+            ] = relationship_term.relatedspdxelement
+            relationship_object["relationshipType"] = relationship_term.relationshiptype
+            if relationship_term.has_comment:
+                relationship_object["comment"] = relationship_term.relationship_comment
 
             relationship_objects.append(relationship_object)
 

--- a/spdx/writers/jsonyamlxml.py
+++ b/spdx/writers/jsonyamlxml.py
@@ -1,4 +1,3 @@
-
 # Copyright (c) Xavier Figueroa
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -35,8 +34,10 @@ class BaseWriter(object):
         """
         Return a string representation of a license or spdx.utils special object
         """
-        if isinstance(license_field, (document.LicenseDisjunction, document.LicenseConjunction)):
-            return '({})'.format(license_field)
+        if isinstance(
+            license_field, (document.LicenseDisjunction, document.LicenseConjunction)
+        ):
+            return "({})".format(license_field)
 
         if isinstance(license_field, document.License):
             license_str = license_field.identifier.__str__()
@@ -49,12 +50,15 @@ class BaseWriter(object):
         Return a dictionary representation of a spdx.checksum.Algorithm object
         """
         checksum_object = dict()
-        checksum_object['algorithm'] = 'checksumAlgorithm_' + checksum_field.identifier.lower()
-        checksum_object['value'] = checksum_field.value
+        checksum_object["algorithm"] = (
+            "checksumAlgorithm_" + checksum_field.identifier.lower()
+        )
+        checksum_object["value"] = checksum_field.value
         return checksum_object
 
     def spdx_id(self, spdx_id_field):
-        return spdx_id_field.__str__().split('#')[-1]
+        return spdx_id_field.__str__().split("#")[-1]
+
 
 class CreationInfoWriter(BaseWriter):
     """
@@ -67,16 +71,20 @@ class CreationInfoWriter(BaseWriter):
     def create_creation_info(self):
         creation_info_object = dict()
         creation_info = self.document.creation_info
-        creation_info_object['creators'] = list(map(str, creation_info.creators))
-        creation_info_object['created'] = creation_info.created_iso_format
+        creation_info_object["creators"] = list(map(str, creation_info.creators))
+        creation_info_object["created"] = creation_info.created_iso_format
 
         if creation_info.license_list_version:
-            creation_info_object['licenseListVersion'] = '{0}.{1}'.format(creation_info.license_list_version.major, creation_info.license_list_version.minor)
+            creation_info_object["licenseListVersion"] = "{0}.{1}".format(
+                creation_info.license_list_version.major,
+                creation_info.license_list_version.minor,
+            )
 
         if creation_info.has_comment:
-            creation_info_object['comment'] = creation_info.comment
+            creation_info_object["comment"] = creation_info.comment
 
         return creation_info_object
+
 
 class PackageWriter(BaseWriter):
     """
@@ -94,57 +102,64 @@ class PackageWriter(BaseWriter):
 
         package_verification_code_object = dict()
 
-        package_verification_code_object['value'] = package.verif_code
+        package_verification_code_object["value"] = package.verif_code
 
         if package.verif_exc_files:
-            package_verification_code_object['excludedFilesNames'] = package.verif_exc_files
+            package_verification_code_object[
+                "excludedFilesNames"
+            ] = package.verif_exc_files
 
         return package_verification_code_object
 
     def create_package_info(self):
         package_object = dict()
         package = self.document.package
-        package_object['id'] = self.spdx_id(package.spdx_id)
-        package_object['name'] = package.name
-        package_object['downloadLocation'] = package.download_location.__str__()
-        package_object['packageVerificationCode'] = self.package_verification_code(package)
-        package_object['licenseConcluded'] = self.license(package.conc_lics)
-        package_object['licenseInfoFromFiles'] = list(map(self.license, package.licenses_from_files))
-        package_object['licenseDeclared'] = self.license(package.license_declared)
-        package_object['copyrightText'] = package.cr_text.__str__()
+        package_object["id"] = self.spdx_id(package.spdx_id)
+        package_object["name"] = package.name
+        package_object["downloadLocation"] = package.download_location.__str__()
+        package_object["packageVerificationCode"] = self.package_verification_code(
+            package
+        )
+        package_object["licenseConcluded"] = self.license(package.conc_lics)
+        package_object["licenseInfoFromFiles"] = list(
+            map(self.license, package.licenses_from_files)
+        )
+        package_object["licenseDeclared"] = self.license(package.license_declared)
+        package_object["copyrightText"] = package.cr_text.__str__()
 
-        if package.has_optional_field('version'):
-            package_object['versionInfo'] = package.version
+        if package.has_optional_field("version"):
+            package_object["versionInfo"] = package.version
 
-        if package.has_optional_field('summary'):
-            package_object['summary'] = package.summary
+        if package.has_optional_field("summary"):
+            package_object["summary"] = package.summary
 
-        if package.has_optional_field('source_info'):
-            package_object['sourceInfo'] = package.source_info
+        if package.has_optional_field("source_info"):
+            package_object["sourceInfo"] = package.source_info
 
-        if package.has_optional_field('file_name'):
-            package_object['packageFileName'] = package.file_name
+        if package.has_optional_field("file_name"):
+            package_object["packageFileName"] = package.file_name
 
-        if package.has_optional_field('supplier'):
-            package_object['supplier'] = package.supplier.__str__()
+        if package.has_optional_field("supplier"):
+            package_object["supplier"] = package.supplier.__str__()
 
-        if package.has_optional_field('originator'):
-            package_object['originator'] = package.originator.__str__()
+        if package.has_optional_field("originator"):
+            package_object["originator"] = package.originator.__str__()
 
-        if package.has_optional_field('check_sum'):
-            package_object['checksums'] = [self.checksum(package.check_sum)]
-            package_object['sha1'] = package.check_sum.value
+        if package.has_optional_field("check_sum"):
+            package_object["checksums"] = [self.checksum(package.check_sum)]
+            package_object["sha1"] = package.check_sum.value
 
-        if package.has_optional_field('description'):
-            package_object['description'] = package.description
+        if package.has_optional_field("description"):
+            package_object["description"] = package.description
 
-        if package.has_optional_field('license_comment'):
-            package_object['licenseComments'] = package.license_comment
+        if package.has_optional_field("license_comment"):
+            package_object["licenseComments"] = package.license_comment
 
-        if package.has_optional_field('homepage'):
-            package_object['homepage'] = package.homepage.__str__()
+        if package.has_optional_field("homepage"):
+            package_object["homepage"] = package.homepage.__str__()
 
         return package_object
+
 
 class FileWriter(BaseWriter):
     """
@@ -162,55 +177,69 @@ class FileWriter(BaseWriter):
 
         for i in range(len(file.artifact_of_project_name)):
             artifact_of_object = dict()
-            artifact_of_object['name'] = file.artifact_of_project_name[i].__str__()
-            artifact_of_object['homePage'] = file.artifact_of_project_home[i].__str__()
-            artifact_of_object['projectUri'] = file.artifact_of_project_uri[i].__str__()
+            artifact_of_object["name"] = file.artifact_of_project_name[i].__str__()
+            artifact_of_object["homePage"] = file.artifact_of_project_home[i].__str__()
+            artifact_of_object["projectUri"] = file.artifact_of_project_uri[i].__str__()
             artifact_of_objects.append(artifact_of_object)
 
         return artifact_of_objects
 
     def create_file_info(self):
-        file_types = { 1: 'fileType_source', 2: 'fileType_binary', 3: 'fileType_archive', 4: 'fileType_other'}
+        file_types = {
+            1: "fileType_source",
+            2: "fileType_binary",
+            3: "fileType_archive",
+            4: "fileType_other",
+        }
         file_objects = []
         files = self.document.files
 
         for file in files:
             file_object = dict()
 
-            file_object['name'] = file.name
-            file_object['id'] = self.spdx_id(file.spdx_id)
-            file_object['checksums'] = [self.checksum(file.chk_sum)]
-            file_object['licenseConcluded'] = self.license(file.conc_lics)
-            file_object['licenseInfoFromFiles'] = list(map(self.license, file.licenses_in_file))
-            file_object['copyrightText'] = file.copyright.__str__()
-            file_object['sha1'] = file.chk_sum.value
+            file_object["name"] = file.name
+            file_object["id"] = self.spdx_id(file.spdx_id)
+            file_object["checksums"] = [self.checksum(file.chk_sum)]
+            file_object["licenseConcluded"] = self.license(file.conc_lics)
+            file_object["licenseInfoFromFiles"] = list(
+                map(self.license, file.licenses_in_file)
+            )
+            file_object["copyrightText"] = file.copyright.__str__()
+            file_object["sha1"] = file.chk_sum.value
 
-            if file.has_optional_field('comment'):
-                file_object['comment'] = file.comment
+            if file.has_optional_field("comment"):
+                file_object["comment"] = file.comment
 
-            if file.has_optional_field('type'):
-                file_object['fileTypes'] = [file_types.get(file.type)]
+            if file.has_optional_field("type"):
+                file_object["fileTypes"] = [file_types.get(file.type)]
 
-            if file.has_optional_field('license_comment'):
-                file_object['licenseComments'] = file.license_comment
+            if file.has_optional_field("license_comment"):
+                file_object["licenseComments"] = file.license_comment
 
-            if file.has_optional_field('notice'):
-                file_object['noticeText'] = file.notice
+            if file.has_optional_field("notice"):
+                file_object["noticeText"] = file.notice
 
             if file.contributors:
-                file_object['fileContributors'] = file.contributors.__str__()
+                file_object["fileContributors"] = file.contributors.__str__()
 
             if file.dependencies:
-                file_object['fileDependencies'] = file.dependencies
+                file_object["fileDependencies"] = file.dependencies
 
-            valid_artifacts = file.artifact_of_project_name and len(file.artifact_of_project_name) == len(file.artifact_of_project_home) and len(file.artifact_of_project_home) == len(file.artifact_of_project_uri)
+            valid_artifacts = (
+                file.artifact_of_project_name
+                and len(file.artifact_of_project_name)
+                == len(file.artifact_of_project_home)
+                and len(file.artifact_of_project_home)
+                == len(file.artifact_of_project_uri)
+            )
 
             if valid_artifacts:
-                file_object['artifactOf'] = self.create_artifact_info(file)
+                file_object["artifactOf"] = self.create_artifact_info(file)
 
             file_objects.append({"File": file_object})
 
         return file_objects
+
 
 class ReviewInfoWriter(BaseWriter):
     """
@@ -226,14 +255,15 @@ class ReviewInfoWriter(BaseWriter):
 
         for review in reviews:
             review_object = dict()
-            review_object['reviewer'] = review.reviewer.__str__()
-            review_object['reviewDate'] = review.review_date_iso_format
+            review_object["reviewer"] = review.reviewer.__str__()
+            review_object["reviewDate"] = review.review_date_iso_format
             if review.has_comment:
-                review_object['comment'] = review.comment
+                review_object["comment"] = review.comment
 
             review_info_objects.append(review_object)
 
         return review_info_objects
+
 
 class AnnotationInfoWriter(BaseWriter):
     """
@@ -254,20 +284,47 @@ class AnnotationInfoWriter(BaseWriter):
 
         for annotation in self.document.annotations:
             annotation_object = dict()
-            annotation_object['id'] = self.spdx_id(annotation.spdx_id)
-            annotation_object['annotator'] = annotation.annotator.__str__()
-            annotation_object['annotationDate'] = annotation.annotation_date_iso_format
-            annotation_object['annotationType'] = annotation.annotation_type
-            annotation_object['comment'] = annotation.comment
+            annotation_object["id"] = self.spdx_id(annotation.spdx_id)
+            annotation_object["annotator"] = annotation.annotator.__str__()
+            annotation_object["annotationDate"] = annotation.annotation_date_iso_format
+            annotation_object["annotationType"] = annotation.annotation_type
+            annotation_object["comment"] = annotation.comment
 
             annotation_objects.append(annotation_object)
 
         return annotation_objects
 
+
+class RelationshipInfoWriter(BaseWriter):
+    """
+    Represent spdx.relationship as json-serializable objects
+    """
+
+    def __init__(self, document):
+        super(RelationshipInfoWriter, self).__init__(document)
+
+    def create_relationship_info(self):
+        relationship_objects = []
+
+        for relationship in self.document.relationships:
+            relationship_object = dict()
+            relationship_split = relationship.relationship.split(" ")
+            relationship_object["spdxElementId"] = relationship_split[0]
+            relationship_object["relatedSpdxElement"] = relationship_split[2]
+            relationship_object["relationshipType"] = relationship_split[1]
+            if relationship.has_comment:
+                relationship_object["comment"] = relationship.relationship_comment
+
+            relationship_objects.append(relationship_object)
+
+        return relationship_objects
+
+
 class SnippetWriter(BaseWriter):
     """
-    Represent spdx.annotation as json-serializable objects
+    Represent spdx.snippet as json-serializable objects
     """
+
     def __init__(self, document):
         super(SnippetWriter, self).__init__(document)
 
@@ -277,24 +334,27 @@ class SnippetWriter(BaseWriter):
 
         for snippet in snippets:
             snippet_object = dict()
-            snippet_object['id'] = self.spdx_id(snippet.spdx_id)
-            snippet_object['copyrightText'] = snippet.copyright
-            snippet_object['fileId'] = self.spdx_id(snippet.snip_from_file_spdxid)
-            snippet_object['licenseConcluded'] = self.license(snippet.conc_lics)
-            snippet_object['licenseInfoFromSnippet'] = list(map(self.license, snippet.licenses_in_snippet))
+            snippet_object["id"] = self.spdx_id(snippet.spdx_id)
+            snippet_object["copyrightText"] = snippet.copyright
+            snippet_object["fileId"] = self.spdx_id(snippet.snip_from_file_spdxid)
+            snippet_object["licenseConcluded"] = self.license(snippet.conc_lics)
+            snippet_object["licenseInfoFromSnippet"] = list(
+                map(self.license, snippet.licenses_in_snippet)
+            )
 
-            if snippet.has_optional_field('name'):
-                snippet_object['name'] = snippet.name
+            if snippet.has_optional_field("name"):
+                snippet_object["name"] = snippet.name
 
-            if snippet.has_optional_field('comment'):
-                snippet_object['comment'] = snippet.comment
+            if snippet.has_optional_field("comment"):
+                snippet_object["comment"] = snippet.comment
 
-            if snippet.has_optional_field('license_comment'):
-                snippet_object['licenseComments'] = snippet.license_comment
+            if snippet.has_optional_field("license_comment"):
+                snippet_object["licenseComments"] = snippet.license_comment
 
             snippet_info_objects.append(snippet_object)
 
         return snippet_info_objects
+
 
 class ExtractedLicenseWriter(BaseWriter):
     """
@@ -312,39 +372,58 @@ class ExtractedLicenseWriter(BaseWriter):
             extracted_license_object = dict()
 
             if isinstance(extracted_license.identifier, Literal):
-                extracted_license_object['licenseId'] = extracted_license.identifier.toPython()
+                extracted_license_object[
+                    "licenseId"
+                ] = extracted_license.identifier.toPython()
             else:
-                extracted_license_object['licenseId'] = extracted_license.identifier
+                extracted_license_object["licenseId"] = extracted_license.identifier
 
             if isinstance(extracted_license.text, Literal):
-                extracted_license_object['extractedText'] = extracted_license.text.toPython()
+                extracted_license_object[
+                    "extractedText"
+                ] = extracted_license.text.toPython()
             else:
-                extracted_license_object['extractedText'] = extracted_license.text
+                extracted_license_object["extractedText"] = extracted_license.text
 
             if extracted_license.full_name:
                 if isinstance(extracted_license.full_name, Literal):
-                    extracted_license_object['name'] = extracted_license.full_name.toPython()
+                    extracted_license_object[
+                        "name"
+                    ] = extracted_license.full_name.toPython()
                 else:
-                    extracted_license_object['name'] = extracted_license.full_name
+                    extracted_license_object["name"] = extracted_license.full_name
 
             if extracted_license.cross_ref:
                 if isinstance(extracted_license.cross_ref, Literal):
-                    extracted_license_object['seeAlso'] = extracted_license.cross_ref.toPython()
+                    extracted_license_object[
+                        "seeAlso"
+                    ] = extracted_license.cross_ref.toPython()
                 else:
-                    extracted_license_object['seeAlso'] = extracted_license.cross_ref
+                    extracted_license_object["seeAlso"] = extracted_license.cross_ref
 
             if extracted_license.comment:
                 if isinstance(extracted_license.comment, Literal):
-                    extracted_license_object['comment'] = extracted_license.comment.toPython()
+                    extracted_license_object[
+                        "comment"
+                    ] = extracted_license.comment.toPython()
                 else:
-                    extracted_license_object['comment'] = extracted_license.comment
+                    extracted_license_object["comment"] = extracted_license.comment
 
             extracted_license_objects.append(extracted_license_object)
 
         return extracted_license_objects
 
-class Writer(CreationInfoWriter, ReviewInfoWriter, FileWriter, PackageWriter,
-    AnnotationInfoWriter, SnippetWriter, ExtractedLicenseWriter):
+
+class Writer(
+    CreationInfoWriter,
+    ReviewInfoWriter,
+    FileWriter,
+    PackageWriter,
+    AnnotationInfoWriter,
+    RelationshipInfoWriter,
+    SnippetWriter,
+    ExtractedLicenseWriter,
+):
     """
     Wrapper for the other writers.
     Represent a whole SPDX Document as json-serializable objects to then
@@ -362,10 +441,16 @@ class Writer(CreationInfoWriter, ReviewInfoWriter, FileWriter, PackageWriter,
         ext_document_reference_objects = []
         for ext_document_reference in ext_document_references_field:
             ext_document_reference_object = dict()
-            ext_document_reference_object['externalDocumentId'] = ext_document_reference.external_document_id
-            ext_document_reference_object['spdxDocumentNamespace'] = ext_document_reference.spdx_document_uri
+            ext_document_reference_object[
+                "externalDocumentId"
+            ] = ext_document_reference.external_document_id
+            ext_document_reference_object[
+                "spdxDocumentNamespace"
+            ] = ext_document_reference.spdx_document_uri
 
-            ext_document_reference_object['checksum'] = self.checksum(ext_document_reference.check_sum)
+            ext_document_reference_object["checksum"] = self.checksum(
+                ext_document_reference.check_sum
+            )
 
             ext_document_reference_objects.append(ext_document_reference_object)
 
@@ -374,34 +459,41 @@ class Writer(CreationInfoWriter, ReviewInfoWriter, FileWriter, PackageWriter,
     def create_document(self):
         self.document_object = dict()
 
-        self.document_object['specVersion'] = self.document.version.__str__()
-        self.document_object['namespace'] = self.document.namespace.__str__()
-        self.document_object['creationInfo'] = self.create_creation_info()
-        self.document_object['dataLicense'] = self.license(self.document.data_license)
-        self.document_object['id'] = self.spdx_id(self.document.spdx_id)
-        self.document_object['name'] = self.document.name
+        self.document_object["specVersion"] = self.document.version.__str__()
+        self.document_object["namespace"] = self.document.namespace.__str__()
+        self.document_object["creationInfo"] = self.create_creation_info()
+        self.document_object["dataLicense"] = self.license(self.document.data_license)
+        self.document_object["id"] = self.spdx_id(self.document.spdx_id)
+        self.document_object["name"] = self.document.name
 
         package_info_object = self.create_package_info()
-        package_info_object['files'] = self.create_file_info()
+        package_info_object["files"] = self.create_file_info()
 
-        self.document_object['documentDescribes'] = [{'Package': package_info_object}]
+        self.document_object["documentDescribes"] = [{"Package": package_info_object}]
 
         if self.document.has_comment:
-            self.document_object['comment'] = self.document.comment
+            self.document_object["comment"] = self.document.comment
 
         if self.document.ext_document_references:
-            self.document_object['externalDocumentRefs'] = self.create_ext_document_references()
+            self.document_object[
+                "externalDocumentRefs"
+            ] = self.create_ext_document_references()
 
         if self.document.extracted_licenses:
-            self.document_object['extractedLicenseInfos'] = self.create_extracted_license()
+            self.document_object[
+                "extractedLicenseInfos"
+            ] = self.create_extracted_license()
 
         if self.document.reviews:
-            self.document_object['reviewers'] = self.create_review_info()
+            self.document_object["reviewers"] = self.create_review_info()
 
         if self.document.snippet:
-            self.document_object['snippets'] = self.create_snippet_info()
+            self.document_object["snippets"] = self.create_snippet_info()
 
         if self.document.annotations:
-            self.document_object['annotations'] = self.create_annotation_info()
+            self.document_object["annotations"] = self.create_annotation_info()
 
-        return {'Document' : self.document_object}
+        if self.document.relationships:
+            self.document_object["relationships"] = self.create_relationship_info()
+
+        return {"Document": self.document_object}

--- a/spdx/writers/rdf.py
+++ b/spdx/writers/rdf.py
@@ -523,12 +523,11 @@ class RelationshipInfoWriter(BaseWriter):
         """
         Return an relationship node.
         """
-        relationship_node = BNode()
+        relationship_node = URIRef(str(relationship.spdxelementid))
         type_triple = (relationship_node, RDF.type, self.spdx_namespace.Relationship)
         self.graph.add(type_triple)
 
-        relationship_split = relationship.relationship
-        relationship_type_node = Literal(relationship_split.split(" ")[1])
+        relationship_type_node = Literal(relationship.relationshiptype)
         self.graph.add(
             (
                 relationship_node,
@@ -536,7 +535,7 @@ class RelationshipInfoWriter(BaseWriter):
                 relationship_type_node,
             )
         )
-        related_spdx_node = Literal(relationship_split.split(" ")[2])
+        related_spdx_node = Literal(relationship.relatedspdxelement)
         related_spdx_triple = (
             relationship_node,
             self.spdx_namespace.relatedSpdxElement,
@@ -994,10 +993,10 @@ class Writer(
         package_node = self.packages()
         package_triple = (doc_node, self.spdx_namespace.describesPackage, package_node)
         self.graph.add(package_triple)
-        # Add relationship
+        """# Add relationship
         relate_node = self.relationships()
         relate_triple = (doc_node, self.spdx_namespace.relationship, relate_node)
-        self.graph.add(relate_triple)
+        self.graph.add(relate_triple)"""
         # Add snippet
         snippet_nodes = self.snippets()
         for snippet in snippet_nodes:

--- a/spdx/writers/rdf.py
+++ b/spdx/writers/rdf.py
@@ -1,4 +1,3 @@
-
 # Copyright (c) 2014 Ahmed H. Ismail
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -39,7 +38,7 @@ class BaseWriter(object):
     def __init__(self, document, out):
         self.document = document
         self.out = out
-        self.doap_namespace = Namespace('http://usefulinc.com/ns/doap#')
+        self.doap_namespace = Namespace("http://usefulinc.com/ns/doap#")
         self.spdx_namespace = Namespace("http://spdx.org/rdf/terms#")
         self.graph = Graph()
 
@@ -50,9 +49,17 @@ class BaseWriter(object):
         chksum_node = BNode()
         type_triple = (chksum_node, RDF.type, self.spdx_namespace.Checksum)
         self.graph.add(type_triple)
-        algorithm_triple = (chksum_node, self.spdx_namespace.algorithm, Literal(chksum.identifier))
+        algorithm_triple = (
+            chksum_node,
+            self.spdx_namespace.algorithm,
+            Literal(chksum.identifier),
+        )
         self.graph.add(algorithm_triple)
-        value_triple = (chksum_node, self.spdx_namespace.checksumValue, Literal(chksum.value))
+        value_triple = (
+            chksum_node,
+            self.spdx_namespace.checksumValue,
+            Literal(chksum.value),
+        )
         self.graph.add(value_triple)
         return chksum_node
 
@@ -77,8 +84,9 @@ class LicenseWriter(BaseWriter):
         super(LicenseWriter, self).__init__(document, out)
 
     def licenses_from_tree_helper(self, current, licenses):
-        if (isinstance(current, (document.LicenseConjunction,
-                                 document.LicenseDisjunction))):
+        if isinstance(
+            current, (document.LicenseConjunction, document.LicenseDisjunction)
+        ):
             self.licenses_from_tree_helper(current.license_1, licenses)
             self.licenses_from_tree_helper(current.license_2, licenses)
         else:
@@ -127,33 +135,57 @@ class LicenseWriter(BaseWriter):
         """
         if isinstance(lic, document.ExtractedLicense):
             return self.create_extracted_license(lic)
-        if lic.identifier.rstrip('+') in config.LICENSE_MAP:
+        if lic.identifier.rstrip("+") in config.LICENSE_MAP:
             return URIRef(lic.url)
         else:
-            matches = [l for l in self.document.extracted_licenses if l.identifier == lic.identifier]
+            matches = [
+                l
+                for l in self.document.extracted_licenses
+                if l.identifier == lic.identifier
+            ]
             if len(matches) != 0:
                 return self.create_extracted_license(matches[0])
             else:
-                raise InvalidDocumentError('Missing extracted license: {0}'.format(lic.identifier))
+                raise InvalidDocumentError(
+                    "Missing extracted license: {0}".format(lic.identifier)
+                )
 
     def create_extracted_license(self, lic):
         """
         Handle extracted license.
         Return the license node.
         """
-        licenses = list(self.graph.triples((None, self.spdx_namespace.licenseId, lic.identifier)))
+        licenses = list(
+            self.graph.triples((None, self.spdx_namespace.licenseId, lic.identifier))
+        )
         if len(licenses) != 0:
             return licenses[0][0]  # return subject in first triple
         else:
             license_node = BNode()
-            type_triple = (license_node, RDF.type, self.spdx_namespace.ExtractedLicensingInfo)
+            type_triple = (
+                license_node,
+                RDF.type,
+                self.spdx_namespace.ExtractedLicensingInfo,
+            )
             self.graph.add(type_triple)
-            ident_triple = (license_node, self.spdx_namespace.licenseId, Literal(lic.identifier))
+            ident_triple = (
+                license_node,
+                self.spdx_namespace.licenseId,
+                Literal(lic.identifier),
+            )
             self.graph.add(ident_triple)
-            text_triple = (license_node, self.spdx_namespace.extractedText, Literal(lic.text))
+            text_triple = (
+                license_node,
+                self.spdx_namespace.extractedText,
+                Literal(lic.text),
+            )
             self.graph.add(text_triple)
             if lic.full_name is not None:
-                name_triple = (license_node, self.spdx_namespace.licenseName, self.to_special_value(lic.full_name))
+                name_triple = (
+                    license_node,
+                    self.spdx_namespace.licenseName,
+                    self.to_special_value(lic.full_name),
+                )
                 self.graph.add(name_triple)
             for ref in lic.cross_ref:
                 triple = (license_node, RDFS.seeAlso, URIRef(ref))
@@ -194,11 +226,12 @@ class FileWriter(LicenseWriter):
     """
     Write spdx.file.File
     """
+
     FILE_TYPES = {
-        file.FileType.SOURCE: 'fileType_source',
-        file.FileType.OTHER: 'fileType_other',
-        file.FileType.BINARY: 'fileType_binary',
-        file.FileType.ARCHIVE: 'fileType_archive'
+        file.FileType.SOURCE: "fileType_source",
+        file.FileType.OTHER: "fileType_other",
+        file.FileType.BINARY: "fileType_binary",
+        file.FileType.ARCHIVE: "fileType_archive",
     }
 
     def __init__(self, document, out):
@@ -208,27 +241,38 @@ class FileWriter(LicenseWriter):
         """
         Create a node for spdx.file.
         """
-        file_node = URIRef('http://www.spdx.org/files#{id}'.format(
-            id=str(doc_file.spdx_id)))
+        file_node = URIRef(
+            "http://www.spdx.org/files#{id}".format(id=str(doc_file.spdx_id))
+        )
         type_triple = (file_node, RDF.type, self.spdx_namespace.File)
         self.graph.add(type_triple)
 
         name_triple = (file_node, self.spdx_namespace.fileName, Literal(doc_file.name))
         self.graph.add(name_triple)
 
-        if doc_file.has_optional_field('comment'):
+        if doc_file.has_optional_field("comment"):
             comment_triple = (file_node, RDFS.comment, Literal(doc_file.comment))
             self.graph.add(comment_triple)
 
-        if doc_file.has_optional_field('type'):
+        if doc_file.has_optional_field("type"):
             ftype = self.spdx_namespace[self.FILE_TYPES[doc_file.type]]
             ftype_triple = (file_node, self.spdx_namespace.fileType, ftype)
             self.graph.add(ftype_triple)
 
-        self.graph.add((file_node, self.spdx_namespace.checksum, self.create_checksum_node(doc_file.chk_sum)))
+        self.graph.add(
+            (
+                file_node,
+                self.spdx_namespace.checksum,
+                self.create_checksum_node(doc_file.chk_sum),
+            )
+        )
 
         conc_lic_node = self.license_or_special(doc_file.conc_lics)
-        conc_lic_triple = (file_node, self.spdx_namespace.licenseConcluded, conc_lic_node)
+        conc_lic_triple = (
+            file_node,
+            self.spdx_namespace.licenseConcluded,
+            conc_lic_node,
+        )
         self.graph.add(conc_lic_triple)
 
         license_info_nodes = map(self.license_or_special, doc_file.licenses_in_file)
@@ -236,20 +280,27 @@ class FileWriter(LicenseWriter):
             triple = (file_node, self.spdx_namespace.licenseInfoInFile, lic)
             self.graph.add(triple)
 
-        if doc_file.has_optional_field('license_comment'):
-            comment_triple = (file_node, self.spdx_namespace.licenseComments, Literal(doc_file.license_comment))
+        if doc_file.has_optional_field("license_comment"):
+            comment_triple = (
+                file_node,
+                self.spdx_namespace.licenseComments,
+                Literal(doc_file.license_comment),
+            )
             self.graph.add(comment_triple)
 
         cr_text_node = self.to_special_value(doc_file.copyright)
         cr_text_triple = (file_node, self.spdx_namespace.copyrightText, cr_text_node)
         self.graph.add(cr_text_triple)
 
-        if doc_file.has_optional_field('notice'):
+        if doc_file.has_optional_field("notice"):
             notice_triple = (file_node, self.spdx_namespace.noticeText, doc_file.notice)
             self.graph.add(notice_triple)
 
         contrib_nodes = map(lambda c: Literal(c), doc_file.contributors)
-        contrib_triples = [(file_node, self.spdx_namespace.fileContributor, node) for node in contrib_nodes]
+        contrib_triples = [
+            (file_node, self.spdx_namespace.fileContributor, node)
+            for node in contrib_nodes
+        ]
         for triple in contrib_triples:
             self.graph.add(triple)
 
@@ -266,18 +317,36 @@ class FileWriter(LicenseWriter):
         Handle dependencies for a single file.
         - doc_file - instance of spdx.file.File.
         """
-        subj_triples = list(self.graph.triples((None, self.spdx_namespace.fileName, Literal(doc_file.name))))
+        subj_triples = list(
+            self.graph.triples(
+                (None, self.spdx_namespace.fileName, Literal(doc_file.name))
+            )
+        )
         if len(subj_triples) != 1:
-            raise InvalidDocumentError('Could not find dependency subject {0}'.format(doc_file.name))
+            raise InvalidDocumentError(
+                "Could not find dependency subject {0}".format(doc_file.name)
+            )
         subject_node = subj_triples[0][0]
         for dependency in doc_file.dependencies:
-            dep_triples = list(self.graph.triples((None, self.spdx_namespace.fileName, Literal(dependency))))
+            dep_triples = list(
+                self.graph.triples(
+                    (None, self.spdx_namespace.fileName, Literal(dependency))
+                )
+            )
             if len(dep_triples) == 1:
                 dep_node = dep_triples[0][0]
-                dep_triple = (subject_node, self.spdx_namespace.fileDependency, dep_node)
+                dep_triple = (
+                    subject_node,
+                    self.spdx_namespace.fileDependency,
+                    dep_node,
+                )
                 self.graph.add(dep_triple)
             else:
-                print('Warning could not resolve file dependency {0} -> {1}'.format(doc_file.name, dependency))
+                print(
+                    "Warning could not resolve file dependency {0} -> {1}".format(
+                        doc_file.name, dependency
+                    )
+                )
 
     def add_file_dependencies(self):
         """
@@ -301,41 +370,52 @@ class SnippetWriter(LicenseWriter):
         """
         Return a snippet node.
         """
-        snippet_node = URIRef('http://spdx.org/rdf/terms/Snippet#' + snippet.spdx_id)
+        snippet_node = URIRef("http://spdx.org/rdf/terms/Snippet#" + snippet.spdx_id)
         type_triple = (snippet_node, RDF.type, self.spdx_namespace.Snippet)
         self.graph.add(type_triple)
 
-        if snippet.has_optional_field('comment'):
+        if snippet.has_optional_field("comment"):
             comment_triple = (snippet_node, RDFS.comment, Literal(snippet.comment))
             self.graph.add(comment_triple)
 
-        if snippet.has_optional_field('name'):
-            name_triple = (snippet_node, self.spdx_namespace.name, Literal(snippet.name))
+        if snippet.has_optional_field("name"):
+            name_triple = (
+                snippet_node,
+                self.spdx_namespace.name,
+                Literal(snippet.name),
+            )
             self.graph.add(name_triple)
 
-        if snippet.has_optional_field('license_comment'):
-            lic_comment_triple = (snippet_node, self.spdx_namespace.licenseComments,
-                                  Literal(snippet.license_comment))
+        if snippet.has_optional_field("license_comment"):
+            lic_comment_triple = (
+                snippet_node,
+                self.spdx_namespace.licenseComments,
+                Literal(snippet.license_comment),
+            )
             self.graph.add(lic_comment_triple)
 
         cr_text_node = self.to_special_value(snippet.copyright)
         cr_text_triple = (snippet_node, self.spdx_namespace.copyrightText, cr_text_node)
         self.graph.add(cr_text_triple)
 
-        snip_from_file_triple = (snippet_node, self.spdx_namespace.snippetFromFile,
-                                 Literal(snippet.snip_from_file_spdxid))
+        snip_from_file_triple = (
+            snippet_node,
+            self.spdx_namespace.snippetFromFile,
+            Literal(snippet.snip_from_file_spdxid),
+        )
         self.graph.add(snip_from_file_triple)
 
         conc_lic_node = self.license_or_special(snippet.conc_lics)
         conc_lic_triple = (
-            snippet_node, self.spdx_namespace.licenseConcluded, conc_lic_node)
+            snippet_node,
+            self.spdx_namespace.licenseConcluded,
+            conc_lic_node,
+        )
         self.graph.add(conc_lic_triple)
 
-        license_info_nodes = map(self.license_or_special,
-                                 snippet.licenses_in_snippet)
+        license_info_nodes = map(self.license_or_special, snippet.licenses_in_snippet)
         for lic in license_info_nodes:
-            triple = (
-            snippet_node, self.spdx_namespace.licenseInfoInSnippet, lic)
+            triple = (snippet_node, self.spdx_namespace.licenseInfoInSnippet, lic)
             self.graph.add(triple)
 
         return snippet_node
@@ -367,7 +447,11 @@ class ReviewInfoWriter(BaseWriter):
         reviewer_node = Literal(review.reviewer.to_value())
         self.graph.add((review_node, self.spdx_namespace.reviewer, reviewer_node))
         reviewed_date_node = Literal(review.review_date_iso_format)
-        reviewed_triple = (review_node, self.spdx_namespace.reviewDate, reviewed_date_node)
+        reviewed_triple = (
+            review_node,
+            self.spdx_namespace.reviewDate,
+            reviewed_date_node,
+        )
         self.graph.add(reviewed_triple)
         if review.has_comment:
             comment_node = Literal(review.comment)
@@ -400,14 +484,22 @@ class AnnotationInfoWriter(BaseWriter):
         annotator_node = Literal(annotation.annotator.to_value())
         self.graph.add((annotation_node, self.spdx_namespace.annotator, annotator_node))
         annotation_date_node = Literal(annotation.annotation_date_iso_format)
-        annotation_triple = (annotation_node, self.spdx_namespace.annotationDate, annotation_date_node)
+        annotation_triple = (
+            annotation_node,
+            self.spdx_namespace.annotationDate,
+            annotation_date_node,
+        )
         self.graph.add(annotation_triple)
         if annotation.has_comment:
             comment_node = Literal(annotation.comment)
             comment_triple = (annotation_node, RDFS.comment, comment_node)
             self.graph.add(comment_triple)
         annotation_type_node = Literal(annotation.annotation_type)
-        annotation_type_triple = (annotation_node, self.spdx_namespace.annotationType, annotation_type_node)
+        annotation_type_triple = (
+            annotation_node,
+            self.spdx_namespace.annotationType,
+            annotation_type_node,
+        )
         self.graph.add(annotation_type_triple)
 
         return annotation_node
@@ -417,6 +509,52 @@ class AnnotationInfoWriter(BaseWriter):
         Return a list of annotation nodes
         """
         return map(self.create_annotation_node, self.document.annotations)
+
+
+class RelationshipInfoWriter(BaseWriter):
+    """
+    Write spdx.relationship.Relationship
+    """
+
+    def __init__(self, document, out):
+        super(RelationshipInfoWriter, self).__init__(document, out)
+
+    def create_relationship_node(self, relationship):
+        """
+        Return an relationship node.
+        """
+        relationship_node = BNode()
+        type_triple = (relationship_node, RDF.type, self.spdx_namespace.Relationship)
+        self.graph.add(type_triple)
+
+        relationship_split = relationship.relationship
+        relationship_type_node = Literal(relationship_split.split(" ")[1])
+        self.graph.add(
+            (
+                relationship_node,
+                self.spdx_namespace.relationshipType,
+                relationship_type_node,
+            )
+        )
+        related_spdx_node = Literal(relationship_split.split(" ")[2])
+        related_spdx_triple = (
+            relationship_node,
+            self.spdx_namespace.relatedSpdxElement,
+            related_spdx_node,
+        )
+        self.graph.add(related_spdx_triple)
+        if relationship.has_comment:
+            comment_node = Literal(relationship.relationship_comment)
+            comment_triple = (relationship_node, RDFS.comment, comment_node)
+            self.graph.add(comment_triple)
+
+        return relationship_node
+
+    def relationships(self):
+        """
+        Return a list of relationship nodes
+        """
+        return map(self.create_relationship_node, self.document.relationships)
 
 
 class CreationInfoWriter(BaseWriter):
@@ -433,7 +571,9 @@ class CreationInfoWriter(BaseWriter):
         Return a list of creator nodes.
         Note: Does not add anything to the graph.
         """
-        return map(lambda c: Literal(c.to_value()), self.document.creation_info.creators)
+        return map(
+            lambda c: Literal(c.to_value()), self.document.creation_info.creators
+        )
 
     def create_creation_info(self):
         """
@@ -473,25 +613,27 @@ class ExternalDocumentRefWriter(BaseWriter):
         Add and return a creation info node to graph
         """
         ext_doc_ref_node = BNode()
-        type_triple = (ext_doc_ref_node, RDF.type, self.spdx_namespace.ExternalDocumentRef)
+        type_triple = (
+            ext_doc_ref_node,
+            RDF.type,
+            self.spdx_namespace.ExternalDocumentRef,
+        )
         self.graph.add(type_triple)
 
-        ext_doc_id = Literal(
-            ext_document_references.external_document_id)
+        ext_doc_id = Literal(ext_document_references.external_document_id)
         ext_doc_id_triple = (
-            ext_doc_ref_node, self.spdx_namespace.externalDocumentId, ext_doc_id)
+            ext_doc_ref_node,
+            self.spdx_namespace.externalDocumentId,
+            ext_doc_id,
+        )
         self.graph.add(ext_doc_id_triple)
 
-        doc_uri = Literal(
-            ext_document_references.spdx_document_uri)
-        doc_uri_triple = (
-            ext_doc_ref_node, self.spdx_namespace.spdxDocument, doc_uri)
+        doc_uri = Literal(ext_document_references.spdx_document_uri)
+        doc_uri_triple = (ext_doc_ref_node, self.spdx_namespace.spdxDocument, doc_uri)
         self.graph.add(doc_uri_triple)
 
-        checksum_node = self.create_checksum_node(
-            ext_document_references.check_sum)
-        self.graph.add(
-            (ext_doc_ref_node, self.spdx_namespace.checksum, checksum_node))
+        checksum_node = self.create_checksum_node(ext_document_references.check_sum)
+        self.graph.add((ext_doc_ref_node, self.spdx_namespace.checksum, checksum_node))
 
         return ext_doc_ref_node
 
@@ -499,8 +641,10 @@ class ExternalDocumentRefWriter(BaseWriter):
         """
         Return a list of review nodes
         """
-        return map(self.create_external_document_ref_node,
-                   self.document.ext_document_references)
+        return map(
+            self.create_external_document_ref_node,
+            self.document.ext_document_references,
+        )
 
 
 class PackageWriter(LicenseWriter):
@@ -517,14 +661,23 @@ class PackageWriter(LicenseWriter):
         Return a node representing package verification code.
         """
         verif_node = BNode()
-        type_triple = (verif_node, RDF.type, self.spdx_namespace.PackageVerificationCode)
+        type_triple = (
+            verif_node,
+            RDF.type,
+            self.spdx_namespace.PackageVerificationCode,
+        )
         self.graph.add(type_triple)
-        value_triple = (verif_node, self.spdx_namespace.packageVerificationCodeValue, Literal(package.verif_code))
+        value_triple = (
+            verif_node,
+            self.spdx_namespace.packageVerificationCodeValue,
+            Literal(package.verif_code),
+        )
         self.graph.add(value_triple)
-        excl_file_nodes = map(
-            lambda excl: Literal(excl), package.verif_exc_files)
+        excl_file_nodes = map(lambda excl: Literal(excl), package.verif_exc_files)
         excl_predicate = self.spdx_namespace.packageVerificationCodeExcludedFile
-        excl_file_triples = [(verif_node, excl_predicate, xcl_file) for xcl_file in excl_file_nodes]
+        excl_file_triples = [
+            (verif_node, excl_predicate, xcl_file) for xcl_file in excl_file_nodes
+        ]
         for trp in excl_file_triples:
             self.graph.add(trp)
         return verif_node
@@ -545,25 +698,51 @@ class PackageWriter(LicenseWriter):
         """
         Write package optional fields.
         """
-        self.handle_package_literal_optional(package, package_node, self.spdx_namespace.versionInfo, 'version')
-        self.handle_package_literal_optional(package, package_node, self.spdx_namespace.packageFileName, 'file_name')
-        self.handle_package_literal_optional(package, package_node, self.spdx_namespace.supplier, 'supplier')
-        self.handle_package_literal_optional(package, package_node, self.spdx_namespace.originator, 'originator')
-        self.handle_package_literal_optional(package, package_node, self.spdx_namespace.sourceInfo, 'source_info')
-        self.handle_package_literal_optional(package, package_node, self.spdx_namespace.licenseComments, 'license_comment')
-        self.handle_package_literal_optional(package, package_node, self.spdx_namespace.summary, 'summary')
-        self.handle_package_literal_optional(package, package_node, self.spdx_namespace.description, 'description')
-        self.handle_package_literal_optional(package, package_node, self.spdx_namespace.comment, 'comment')
-        self.handle_package_literal_optional(package, package_node, self.spdx_namespace.filesAnalyzed, 'files_analyzed')
+        self.handle_package_literal_optional(
+            package, package_node, self.spdx_namespace.versionInfo, "version"
+        )
+        self.handle_package_literal_optional(
+            package, package_node, self.spdx_namespace.packageFileName, "file_name"
+        )
+        self.handle_package_literal_optional(
+            package, package_node, self.spdx_namespace.supplier, "supplier"
+        )
+        self.handle_package_literal_optional(
+            package, package_node, self.spdx_namespace.originator, "originator"
+        )
+        self.handle_package_literal_optional(
+            package, package_node, self.spdx_namespace.sourceInfo, "source_info"
+        )
+        self.handle_package_literal_optional(
+            package,
+            package_node,
+            self.spdx_namespace.licenseComments,
+            "license_comment",
+        )
+        self.handle_package_literal_optional(
+            package, package_node, self.spdx_namespace.summary, "summary"
+        )
+        self.handle_package_literal_optional(
+            package, package_node, self.spdx_namespace.description, "description"
+        )
+        self.handle_package_literal_optional(
+            package, package_node, self.spdx_namespace.comment, "comment"
+        )
+        self.handle_package_literal_optional(
+            package, package_node, self.spdx_namespace.filesAnalyzed, "files_analyzed"
+        )
 
-
-        if package.has_optional_field('check_sum'):
+        if package.has_optional_field("check_sum"):
             checksum_node = self.create_checksum_node(package.check_sum)
             self.graph.add((package_node, self.spdx_namespace.checksum, checksum_node))
 
-        if package.has_optional_field('homepage'):
+        if package.has_optional_field("homepage"):
             homepage_node = URIRef(self.to_special_value(package.homepage))
-            homepage_triple = (package_node, self.doap_namespace.homepage, homepage_node)
+            homepage_triple = (
+                package_node,
+                self.doap_namespace.homepage,
+                homepage_node,
+            )
             self.graph.add(homepage_triple)
 
     def create_package_node(self, package):
@@ -571,14 +750,17 @@ class PackageWriter(LicenseWriter):
         Return a Node representing the package.
         Files must have been added to the graph before this method is called.
         """
-        package_node = URIRef('http://www.spdx.org/tools#SPDXRef-Package')
+        package_node = URIRef("http://www.spdx.org/tools#SPDXRef-Package")
         type_triple = (package_node, RDF.type, self.spdx_namespace.Package)
         self.graph.add(type_triple)
         # Package SPDXID
         if package.spdx_id:
             pkg_spdx_id = URIRef(package.spdx_id)
-            pkg_spdx_id_triple = (package_node, self.spdx_namespace.Package,
-                                  pkg_spdx_id)
+            pkg_spdx_id_triple = (
+                package_node,
+                self.spdx_namespace.Package,
+                pkg_spdx_id,
+            )
             self.graph.add(pkg_spdx_id_triple)
         # Handle optional fields:
         self.handle_pkg_optional_fields(package, package_node)
@@ -586,24 +768,45 @@ class PackageWriter(LicenseWriter):
         name_triple = (package_node, self.spdx_namespace.name, Literal(package.name))
         self.graph.add(name_triple)
         # Package download location
-        down_loc_node = (package_node, self.spdx_namespace.downloadLocation, self.to_special_value(package.download_location))
+        down_loc_node = (
+            package_node,
+            self.spdx_namespace.downloadLocation,
+            self.to_special_value(package.download_location),
+        )
         self.graph.add(down_loc_node)
         # Handle package verification
         verif_node = self.package_verif_node(package)
-        verif_triple = (package_node, self.spdx_namespace.packageVerificationCode, verif_node)
+        verif_triple = (
+            package_node,
+            self.spdx_namespace.packageVerificationCode,
+            verif_node,
+        )
         self.graph.add(verif_triple)
         # Handle concluded license
         conc_lic_node = self.license_or_special(package.conc_lics)
-        conc_lic_triple = (package_node, self.spdx_namespace.licenseConcluded, conc_lic_node)
+        conc_lic_triple = (
+            package_node,
+            self.spdx_namespace.licenseConcluded,
+            conc_lic_node,
+        )
         self.graph.add(conc_lic_triple)
         # Handle declared license
         decl_lic_node = self.license_or_special(package.license_declared)
-        decl_lic_triple = (package_node, self.spdx_namespace.licenseDeclared, decl_lic_node)
+        decl_lic_triple = (
+            package_node,
+            self.spdx_namespace.licenseDeclared,
+            decl_lic_node,
+        )
         self.graph.add(decl_lic_triple)
         # Package licenses from files
-        licenses_from_files_nodes = map(lambda el: self.license_or_special(el), package.licenses_from_files)
+        licenses_from_files_nodes = map(
+            lambda el: self.license_or_special(el), package.licenses_from_files
+        )
         lic_from_files_predicate = self.spdx_namespace.licenseInfoFromFiles
-        lic_from_files_triples = [(package_node, lic_from_files_predicate, node) for node in licenses_from_files_nodes]
+        lic_from_files_triples = [
+            (package_node, lic_from_files_predicate, node)
+            for node in licenses_from_files_nodes
+        ]
         for triple in lic_from_files_triples:
             self.graph.add(triple)
         # Copyright Text
@@ -627,12 +830,18 @@ class PackageWriter(LicenseWriter):
         Return node representing pkg_file
         pkg_file should be instance of spdx.file.
         """
-        nodes = list(self.graph.triples((None, self.spdx_namespace.fileName, Literal(pkg_file.name))))
+        nodes = list(
+            self.graph.triples(
+                (None, self.spdx_namespace.fileName, Literal(pkg_file.name))
+            )
+        )
         if len(nodes) == 1:
             return nodes[0][0]
         else:
-            raise InvalidDocumentError('handle_package_has_file_helper could not' +
-                                       ' find file node for file: {0}'.format(pkg_file.name))
+            raise InvalidDocumentError(
+                "handle_package_has_file_helper could not"
+                + " find file node for file: {0}".format(pkg_file.name)
+            )
 
     def handle_package_has_file(self, package, package_node):
         """
@@ -640,7 +849,9 @@ class PackageWriter(LicenseWriter):
         Must be called after files have been added.
         """
         file_nodes = map(self.handle_package_has_file_helper, package.files)
-        triples = [(package_node, self.spdx_namespace.hasFile, node) for node in file_nodes]
+        triples = [
+            (package_node, self.spdx_namespace.hasFile, node) for node in file_nodes
+        ]
         for triple in triples:
             self.graph.add(triple)
 
@@ -658,27 +869,43 @@ class PackageExternalRefWriter(BaseWriter):
         Add and return an external package reference node to graph.
         """
         pkg_ext_ref_node = BNode()
-        pkg_ext_ref_triple = (pkg_ext_ref_node, RDF.type, self.spdx_namespace.ExternalRef)
+        pkg_ext_ref_triple = (
+            pkg_ext_ref_node,
+            RDF.type,
+            self.spdx_namespace.ExternalRef,
+        )
         self.graph.add(pkg_ext_ref_triple)
 
         pkg_ext_ref_category = Literal(pkg_ext_refs.category)
         pkg_ext_ref_category_triple = (
-            pkg_ext_ref_node, self.spdx_namespace.referenceCategory, pkg_ext_ref_category)
+            pkg_ext_ref_node,
+            self.spdx_namespace.referenceCategory,
+            pkg_ext_ref_category,
+        )
         self.graph.add(pkg_ext_ref_category_triple)
 
         pkg_ext_ref_type = Literal(pkg_ext_refs.pkg_ext_ref_type)
         pkg_ext_ref_type_triple = (
-            pkg_ext_ref_node, self.spdx_namespace.referenceType, pkg_ext_ref_type)
+            pkg_ext_ref_node,
+            self.spdx_namespace.referenceType,
+            pkg_ext_ref_type,
+        )
         self.graph.add(pkg_ext_ref_type_triple)
 
         pkg_ext_ref_locator = Literal(pkg_ext_refs.locator)
         pkg_ext_ref_locator_triple = (
-            pkg_ext_ref_node, self.spdx_namespace.referenceLocator, pkg_ext_ref_locator)
+            pkg_ext_ref_node,
+            self.spdx_namespace.referenceLocator,
+            pkg_ext_ref_locator,
+        )
         self.graph.add(pkg_ext_ref_locator_triple)
 
         pkg_ext_ref_comment = Literal(pkg_ext_refs.comment)
         pkg_ext_ref_comment_triple = (
-            pkg_ext_ref_node, RDFS.comment, pkg_ext_ref_comment)
+            pkg_ext_ref_node,
+            RDFS.comment,
+            pkg_ext_ref_comment,
+        )
         self.graph.add(pkg_ext_ref_comment_triple)
 
         return pkg_ext_ref_node
@@ -687,13 +914,22 @@ class PackageExternalRefWriter(BaseWriter):
         """
         Return a list of package external references.
         """
-        return map(self.create_package_external_ref_node,
-                   self.document.package.pkg_ext_refs)
+        return map(
+            self.create_package_external_ref_node, self.document.package.pkg_ext_refs
+        )
 
 
-class Writer(CreationInfoWriter, ReviewInfoWriter, FileWriter, PackageWriter,
-            PackageExternalRefWriter, ExternalDocumentRefWriter, AnnotationInfoWriter,
-            SnippetWriter):
+class Writer(
+    CreationInfoWriter,
+    ReviewInfoWriter,
+    FileWriter,
+    PackageWriter,
+    PackageExternalRefWriter,
+    ExternalDocumentRefWriter,
+    AnnotationInfoWriter,
+    RelationshipInfoWriter,
+    SnippetWriter,
+):
     """
     Warpper for other writers to write all fields of spdx.document.Document
     Call `write()` to start writing.
@@ -710,7 +946,7 @@ class Writer(CreationInfoWriter, ReviewInfoWriter, FileWriter, PackageWriter,
         """
         Add and return the root document node to graph.
         """
-        doc_node = URIRef('http://www.spdx.org/tools#SPDXRef-DOCUMENT')
+        doc_node = URIRef("http://www.spdx.org/tools#SPDXRef-DOCUMENT")
         # Doc type
         self.graph.add((doc_node, RDF.type, self.spdx_namespace.SpdxDocument))
         # Version
@@ -737,15 +973,18 @@ class Writer(CreationInfoWriter, ReviewInfoWriter, FileWriter, PackageWriter,
         # Add external document references info
         ext_doc_ref_nodes = self.ext_doc_refs()
         for ext_doc_ref in ext_doc_ref_nodes:
-            ext_doc_ref_triple = (doc_node,
-                                  self.spdx_namespace.externalDocumentRef,
-                                  ext_doc_ref)
+            ext_doc_ref_triple = (
+                doc_node,
+                self.spdx_namespace.externalDocumentRef,
+                ext_doc_ref,
+            )
             self.graph.add(ext_doc_ref_triple)
         # Add extracted licenses
-        licenses = map(
-            self.create_extracted_license, self.document.extracted_licenses)
+        licenses = map(self.create_extracted_license, self.document.extracted_licenses)
         for lic in licenses:
-            self.graph.add((doc_node, self.spdx_namespace.hasExtractedLicensingInfo, lic))
+            self.graph.add(
+                (doc_node, self.spdx_namespace.hasExtractedLicensingInfo, lic)
+            )
         # Add files
         files = self.files()
         for file_node in files:
@@ -755,6 +994,10 @@ class Writer(CreationInfoWriter, ReviewInfoWriter, FileWriter, PackageWriter,
         package_node = self.packages()
         package_triple = (doc_node, self.spdx_namespace.describesPackage, package_node)
         self.graph.add(package_triple)
+        # Add relationship
+        relate_node = self.relationships()
+        relate_triple = (doc_node, self.spdx_namespace.relationship, relate_node)
+        self.graph.add(relate_triple)
         # Add snippet
         snippet_nodes = self.snippets()
         for snippet in snippet_nodes:
@@ -764,7 +1007,7 @@ class Writer(CreationInfoWriter, ReviewInfoWriter, FileWriter, PackageWriter,
         self.graph = to_isomorphic(self.graph)
 
         # Write file
-        self.graph.serialize(self.out, 'pretty-xml', encoding='utf-8')
+        self.graph.serialize(self.out, "pretty-xml", encoding="utf-8")
 
 
 def write_document(document, out, validate=True):

--- a/spdx/writers/tagvalue.py
+++ b/spdx/writers/tagvalue.py
@@ -89,14 +89,16 @@ def write_annotation(annotation, out):
         write_value("SPDXREF", annotation.spdx_id, out)
 
 
-def write_relationship(relationship, out):
+def write_relationship(relationship_term, out):
     """
     Write the fields of relationships to out.
     """
     out.write("# Relationships\n\n")
-    write_value("Relationship", relationship.relationship, out)
-    if relationship.has_comment:
-        write_text_value("RelationshipComment", relationship.relationship_comment, out)
+    write_value("Relationship", relationship_term.relationship, out)
+    if relationship_term.has_comment:
+        write_text_value(
+            "RelationshipComment", relationship_term.relationship_comment, out
+        )
 
 
 def write_file_type(ftype, out):
@@ -344,8 +346,8 @@ def write_document(document, out, validate=True):
         write_annotation(annotation, out)
         write_separators(out)
 
-    # Write sorted relationships
-    for relationship in sorted(document.relationships):
+    # Write relationships
+    for relationship in document.relationships:
         write_relationship(relationship, out)
         write_separators(out)
 

--- a/spdx/writers/tagvalue.py
+++ b/spdx/writers/tagvalue.py
@@ -1,4 +1,3 @@
-
 # Copyright (c) 2014 Ahmed H. Ismail
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -25,26 +24,27 @@ class InvalidDocumentError(Exception):
     """
     Raised when attempting to write an invalid document.
     """
+
     pass
 
 
 def write_separators(out):
-    out.write(u'\n' * 2)
+    out.write("\n" * 2)
 
 
 def format_verif_code(package):
     if len(package.verif_exc_files) == 0:
         return package.verif_code
     else:
-        return "{0} ({1})".format(package.verif_code, ','.join(package.verif_exc_files))
+        return "{0} ({1})".format(package.verif_code, ",".join(package.verif_exc_files))
 
 
 def write_value(tag, value, out):
-    out.write(u'{0}: {1}\n'.format(tag, value))
+    out.write("{0}: {1}\n".format(tag, value))
 
 
 def write_text_value(tag, value, out):
-    value = u'{0}: <text>{1}</text>\n'.format(tag, value)
+    value = "{0}: <text>{1}</text>\n".format(tag, value)
     out.write(value)
 
 
@@ -52,208 +52,225 @@ def write_creation_info(creation_info, out):
     """
     Write the creation info to out.
     """
-    out.write('# Creation Info\n\n')
+    out.write("# Creation Info\n\n")
     # Write sorted creators
     for creator in sorted(creation_info.creators):
-        write_value('Creator', creator, out)
+        write_value("Creator", creator, out)
 
     # write created
-    write_value('Created', creation_info.created_iso_format, out)
+    write_value("Created", creation_info.created_iso_format, out)
     # possible comment
     if creation_info.has_comment:
-        write_text_value('CreatorComment', creation_info.comment, out)
+        write_text_value("CreatorComment", creation_info.comment, out)
 
 
 def write_review(review, out):
     """
     Write the fields of a single review to out.
     """
-    out.write('# Review\n\n')
-    write_value('Reviewer', review.reviewer, out)
-    write_value('ReviewDate', review.review_date_iso_format, out)
+    out.write("# Review\n\n")
+    write_value("Reviewer", review.reviewer, out)
+    write_value("ReviewDate", review.review_date_iso_format, out)
     if review.has_comment:
-        write_text_value('ReviewComment', review.comment, out)
+        write_text_value("ReviewComment", review.comment, out)
 
 
 def write_annotation(annotation, out):
     """
     Write the fields of a single annotation to out.
     """
-    out.write('# Annotation\n\n')
-    write_value('Annotator', annotation.annotator, out)
-    write_value('AnnotationDate', annotation.annotation_date_iso_format, out)
+    out.write("# Annotation\n\n")
+    write_value("Annotator", annotation.annotator, out)
+    write_value("AnnotationDate", annotation.annotation_date_iso_format, out)
     if annotation.has_comment:
-        write_text_value('AnnotationComment', annotation.comment, out)
-    write_value('AnnotationType', annotation.annotation_type, out)
+        write_text_value("AnnotationComment", annotation.comment, out)
+    write_value("AnnotationType", annotation.annotation_type, out)
     if annotation.spdx_id:
-        write_value('SPDXREF', annotation.spdx_id, out)
+        write_value("SPDXREF", annotation.spdx_id, out)
+
+
+def write_relationship(relationship, out):
+    """
+    Write the fields of relationships to out.
+    """
+    out.write("# Relationships\n\n")
+    write_value("Relationship", relationship.relationship, out)
+    if relationship.has_comment:
+        write_text_value("RelationshipComment", relationship.relationship_comment, out)
 
 
 def write_file_type(ftype, out):
     VALUES = {
-        spdx_file.FileType.SOURCE: 'SOURCE',
-        spdx_file.FileType.OTHER: 'OTHER',
-        spdx_file.FileType.BINARY: 'BINARY',
-        spdx_file.FileType.ARCHIVE: 'ARCHIVE'
+        spdx_file.FileType.SOURCE: "SOURCE",
+        spdx_file.FileType.OTHER: "OTHER",
+        spdx_file.FileType.BINARY: "BINARY",
+        spdx_file.FileType.ARCHIVE: "ARCHIVE",
     }
-    write_value('FileType', VALUES[ftype], out)
+    write_value("FileType", VALUES[ftype], out)
 
 
 def write_file(spdx_file, out):
     """
     Write a file fields to out.
     """
-    out.write('# File\n\n')
-    write_value('FileName', spdx_file.name, out)
+    out.write("# File\n\n")
+    write_value("FileName", spdx_file.name, out)
     if spdx_file.spdx_id:
-        write_value('SPDXID', spdx_file.spdx_id, out)
-    if spdx_file.has_optional_field('type'):
+        write_value("SPDXID", spdx_file.spdx_id, out)
+    if spdx_file.has_optional_field("type"):
         write_file_type(spdx_file.type, out)
-    write_value('FileChecksum', spdx_file.chk_sum.to_tv(), out)
-    if isinstance(spdx_file.conc_lics, (document.LicenseConjunction, document.LicenseDisjunction)):
-        write_value('LicenseConcluded', u'({0})'.format(spdx_file.conc_lics), out)
+    write_value("FileChecksum", spdx_file.chk_sum.to_tv(), out)
+    if isinstance(
+        spdx_file.conc_lics, (document.LicenseConjunction, document.LicenseDisjunction)
+    ):
+        write_value("LicenseConcluded", "({0})".format(spdx_file.conc_lics), out)
     else:
-        write_value('LicenseConcluded', spdx_file.conc_lics, out)
+        write_value("LicenseConcluded", spdx_file.conc_lics, out)
 
     # write sorted list
     for lics in sorted(spdx_file.licenses_in_file):
-        write_value('LicenseInfoInFile', lics, out)
+        write_value("LicenseInfoInFile", lics, out)
 
     if isinstance(spdx_file.copyright, six.string_types):
-        write_text_value('FileCopyrightText', spdx_file.copyright, out)
+        write_text_value("FileCopyrightText", spdx_file.copyright, out)
     else:
-        write_value('FileCopyrightText', spdx_file.copyright, out)
+        write_value("FileCopyrightText", spdx_file.copyright, out)
 
-    if spdx_file.has_optional_field('license_comment'):
-        write_text_value('LicenseComments', spdx_file.license_comment, out)
+    if spdx_file.has_optional_field("license_comment"):
+        write_text_value("LicenseComments", spdx_file.license_comment, out)
 
-    if spdx_file.has_optional_field('comment'):
-        write_text_value('FileComment', spdx_file.comment, out)
+    if spdx_file.has_optional_field("comment"):
+        write_text_value("FileComment", spdx_file.comment, out)
 
-    if spdx_file.has_optional_field('notice'):
-        write_text_value('FileNotice', spdx_file.notice, out)
+    if spdx_file.has_optional_field("notice"):
+        write_text_value("FileNotice", spdx_file.notice, out)
 
     for contributor in sorted(spdx_file.contributors):
-        write_value('FileContributor', contributor, out)
+        write_value("FileContributor", contributor, out)
 
     for dependency in sorted(spdx_file.dependencies):
-        write_value('FileDependency', dependency, out)
+        write_value("FileDependency", dependency, out)
 
     names = spdx_file.artifact_of_project_name
     homepages = spdx_file.artifact_of_project_home
     uris = spdx_file.artifact_of_project_uri
 
     for name, homepage, uri in sorted(zip_longest(names, homepages, uris)):
-        write_value('ArtifactOfProjectName', name, out)
+        write_value("ArtifactOfProjectName", name, out)
         if homepage is not None:
-            write_value('ArtifactOfProjectHomePage', homepage, out)
+            write_value("ArtifactOfProjectHomePage", homepage, out)
         if uri is not None:
-            write_value('ArtifactOfProjectURI', uri, out)
+            write_value("ArtifactOfProjectURI", uri, out)
 
 
 def write_snippet(snippet, out):
     """
     Write snippet fields to out.
     """
-    out.write('# Snippet\n\n')
-    write_value('SnippetSPDXID', snippet.spdx_id, out)
-    write_value('SnippetFromFileSPDXID', snippet.snip_from_file_spdxid, out)
-    write_text_value('SnippetCopyrightText', snippet.copyright, out)
-    if snippet.has_optional_field('name'):
-        write_value('SnippetName', snippet.name, out)
-    if snippet.has_optional_field('comment'):
-        write_text_value('SnippetComment', snippet.comment, out)
-    if snippet.has_optional_field('license_comment'):
-        write_text_value('SnippetLicenseComments', snippet.license_comment, out)
-    if isinstance(snippet.conc_lics,
-                  (document.LicenseConjunction, document.LicenseDisjunction)):
-        write_value('SnippetLicenseConcluded', u'({0})'.format(
-            snippet.conc_lics), out)
+    out.write("# Snippet\n\n")
+    write_value("SnippetSPDXID", snippet.spdx_id, out)
+    write_value("SnippetFromFileSPDXID", snippet.snip_from_file_spdxid, out)
+    write_text_value("SnippetCopyrightText", snippet.copyright, out)
+    if snippet.has_optional_field("name"):
+        write_value("SnippetName", snippet.name, out)
+    if snippet.has_optional_field("comment"):
+        write_text_value("SnippetComment", snippet.comment, out)
+    if snippet.has_optional_field("license_comment"):
+        write_text_value("SnippetLicenseComments", snippet.license_comment, out)
+    if isinstance(
+        snippet.conc_lics, (document.LicenseConjunction, document.LicenseDisjunction)
+    ):
+        write_value("SnippetLicenseConcluded", "({0})".format(snippet.conc_lics), out)
     else:
-        write_value('SnippetLicenseConcluded', snippet.conc_lics, out)
+        write_value("SnippetLicenseConcluded", snippet.conc_lics, out)
     # Write sorted list
     for lics in sorted(snippet.licenses_in_snippet):
-        write_value('LicenseInfoInSnippet', lics, out)
+        write_value("LicenseInfoInSnippet", lics, out)
 
 
 def write_package(package, out):
     """
     Write a package fields to out.
     """
-    out.write('# Package\n\n')
+    out.write("# Package\n\n")
     if package.name:
-        write_value('PackageName', package.name, out)
+        write_value("PackageName", package.name, out)
     if package.spdx_id:
-        write_value('SPDXID', package.spdx_id, out)
-    if package.has_optional_field('version'):
-        write_value('PackageVersion', package.version, out)
-    write_value('PackageDownloadLocation', package.download_location, out)
+        write_value("SPDXID", package.spdx_id, out)
+    if package.has_optional_field("version"):
+        write_value("PackageVersion", package.version, out)
+    write_value("PackageDownloadLocation", package.download_location, out)
 
-    if package.has_optional_field('files_analyzed'):
-        write_value('FilesAnalyzed', package.files_analyzed, out)
+    if package.has_optional_field("files_analyzed"):
+        write_value("FilesAnalyzed", package.files_analyzed, out)
 
-    if package.has_optional_field('summary'):
-        write_text_value('PackageSummary', package.summary, out)
+    if package.has_optional_field("summary"):
+        write_text_value("PackageSummary", package.summary, out)
 
-    if package.has_optional_field('source_info'):
-        write_text_value('PackageSourceInfo', package.source_info, out)
+    if package.has_optional_field("source_info"):
+        write_text_value("PackageSourceInfo", package.source_info, out)
 
-    if package.has_optional_field('file_name'):
-        write_value('PackageFileName', package.file_name, out)
+    if package.has_optional_field("file_name"):
+        write_value("PackageFileName", package.file_name, out)
 
-    if package.has_optional_field('supplier'):
-        write_value('PackageSupplier', package.supplier, out)
+    if package.has_optional_field("supplier"):
+        write_value("PackageSupplier", package.supplier, out)
 
-    if package.has_optional_field('originator'):
-        write_value('PackageOriginator', package.originator, out)
+    if package.has_optional_field("originator"):
+        write_value("PackageOriginator", package.originator, out)
 
-    if package.has_optional_field('check_sum'):
-        write_value('PackageChecksum', package.check_sum.to_tv(), out)
+    if package.has_optional_field("check_sum"):
+        write_value("PackageChecksum", package.check_sum.to_tv(), out)
 
-    write_value('PackageVerificationCode', format_verif_code(package), out)
+    write_value("PackageVerificationCode", format_verif_code(package), out)
 
-    if package.has_optional_field('description'):
-        write_text_value('PackageDescription', package.description, out)
+    if package.has_optional_field("description"):
+        write_text_value("PackageDescription", package.description, out)
 
-    if package.has_optional_field('comment'):
-        write_text_value('PackageComment', package.comment, out)
+    if package.has_optional_field("comment"):
+        write_text_value("PackageComment", package.comment, out)
 
-    if isinstance(package.license_declared, (document.LicenseConjunction,
-        document.LicenseDisjunction)):
-        write_value('PackageLicenseDeclared', u'({0})'.format(package.license_declared), out)
+    if isinstance(
+        package.license_declared,
+        (document.LicenseConjunction, document.LicenseDisjunction),
+    ):
+        write_value(
+            "PackageLicenseDeclared", "({0})".format(package.license_declared), out
+        )
     else:
-        write_value('PackageLicenseDeclared', package.license_declared, out)
+        write_value("PackageLicenseDeclared", package.license_declared, out)
 
-    if isinstance(package.conc_lics, (document.LicenseConjunction,
-        document.LicenseDisjunction)):
-        write_value('PackageLicenseConcluded', u'({0})'.format(package.conc_lics), out)
+    if isinstance(
+        package.conc_lics, (document.LicenseConjunction, document.LicenseDisjunction)
+    ):
+        write_value("PackageLicenseConcluded", "({0})".format(package.conc_lics), out)
     else:
-        write_value('PackageLicenseConcluded', package.conc_lics, out)
+        write_value("PackageLicenseConcluded", package.conc_lics, out)
 
     # Write sorted list of licenses.
     for lics in sorted(package.licenses_from_files):
-        write_value('PackageLicenseInfoFromFiles', lics, out)
+        write_value("PackageLicenseInfoFromFiles", lics, out)
 
-    if package.has_optional_field('license_comment'):
-        write_text_value('PackageLicenseComments', package.license_comment, out)
+    if package.has_optional_field("license_comment"):
+        write_text_value("PackageLicenseComments", package.license_comment, out)
 
     # cr_text is either free form text or NONE or NOASSERTION.
     if package.cr_text:
         if isinstance(package.cr_text, six.string_types):
-            write_text_value('PackageCopyrightText', package.cr_text, out)
+            write_text_value("PackageCopyrightText", package.cr_text, out)
         else:
-            write_value('PackageCopyrightText', package.cr_text, out)
+            write_value("PackageCopyrightText", package.cr_text, out)
 
-    if package.has_optional_field('homepage'):
-        write_value('PackageHomePage', package.homepage, out)
+    if package.has_optional_field("homepage"):
+        write_value("PackageHomePage", package.homepage, out)
 
     for pkg_ref in package.pkg_ext_refs:
-        pkg_ref_str = ' '.join([pkg_ref.category,
-                                pkg_ref.pkg_ext_ref_type,
-                                pkg_ref.locator])
-        write_value('ExternalRef', pkg_ref_str, out)
+        pkg_ref_str = " ".join(
+            [pkg_ref.category, pkg_ref.pkg_ext_ref_type, pkg_ref.locator]
+        )
+        write_value("ExternalRef", pkg_ref_str, out)
         if pkg_ref.comment:
-            write_text_value('ExternalRefComment', pkg_ref.comment, out)
+            write_text_value("ExternalRefComment", pkg_ref.comment, out)
 
     # Write sorted files.
     for spdx_file in sorted(package.files):
@@ -265,18 +282,18 @@ def write_extracted_licenses(lics, out):
     """
     Write extracted licenses fields to out.
     """
-    write_value('LicenseID', lics.identifier, out)
+    write_value("LicenseID", lics.identifier, out)
 
     if lics.full_name is not None:
-        write_value('LicenseName', lics.full_name, out)
+        write_value("LicenseName", lics.full_name, out)
 
     if lics.comment is not None:
-        write_text_value('LicenseComment', lics.comment, out)
+        write_text_value("LicenseComment", lics.comment, out)
 
     for xref in sorted(lics.cross_ref):
-        write_value('LicenseCrossReference', xref, out)
+        write_value("LicenseCrossReference", xref, out)
 
-    write_text_value('ExtractedText', lics.text, out)
+    write_text_value("ExtractedText", lics.text, out)
 
 
 def write_document(document, out, validate=True):
@@ -293,22 +310,25 @@ def write_document(document, out, validate=True):
         raise InvalidDocumentError(messages)
 
     # Write out document information
-    out.write('# Document Information\n\n')
-    write_value('SPDXVersion', str(document.version), out)
-    write_value('DataLicense', document.data_license.identifier, out)
+    out.write("# Document Information\n\n")
+    write_value("SPDXVersion", str(document.version), out)
+    write_value("DataLicense", document.data_license.identifier, out)
     if document.name:
-        write_value('DocumentName', document.name, out)
-    write_value('SPDXID', 'SPDXRef-DOCUMENT', out)
+        write_value("DocumentName", document.name, out)
+    write_value("SPDXID", "SPDXRef-DOCUMENT", out)
     if document.namespace:
-        write_value('DocumentNamespace', document.namespace, out)
+        write_value("DocumentNamespace", document.namespace, out)
     if document.has_comment:
-        write_text_value('DocumentComment', document.comment, out)
+        write_text_value("DocumentComment", document.comment, out)
     for doc_ref in document.ext_document_references:
-        doc_ref_str = ' '.join([doc_ref.external_document_id,
-                                doc_ref.spdx_document_uri,
-                                doc_ref.check_sum.identifier + ':' +
-                                doc_ref.check_sum.value])
-        write_value('ExternalDocumentRef', doc_ref_str, out)
+        doc_ref_str = " ".join(
+            [
+                doc_ref.external_document_id,
+                doc_ref.spdx_document_uri,
+                doc_ref.check_sum.identifier + ":" + doc_ref.check_sum.value,
+            ]
+        )
+        write_value("ExternalDocumentRef", doc_ref_str, out)
     write_separators(out)
     # Write out creation info
     write_creation_info(document.creation_info, out)
@@ -324,6 +344,11 @@ def write_document(document, out, validate=True):
         write_annotation(annotation, out)
         write_separators(out)
 
+    # Write sorted relationships
+    for relationship in sorted(document.relationships):
+        write_relationship(relationship, out)
+        write_separators(out)
+
     # Write out package info
     write_package(document.package, out)
     write_separators(out)
@@ -333,7 +358,7 @@ def write_document(document, out, validate=True):
         write_snippet(snippet, out)
         write_separators(out)
 
-    out.write('# Extracted Licenses\n\n')
+    out.write("# Extracted Licenses\n\n")
     for lic in sorted(document.extracted_licenses):
         write_extracted_licenses(lic, out)
         write_separators(out)

--- a/tests/data/formats/SPDXJsonExample.json
+++ b/tests/data/formats/SPDXJsonExample.json
@@ -127,7 +127,44 @@
                 "annotationDate": "2012-06-13T00:00:00Z", 
                 "annotator": "Person: Jim Reviewer"
             }
-        ], 
+        ],
+        "relationships" : [ {
+    "spdxElementId" : "SPDXRef-DOCUMENT",
+    "relatedSpdxElement" : "SPDXRef-Package",
+    "relationshipType" : "CONTAINS"
+  }, {
+    "spdxElementId" : "SPDXRef-DOCUMENT",
+    "relatedSpdxElement" : "SPDXRef-File",
+    "relationshipType" : "DESCRIBES"
+  }, {
+    "spdxElementId" : "SPDXRef-DOCUMENT",
+    "relatedSpdxElement" : "DocumentRef-spdx-tool-1.2:SPDXRef-ToolsElement",
+    "relationshipType" : "COPY_OF"
+  }, {
+    "spdxElementId" : "SPDXRef-DOCUMENT",
+    "relatedSpdxElement" : "SPDXRef-Package",
+    "relationshipType" : "DESCRIBES"
+  }, {
+    "spdxElementId" : "SPDXRef-Package",
+    "relatedSpdxElement" : "SPDXRef-Saxon",
+    "relationshipType" : "DYNAMIC_LINK"
+  }, {
+    "spdxElementId" : "SPDXRef-Package",
+    "relatedSpdxElement" : "SPDXRef-JenaLib",
+    "relationshipType" : "CONTAINS"
+  }, {
+    "spdxElementId" : "SPDXRef-CommonsLangSrc",
+    "relatedSpdxElement" : "NOASSERTION",
+    "relationshipType" : "GENERATED_FROM"
+  }, {
+    "spdxElementId" : "SPDXRef-JenaLib",
+    "relatedSpdxElement" : "SPDXRef-Package",
+    "relationshipType" : "CONTAINS"
+  }, {
+    "spdxElementId" : "SPDXRef-File",
+    "relatedSpdxElement" : "SPDXRef-fromDoap-0",
+    "relationshipType" : "GENERATED_FROM"
+  } ], 
         "dataLicense": "CC0-1.0", 
         "reviewers": [
             {

--- a/tests/data/formats/SPDXRdfExample.rdf
+++ b/tests/data/formats/SPDXRdfExample.rdf
@@ -115,6 +115,12 @@
         <annotator>Person: Jim Reviewer</annotator>
       </Annotation>
     </annotation>
+    <relationship>
+      <Relationship>
+        <relationshipType rdf:resource="http://spdx.org/rdf/terms#relationshipType_describes"/>
+        <relatedSpdxElement rdf:resource="http://spdx.org/spdxdocs/spdx-example-444504E0-4F89-41D3-9A0C-0305E82C3301#SPDXRef-Package"/>
+      </Relationship>
+    </relationship>
     <referencesFile>
       <File rdf:about="https://spdx.org/spdxdocs/spdx-example-444504E0-4F89-41D3-9A0C-0305E82C3301#SPDXRef-File2">
         <copyrightText>Copyright 2010, 2011 Source Auditor Inc.</copyrightText>

--- a/tests/data/formats/SPDXTagExample.tag
+++ b/tests/data/formats/SPDXTagExample.tag
@@ -28,6 +28,12 @@ AnnotationDate: 2012-03-11T00:00:00Z
 AnnotationComment: <text>An example annotation comment.</text>
 SPDXREF: SPDXRef-45
 
+## Relationships
+Relationship: SPDXRef-DOCUMENT DESCRIBES SPDXRef-File
+Relationship: SPDXRef-DOCUMENT DESCRIBES SPDXRef-Package
+Relationship: SPDXRef-DOCUMENT COPY_OF DocumentRef-spdx-tool-1.2:SPDXRef-ToolsElement
+Relationship: SPDXRef-DOCUMENT CONTAINS SPDXRef-Package
+
 ## Package Information
 PackageName: SPDX Translator
 SPDXID: SPDXRef-Package

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -454,11 +454,6 @@ class TestRelationshipBuilder(TestCase):
         assert self.builder.add_relationship_comment(self.document, comment)
 
     @testing_utils.raises(builders.SPDXValueError)
-    def test_incorrect_relationship_value(self):
-        relationship_type = "SPDXRef-DOCUMENT unknown SPDXRef-File"
-        self.builder.add_relationship(self.document, relationship_type)
-
-    @testing_utils.raises(builders.SPDXValueError)
     def test_relationship_comment_value(self):
         comment = "<text>Relationship Comment<text>"
         self.add_relationship()

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -1,4 +1,3 @@
-
 # Copyright (c) 2014 Ahmed H. Ismail
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -31,81 +30,80 @@ class TestDocumentBuilder(TestCase):
         self.builder = builders.DocBuilder()
 
     def test_correct_version(self):
-        version_str = 'SPDX-2.1'
+        version_str = "SPDX-2.1"
         self.builder.set_doc_version(self.document, version_str)
-        assert (self.document.version.major == 2 and
-                self.document.version.minor == 1)
+        assert self.document.version.major == 2 and self.document.version.minor == 1
 
     @testing_utils.raises(builders.CardinalityError)
     def test_version_cardinality(self):
-        version_str = 'SPDX-2.1'
+        version_str = "SPDX-2.1"
         self.builder.set_doc_version(self.document, version_str)
         self.builder.set_doc_version(self.document, version_str)
 
     @testing_utils.raises(builders.SPDXValueError)
     def test_version_value(self):
-        version_str = '2.1'
+        version_str = "2.1"
         self.builder.set_doc_version(self.document, version_str)
 
     def test_correct_data_lics(self):
-        lics_str = 'CC0-1.0'
+        lics_str = "CC0-1.0"
         self.builder.set_doc_data_lics(self.document, lics_str)
         assert self.document.data_license == License.from_identifier(lics_str)
 
     @testing_utils.raises(builders.SPDXValueError)
     def test_data_lics_value(self):
-        lics_str = 'GPL'
+        lics_str = "GPL"
         self.builder.set_doc_data_lics(self.document, lics_str)
 
     @testing_utils.raises(builders.CardinalityError)
     def test_data_lics_cardinality(self):
-        lics_str = 'CC0-1.0'
+        lics_str = "CC0-1.0"
         self.builder.set_doc_data_lics(self.document, lics_str)
         self.builder.set_doc_data_lics(self.document, lics_str)
 
     def test_correct_name(self):
-        name_str = 'Sample_Document-V2.1'
+        name_str = "Sample_Document-V2.1"
         self.builder.set_doc_name(self.document, name_str)
         assert self.document.name == name_str
 
     @testing_utils.raises(builders.CardinalityError)
     def test_name_cardinality(self):
-        name_str = 'Sample_Document-V2.1'
+        name_str = "Sample_Document-V2.1"
         self.builder.set_doc_name(self.document, name_str)
         self.builder.set_doc_name(self.document, name_str)
 
     def test_correct_doc_namespace(self):
-        doc_namespace_str = 'https://spdx.org/spdxdocs/spdx-example-444504E0-4F89-41D3-9A0C-0305E82C3301'
+        doc_namespace_str = "https://spdx.org/spdxdocs/spdx-example-444504E0-4F89-41D3-9A0C-0305E82C3301"
         self.builder.set_doc_namespace(self.document, doc_namespace_str)
         assert self.document.namespace == doc_namespace_str
 
     @testing_utils.raises(builders.SPDXValueError)
     def test_doc_namespace_value(self):
-        doc_namespace_str = 'https://spdx.org/spdxdocs/spdx-example-444504E0-4F89-41D3-9A0C-0305E82C3301#SPDXRef-DOCUMENT'
+        doc_namespace_str = "https://spdx.org/spdxdocs/spdx-example-444504E0-4F89-41D3-9A0C-0305E82C3301#SPDXRef-DOCUMENT"
         self.builder.set_doc_data_lics(self.document, doc_namespace_str)
 
     @testing_utils.raises(builders.CardinalityError)
     def test_doc_namespace_cardinality(self):
-        doc_namespace_str = 'https://spdx.org/spdxdocs/spdx-example-444504E0-4F89-41D3-9A0C-0305E82C3301'
+        doc_namespace_str = "https://spdx.org/spdxdocs/spdx-example-444504E0-4F89-41D3-9A0C-0305E82C3301"
         self.builder.set_doc_namespace(self.document, doc_namespace_str)
         self.builder.set_doc_namespace(self.document, doc_namespace_str)
 
     def test_correct_data_comment(self):
-        comment_str = 'This is a comment.'
-        comment_text = '<text>' + comment_str + '</text>'
+        comment_str = "This is a comment."
+        comment_text = "<text>" + comment_str + "</text>"
         self.builder.set_doc_comment(self.document, comment_text)
         assert self.document.comment == comment_str
 
     @testing_utils.raises(builders.CardinalityError)
     def test_comment_cardinality(self):
-        comment_str = 'This is a comment.'
-        comment_text = '<text>' + comment_str + '</text>'
+        comment_str = "This is a comment."
+        comment_text = "<text>" + comment_str + "</text>"
         self.builder.set_doc_comment(self.document, comment_text)
         self.builder.set_doc_comment(self.document, comment_text)
 
     @testing_utils.raises(builders.SPDXValueError)
     def test_comment_value(self):
-        comment = '<text>slslss<text'
+        comment = "<text>slslss<text"
         self.builder.set_doc_comment(self.document, comment)
 
 
@@ -117,33 +115,43 @@ class TestExternalDocumentRefBuilder(TestCase):
         self.builder = builders.ExternalDocumentRefBuilder()
 
     def test_external_doc_id(self):
-        ext_doc_id = 'DocumentRef-spdx-tool-2.1'
+        ext_doc_id = "DocumentRef-spdx-tool-2.1"
         self.builder.set_ext_doc_id(self.document, ext_doc_id)
-        assert self.document.ext_document_references[-1].external_document_id == ext_doc_id
+        assert (
+            self.document.ext_document_references[-1].external_document_id == ext_doc_id
+        )
 
     def test_spdx_doc_uri(self):
-        spdx_doc_uri = 'https://spdx.org/spdxdocs/spdx-tools-v2.1-3F2504E0-4F89-41D3-9A0C-0305E82C3301'
-        self.builder.set_ext_doc_id(self.document, 'DocumentRef-spdx-tool-2.1')
+        spdx_doc_uri = "https://spdx.org/spdxdocs/spdx-tools-v2.1-3F2504E0-4F89-41D3-9A0C-0305E82C3301"
+        self.builder.set_ext_doc_id(self.document, "DocumentRef-spdx-tool-2.1")
         self.builder.set_spdx_doc_uri(self.document, spdx_doc_uri)
-        assert self.document.ext_document_references[-1].spdx_document_uri == spdx_doc_uri
+        assert (
+            self.document.ext_document_references[-1].spdx_document_uri == spdx_doc_uri
+        )
 
     def test_checksum(self):
-        chksum = 'SHA1: d6a770ba38583ed4bb4525bd96e50461655d2759'
-        chksum_val = 'd6a770ba38583ed4bb4525bd96e50461655d2759'
-        self.builder.set_ext_doc_id(self.document, 'DocumentRef-spdx-tool-2.1')
+        chksum = "SHA1: d6a770ba38583ed4bb4525bd96e50461655d2759"
+        chksum_val = "d6a770ba38583ed4bb4525bd96e50461655d2759"
+        self.builder.set_ext_doc_id(self.document, "DocumentRef-spdx-tool-2.1")
         self.builder.set_chksum(self.document, chksum)
         assert self.document.ext_document_references[-1].check_sum.value == chksum_val
 
     def test_add_ext_doc_refs(self):
-        ext_doc_id_val = 'DocumentRef-spdx-tool-2.1'
-        spdx_doc_uri = 'http://spdx.org/spdxdocs/spdx-tools-v2.1-3F2504E0-4F89-41D3-9A0C-0305E82C3301'
-        chksum = 'SHA1: d6a770ba38583ed4bb4525bd96e50461655d2759'
-        chksum_val = 'd6a770ba38583ed4bb4525bd96e50461655d2759'
+        ext_doc_id_val = "DocumentRef-spdx-tool-2.1"
+        spdx_doc_uri = "http://spdx.org/spdxdocs/spdx-tools-v2.1-3F2504E0-4F89-41D3-9A0C-0305E82C3301"
+        chksum = "SHA1: d6a770ba38583ed4bb4525bd96e50461655d2759"
+        chksum_val = "d6a770ba38583ed4bb4525bd96e50461655d2759"
 
-        self.builder.add_ext_doc_refs(self.document, ext_doc_id_val,
-                                      spdx_doc_uri, chksum)
-        assert self.document.ext_document_references[-1].external_document_id == ext_doc_id_val
-        assert self.document.ext_document_references[-1].spdx_document_uri == spdx_doc_uri
+        self.builder.add_ext_doc_refs(
+            self.document, ext_doc_id_val, spdx_doc_uri, chksum
+        )
+        assert (
+            self.document.ext_document_references[-1].external_document_id
+            == ext_doc_id_val
+        )
+        assert (
+            self.document.ext_document_references[-1].spdx_document_uri == spdx_doc_uri
+        )
         assert self.document.ext_document_references[-1].check_sum.value == chksum_val
 
 
@@ -155,56 +163,56 @@ class TestEntityBuilder(TestCase):
         self.document = Document()
 
     def test_tool(self):
-        tool_name = 'autoanal-2.0'
-        tool_str = 'Tool: ' + tool_name
+        tool_name = "autoanal-2.0"
+        tool_str = "Tool: " + tool_name
         tool = self.builder.build_tool(self.document, tool_str)
         assert tool.name == tool_name
 
     @testing_utils.raises(builders.SPDXValueError)
     def test_tool_value_error(self):
-        tool_str = 'tool: ll'
+        tool_str = "tool: ll"
         self.builder.build_tool(self.document, tool_str)
 
     def test_org_with_email(self):
-        org_name = 'Example'
-        org_email = 'example@example.org'
-        org_str = 'Organization: {0} ( {1} )'.format(org_name, org_email)
+        org_name = "Example"
+        org_email = "example@example.org"
+        org_str = "Organization: {0} ( {1} )".format(org_name, org_email)
         org = self.builder.build_org(self.document, org_str)
         assert org.name == org_name
         assert org.email == org_email
 
     def test_org(self):
-        org_name = 'Example'
-        org_str = 'Organization: {0} ()'.format(org_name)
+        org_name = "Example"
+        org_str = "Organization: {0} ()".format(org_name)
         org = self.builder.build_org(self.document, org_str)
         assert org.name == org_name
         assert org.email is None
 
     @testing_utils.raises(builders.SPDXValueError)
     def test_org_value_error(self):
-        org_name = 'Example'
-        org_str = 'Organization {0}'.format(org_name)
+        org_name = "Example"
+        org_str = "Organization {0}".format(org_name)
         self.builder.build_org(self.document, org_str)
 
     def test_person_with_email(self):
-        per_name = 'Bob'
-        per_email = 'bob@example.org'
-        per_str = 'Person: {0} ( {1} )'.format(per_name, per_email)
+        per_name = "Bob"
+        per_email = "bob@example.org"
+        per_str = "Person: {0} ( {1} )".format(per_name, per_email)
         per = self.builder.build_person(self.document, per_str)
         assert per.name == per_name
         assert per.email == per_email
 
     def test_per(self):
-        per_name = 'Bob'
-        per_str = 'Person: {0} ()'.format(per_name)
+        per_name = "Bob"
+        per_str = "Person: {0} ()".format(per_name)
         per = self.builder.build_person(self.document, per_str)
         assert per.name == per_name
         assert per.email is None
 
     @testing_utils.raises(builders.SPDXValueError)
     def test_per_value_error(self):
-        per_name = 'Bob'
-        per_str = 'Person {0}'.format(per_name)
+        per_name = "Bob"
+        per_str = "Person {0}".format(per_name)
         self.builder.build_person(self.document, per_str)
 
 
@@ -217,7 +225,7 @@ class TestCreationInfoBuilder(TestCase):
         self.entity_builder = builders.EntityBuilder()
 
     def test_add_creator(self):
-        per_str = 'Person: Bob (bob@example.com)'
+        per_str = "Person: Bob (bob@example.com)"
         per = self.entity_builder.build_person(self.document, per_str)
         assert self.builder.add_creator(self.document, per)
         assert len(self.document.creation_info.creators) == 1
@@ -225,37 +233,36 @@ class TestCreationInfoBuilder(TestCase):
 
     @testing_utils.raises(builders.SPDXValueError)
     def test_invalid_creator_type(self):
-        self.builder.add_creator(self.document, 'hello')
+        self.builder.add_creator(self.document, "hello")
 
     def test_created(self):
-        created_str = '2010-02-03T00:00:00Z'
+        created_str = "2010-02-03T00:00:00Z"
         assert self.builder.set_created_date(self.document, created_str)
 
     @testing_utils.raises(builders.CardinalityError)
     def test_more_than_one_created(self):
-        created_str = '2010-02-03T00:00:00Z'
+        created_str = "2010-02-03T00:00:00Z"
         self.builder.set_created_date(self.document, created_str)
         self.builder.set_created_date(self.document, created_str)
 
     @testing_utils.raises(builders.SPDXValueError)
     def test_created_value(self):
-        created_str = '2010-02-03T00:00:00'
+        created_str = "2010-02-03T00:00:00"
         self.builder.set_created_date(self.document, created_str)
 
     def test_license_list_vers(self):
-        vers_str = '1.2'
+        vers_str = "1.2"
         assert self.builder.set_lics_list_ver(self.document, vers_str)
-        assert (self.document.creation_info.license_list_version ==
-                Version(1, 2))
+        assert self.document.creation_info.license_list_version == Version(1, 2)
 
     @testing_utils.raises(builders.SPDXValueError)
     def test_lics_list_ver_value(self):
-        self.builder.set_lics_list_ver(self.document, '1 2')
+        self.builder.set_lics_list_ver(self.document, "1 2")
 
     @testing_utils.raises(builders.CardinalityError)
     def test_lics_list_ver_card(self):
-        self.builder.set_lics_list_ver(self.document, '1.2')
-        self.builder.set_lics_list_ver(self.document, '1.3')
+        self.builder.set_lics_list_ver(self.document, "1.2")
+        self.builder.set_lics_list_ver(self.document, "1.3")
 
 
 class TestReviewBuilder(TestCase):
@@ -268,37 +275,37 @@ class TestReviewBuilder(TestCase):
 
     @testing_utils.raises(builders.OrderError)
     def test_reviewed_without_reviewer(self):
-        date_str = '2010-02-03T00:00:00Z'
+        date_str = "2010-02-03T00:00:00Z"
         self.builder.add_review_date(self.document, date_str)
 
     @testing_utils.raises(builders.OrderError)
     def test_comment_without_reviewer(self):
-        comment = '<text>Comment</text>'
+        comment = "<text>Comment</text>"
         self.builder.add_review_comment(self.document, comment)
 
     @testing_utils.raises(builders.CardinalityError)
     def test_comment_cardinality(self):
-        comment = '<text>Comment</text>'
+        comment = "<text>Comment</text>"
         self.add_reviewer()
         assert self.builder.add_review_comment(self.document, comment)
         self.builder.add_review_comment(self.document, comment)
 
     @testing_utils.raises(builders.CardinalityError)
     def test_reviewed_cardinality(self):
-        date_str = '2010-02-03T00:00:00Z'
+        date_str = "2010-02-03T00:00:00Z"
         self.add_reviewer()
         assert self.builder.add_review_date(self.document, date_str)
         self.builder.add_review_date(self.document, date_str)
 
     def test_comment_reset(self):
-        comment = '<text>Comment</text>'
+        comment = "<text>Comment</text>"
         self.add_reviewer()
         assert self.builder.add_review_comment(self.document, comment)
         self.add_reviewer()
         assert self.builder.add_review_comment(self.document, comment)
 
     def test_reviewed_reset(self):
-        date_str = '2010-02-03T00:00:00Z'
+        date_str = "2010-02-03T00:00:00Z"
         self.add_reviewer()
         assert self.builder.add_review_date(self.document, date_str)
         self.add_reviewer()
@@ -306,18 +313,18 @@ class TestReviewBuilder(TestCase):
 
     @testing_utils.raises(builders.SPDXValueError)
     def test_date_value(self):
-        date_str = '2010-2-03T00:00:00Z'
+        date_str = "2010-2-03T00:00:00Z"
         self.add_reviewer()
         self.builder.add_review_date(self.document, date_str)
 
     @testing_utils.raises(builders.SPDXValueError)
     def test_comment_value(self):
-        comment = '<text>Comment<text>'
+        comment = "<text>Comment<text>"
         self.add_reviewer()
         self.builder.add_review_comment(self.document, comment)
 
     def add_reviewer(self):
-        per_str = 'Person: Bob (bob@example.com)'
+        per_str = "Person: Bob (bob@example.com)"
         per = self.entity_builder.build_person(self.document, per_str)
         self.builder.add_reviewer(self.document, per)
 
@@ -332,54 +339,54 @@ class TestAnnotationBuilder(TestCase):
 
     @testing_utils.raises(builders.OrderError)
     def test_annotation_without_annotator(self):
-        date_str = '2014-08-06T00:00:00Z'
+        date_str = "2014-08-06T00:00:00Z"
         self.builder.add_annotation_date(self.document, date_str)
 
     @testing_utils.raises(builders.OrderError)
     def test_comment_without_annotator(self):
-        comment = '<text>Comment without annotator</text>'
+        comment = "<text>Comment without annotator</text>"
         self.builder.add_annotation_comment(self.document, comment)
 
     @testing_utils.raises(builders.OrderError)
     def test_type_without_annotator(self):
-        annotation_type = 'REVIEW'
+        annotation_type = "REVIEW"
         self.builder.add_annotation_type(self.document, annotation_type)
 
     @testing_utils.raises(builders.OrderError)
     def test_spdx_id_without_annotator(self):
-        spdx_id = 'SPDXRef-45'
+        spdx_id = "SPDXRef-45"
         self.builder.set_annotation_spdx_id(self.document, spdx_id)
 
     @testing_utils.raises(builders.CardinalityError)
     def test_annotation_comment_cardinality(self):
-        comment = '<text>Annotation Comment</text>'
+        comment = "<text>Annotation Comment</text>"
         self.add_annotator()
         assert self.builder.add_annotation_comment(self.document, comment)
         self.builder.add_annotation_comment(self.document, comment)
 
     @testing_utils.raises(builders.CardinalityError)
     def test_annotation_cardinality(self):
-        date_str = '2014-08-06T00:00:00Z'
+        date_str = "2014-08-06T00:00:00Z"
         self.add_annotator()
         assert self.builder.add_annotation_date(self.document, date_str)
         self.builder.add_annotation_date(self.document, date_str)
 
     @testing_utils.raises(builders.CardinalityError)
     def test_annotation_spdx_id_cardinality(self):
-        spdx_id = 'SPDXRef-45'
+        spdx_id = "SPDXRef-45"
         self.add_annotator()
         self.builder.set_annotation_spdx_id(self.document, spdx_id)
         self.builder.set_annotation_spdx_id(self.document, spdx_id)
 
     def test_annotation_comment_reset(self):
-        comment = '<text>Annotation Comment</text>'
+        comment = "<text>Annotation Comment</text>"
         self.add_annotator()
         assert self.builder.add_annotation_comment(self.document, comment)
         self.add_annotator()
         assert self.builder.add_annotation_comment(self.document, comment)
 
     def test_annotation_reset(self):
-        date_str = '2014-08-06T00:00:00Z'
+        date_str = "2014-08-06T00:00:00Z"
         self.add_annotator()
         assert self.builder.add_annotation_date(self.document, date_str)
         self.add_annotator()
@@ -387,43 +394,83 @@ class TestAnnotationBuilder(TestCase):
 
     @testing_utils.raises(builders.SPDXValueError)
     def test_annotation_date_value(self):
-        date_str = '2014-8-06T00:00:00Z'
+        date_str = "2014-8-06T00:00:00Z"
         self.add_annotator()
         self.builder.add_annotation_date(self.document, date_str)
 
     @testing_utils.raises(builders.SPDXValueError)
     def test_annotation_comment_value(self):
-        comment = '<text>Annotation Comment<text>'
+        comment = "<text>Annotation Comment<text>"
         self.add_annotator()
         self.builder.add_annotation_comment(self.document, comment)
 
     @testing_utils.raises(builders.SPDXValueError)
     def test_incorrect_annotation_type_value(self):
-        annotation_type = 'Some random value instead of REVIEW or OTHER'
+        annotation_type = "Some random value instead of REVIEW or OTHER"
         self.add_annotator()
         self.builder.add_annotation_type(self.document, annotation_type)
 
     def test_correct_annotation_type(self):
-        annotation_type = 'REVIEW'
+        annotation_type = "REVIEW"
         self.add_annotator()
         assert self.builder.add_annotation_type(self.document, annotation_type)
 
     def test_correct_annotation_spdx_id(self):
-        spdx_id = 'SPDXRef-45'
+        spdx_id = "SPDXRef-45"
         self.add_annotator()
         self.builder.set_annotation_spdx_id(self.document, spdx_id)
 
     @testing_utils.raises(builders.CardinalityError)
     def test_annotation_type_cardinality(self):
-        annotation_type = 'REVIEW'
+        annotation_type = "REVIEW"
         self.add_annotator()
         assert self.builder.add_annotation_type(self.document, annotation_type)
         self.builder.add_annotation_type(self.document, annotation_type)
 
     def add_annotator(self):
-        per_str = 'Person: Jim (jim@example.com)'
+        per_str = "Person: Jim (jim@example.com)"
         per = self.entity_builder.build_person(self.document, per_str)
         self.builder.add_annotator(self.document, per)
+
+
+class TestRelationshipBuilder(TestCase):
+    maxDiff = None
+
+    def setUp(self):
+        self.entity_builder = builders.EntityBuilder()
+        self.builder = builders.RelationshipBuilder()
+        self.document = Document()
+
+    @testing_utils.raises(builders.OrderError)
+    def test_relationship_comment_without_relationship(self):
+        comment = "<text>Comment without relationship</text>"
+        self.builder.add_relationship_comment(self.document, comment)
+
+    def test_relationship_comment_reset(self):
+        comment = "<text>Relationship Comment</text>"
+        self.add_relationship()
+        assert self.builder.add_relationship_comment(self.document, comment)
+        self.add_relationship()
+        assert self.builder.add_relationship_comment(self.document, comment)
+
+    @testing_utils.raises(builders.SPDXValueError)
+    def test_incorrect_relationship_value(self):
+        relationship_type = "SPDXRef-DOCUMENT unknown SPDXRef-File"
+        self.builder.add_relationship(self.document, relationship_type)
+
+    @testing_utils.raises(builders.SPDXValueError)
+    def test_relationship_comment_value(self):
+        comment = "<text>Relationship Comment<text>"
+        self.add_relationship()
+        self.builder.add_relationship_comment(self.document, comment)
+
+    def test_correct_relationship(self):
+        relationship = "SPDXRef-DOCUMENT DESCRIBES SPDXRef-File"
+        assert self.builder.add_relationship(self.document, relationship)
+
+    def add_relationship(self):
+        relate_str = "SPDXRef-DOCUMENT DESCRIBES SPDXRef-File"
+        self.builder.add_relationship(self.document, relate_str)
 
 
 class TestPackageBuilder(TestCase):
@@ -436,24 +483,24 @@ class TestPackageBuilder(TestCase):
 
     @testing_utils.raises(builders.CardinalityError)
     def test_package_cardinality(self):
-        assert self.builder.create_package(self.document, 'pkg1')
-        self.builder.create_package(self.document, 'pkg2')
+        assert self.builder.create_package(self.document, "pkg1")
+        self.builder.create_package(self.document, "pkg2")
 
     def make_package(self):
-        self.builder.create_package(self.document, 'pkg')
+        self.builder.create_package(self.document, "pkg")
 
     def make_person(self):
-        per_str = 'Person: Bob (bob@example.com)'
+        per_str = "Person: Bob (bob@example.com)"
         per = self.entity_builder.build_person(self.document, per_str)
         return per
 
     @testing_utils.raises(builders.OrderError)
     def test_vers_order(self):
-        self.builder.set_pkg_vers(self.document, '1.1')
+        self.builder.set_pkg_vers(self.document, "1.1")
 
     @testing_utils.raises(builders.OrderError)
     def test_file_name_order(self):
-        self.builder.set_pkg_file_name(self.document, 'test.jar')
+        self.builder.set_pkg_file_name(self.document, "test.jar")
 
     @testing_utils.raises(builders.OrderError)
     def test_pkg_supplier_order(self):
@@ -465,147 +512,146 @@ class TestPackageBuilder(TestCase):
 
     @testing_utils.raises(builders.OrderError)
     def test_pkg_down_loc_order(self):
-        self.builder.set_pkg_down_location(
-            self.document, 'http://example.com/pkg')
+        self.builder.set_pkg_down_location(self.document, "http://example.com/pkg")
 
     @testing_utils.raises(builders.OrderError)
     def test_pkg_home_order(self):
-        self.builder.set_pkg_home(self.document, 'http://example.com')
+        self.builder.set_pkg_home(self.document, "http://example.com")
 
     @testing_utils.raises(builders.OrderError)
     def test_pkg_verif_order(self):
-        self.builder.set_pkg_verif_code(self.document, 'some code')
+        self.builder.set_pkg_verif_code(self.document, "some code")
 
     @testing_utils.raises(builders.OrderError)
     def test_pkg_chksum_order(self):
-        self.builder.set_pkg_chk_sum(self.document, 'some code')
+        self.builder.set_pkg_chk_sum(self.document, "some code")
 
     @testing_utils.raises(builders.OrderError)
     def test_pkg_source_info_order(self):
-        self.builder.set_pkg_source_info(self.document, 'hello')
+        self.builder.set_pkg_source_info(self.document, "hello")
 
     @testing_utils.raises(builders.OrderError)
     def test_pkg_licenses_concluded_order(self):
-        self.builder.set_pkg_licenses_concluded(self.document, 'some license')
+        self.builder.set_pkg_licenses_concluded(self.document, "some license")
 
     @testing_utils.raises(builders.OrderError)
     def test_pkg_lics_from_file_order(self):
-        self.builder.set_pkg_license_from_file(self.document, 'some license')
+        self.builder.set_pkg_license_from_file(self.document, "some license")
 
     @testing_utils.raises(builders.OrderError)
     def test_pkg_lics_decl_order(self):
-        self.builder.set_pkg_license_declared(self.document, 'license')
+        self.builder.set_pkg_license_declared(self.document, "license")
 
     @testing_utils.raises(builders.OrderError)
     def test_pkg_lics_comment_order(self):
-        self.builder.set_pkg_license_comment(
-            self.document, '<text>hello</text>')
+        self.builder.set_pkg_license_comment(self.document, "<text>hello</text>")
 
     @testing_utils.raises(builders.OrderError)
     def test_pkg_cr_text_order(self):
-        self.builder.set_pkg_cr_text(self.document, '<text>Something</text>')
+        self.builder.set_pkg_cr_text(self.document, "<text>Something</text>")
 
     @testing_utils.raises(builders.OrderError)
     def test_pkg_summary_order(self):
-        self.builder.set_pkg_summary(self.document, '<text>Something</text>')
+        self.builder.set_pkg_summary(self.document, "<text>Something</text>")
 
     @testing_utils.raises(builders.OrderError)
     def test_set_pkg_desc_order(self):
-        self.builder.set_pkg_desc(self.document, '<text>something</text>')
+        self.builder.set_pkg_desc(self.document, "<text>something</text>")
 
     @testing_utils.raises(builders.OrderError)
     def test_set_pkg_spdx_id_order(self):
-        self.builder.set_pkg_spdx_id(self.document, 'SPDXRe-Package')
+        self.builder.set_pkg_spdx_id(self.document, "SPDXRe-Package")
 
     @testing_utils.raises(builders.OrderError)
     def test_set_pkg_files_analyzed_order(self):
-        self.builder.set_pkg_files_analyzed(self.document, 'True')
+        self.builder.set_pkg_files_analyzed(self.document, "True")
 
     @testing_utils.raises(builders.OrderError)
     def test_set_pkg_comment_order(self):
-        self.builder.set_pkg_comment(self.document, '<text>something</text>')
+        self.builder.set_pkg_comment(self.document, "<text>something</text>")
 
     def test_correct_pkg_comment(self):
-        self.builder.create_package(self.document, 'pkg')
-        self.builder.set_pkg_comment(self.document, '<text>something</text>')
+        self.builder.create_package(self.document, "pkg")
+        self.builder.set_pkg_comment(self.document, "<text>something</text>")
 
     @testing_utils.raises(builders.SPDXValueError)
     def test_incorrect_pkg_comment(self):
-        self.builder.create_package(self.document, 'pkg')
-        self.builder.set_pkg_comment(self.document, 'not_free_form_text')
+        self.builder.create_package(self.document, "pkg")
+        self.builder.set_pkg_comment(self.document, "not_free_form_text")
 
     def test_correct_pkg_spdx_id(self):
-        self.builder.create_package(self.document, 'pkg')
-        assert self.builder.set_pkg_spdx_id(self.document, 'SPDXRef-Package')
-        assert self.document.package.spdx_id == 'SPDXRef-Package'
+        self.builder.create_package(self.document, "pkg")
+        assert self.builder.set_pkg_spdx_id(self.document, "SPDXRef-Package")
+        assert self.document.package.spdx_id == "SPDXRef-Package"
 
     @testing_utils.raises(builders.SPDXValueError)
     def test_incorrect_pkg_spdx_id(self):
-        self.builder.create_package(self.document, 'pkg')
-        assert self.builder.set_pkg_spdx_id(self.document, 'SPDXRe-Package')
+        self.builder.create_package(self.document, "pkg")
+        assert self.builder.set_pkg_spdx_id(self.document, "SPDXRe-Package")
 
     @testing_utils.raises(builders.SPDXValueError)
     def test_incorrect_pkg_files_analyzed(self):
-        self.builder.create_package(self.document, 'pkg')
-        assert self.builder.set_pkg_files_analyzed(self.document, 'XYZ')
+        self.builder.create_package(self.document, "pkg")
+        assert self.builder.set_pkg_files_analyzed(self.document, "XYZ")
 
     def test_correct_pkg_files_analyzed_1(self):
-        self.builder.create_package(self.document, 'pkg')
-        assert self.builder.set_pkg_files_analyzed(self.document, 'True')
+        self.builder.create_package(self.document, "pkg")
+        assert self.builder.set_pkg_files_analyzed(self.document, "True")
 
     def test_correct_pkg_files_analyzed_2(self):
-        self.builder.create_package(self.document, 'pkg')
-        assert self.builder.set_pkg_files_analyzed(self.document, 'true')
+        self.builder.create_package(self.document, "pkg")
+        assert self.builder.set_pkg_files_analyzed(self.document, "true")
 
     def test_correct_pkg_ext_ref_category(self):
-        category = 'SECURITY'
-        self.builder.create_package(self.document, 'pkg')
+        category = "SECURITY"
+        self.builder.create_package(self.document, "pkg")
         self.builder.set_pkg_ext_ref_category(self.document, category)
         assert self.document.package.pkg_ext_refs[-1].category == category
 
     @testing_utils.raises(builders.SPDXValueError)
     def test_incorrect_pkg_ext_ref_category(self):
-        category = 'some_other_value'
-        self.builder.create_package(self.document, 'pkg')
+        category = "some_other_value"
+        self.builder.create_package(self.document, "pkg")
         self.builder.set_pkg_ext_ref_category(self.document, category)
 
     def test_correct_pkg_ext_ref_type(self):
-        pkg_ext_ref_type = 'cpe23Type'
-        self.builder.create_package(self.document, 'pkg')
+        pkg_ext_ref_type = "cpe23Type"
+        self.builder.create_package(self.document, "pkg")
         self.builder.set_pkg_ext_ref_type(self.document, pkg_ext_ref_type)
-        assert self.document.package.pkg_ext_refs[
-                   -1].pkg_ext_ref_type == pkg_ext_ref_type
+        assert (
+            self.document.package.pkg_ext_refs[-1].pkg_ext_ref_type == pkg_ext_ref_type
+        )
 
     @testing_utils.raises(builders.SPDXValueError)
     def test_incorrect_pkg_ext_ref_type(self):
-        pkg_ext_ref_type = 'cpe23Type_with_special_symbols&%'
-        self.builder.create_package(self.document, 'pkg')
+        pkg_ext_ref_type = "cpe23Type_with_special_symbols&%"
+        self.builder.create_package(self.document, "pkg")
         self.builder.set_pkg_ext_ref_type(self.document, pkg_ext_ref_type)
 
     def test_correct_pkg_ext_ref_locator(self):
-        locator = 'cpe:2.3:a:pivotal_software:spring_framework:4.1.0:*:*:*'
-        self.builder.create_package(self.document, 'pkg')
+        locator = "cpe:2.3:a:pivotal_software:spring_framework:4.1.0:*:*:*"
+        self.builder.create_package(self.document, "pkg")
         self.builder.set_pkg_ext_ref_locator(self.document, locator)
         assert self.document.package.pkg_ext_refs[-1].locator == locator
 
     @testing_utils.raises(builders.OrderError)
     def test_pkg_ext_ref_without_pkg(self):
-        locator = 'cpe:2.3:a:pivotal_software:spring_framework:4.1.0:*:*:*'
+        locator = "cpe:2.3:a:pivotal_software:spring_framework:4.1.0:*:*:*"
         self.builder.set_pkg_ext_ref_locator(self.document, locator)
 
     def test_correct_pkg_ext_comment(self):
-        comment_str = 'This is a comment.'
-        comment_text = '<text>' + comment_str + '</text>'
-        self.builder.create_package(self.document, 'pkg')
-        self.builder.set_pkg_ext_ref_category(self.document, 'SECURITY')
+        comment_str = "This is a comment."
+        comment_text = "<text>" + comment_str + "</text>"
+        self.builder.create_package(self.document, "pkg")
+        self.builder.set_pkg_ext_ref_category(self.document, "SECURITY")
         self.builder.add_pkg_ext_ref_comment(self.document, comment_text)
         assert self.document.package.pkg_ext_refs[-1].comment == comment_str
 
     @testing_utils.raises(builders.OrderError)
     def test_pkg_ext_comment_without_pkg_ext_ref(self):
-        comment_str = 'This is a comment.'
-        comment_text = '<text>' + comment_str + '</text>'
-        self.builder.create_package(self.document, 'pkg')
+        comment_str = "This is a comment."
+        comment_text = "<text>" + comment_str + "</text>"
+        self.builder.create_package(self.document, "pkg")
         self.builder.add_pkg_ext_ref_comment(self.document, comment_text)
 
 
@@ -618,131 +664,127 @@ class TestSnippetBuilder(TestCase):
         self.document = Document()
 
     def test_create_snippet(self):
-        assert self.builder.create_snippet(self.document, 'SPDXRef-Snippet')
+        assert self.builder.create_snippet(self.document, "SPDXRef-Snippet")
 
     @testing_utils.raises(builders.SPDXValueError)
     def test_incorrect_snippet_spdx_id(self):
-        self.builder.create_snippet(self.document, 'Some_value_with_$%')
+        self.builder.create_snippet(self.document, "Some_value_with_$%")
 
     def test_snippet_name(self):
-        self.builder.create_snippet(self.document, 'SPDXRef-Snippet')
-        self.builder.set_snippet_name(self.document, 'Name_of_snippet')
+        self.builder.create_snippet(self.document, "SPDXRef-Snippet")
+        self.builder.set_snippet_name(self.document, "Name_of_snippet")
 
     @testing_utils.raises(builders.OrderError)
     def test_snippet_name_order(self):
-        self.builder.set_snippet_name(self.document, 'Name_of_snippet')
+        self.builder.set_snippet_name(self.document, "Name_of_snippet")
 
     def test_snippet_comment(self):
-        self.builder.create_snippet(self.document, 'SPDXRef-Snippet')
-        self.builder.set_snippet_comment(self.document, '<text>Comment</text>')
+        self.builder.create_snippet(self.document, "SPDXRef-Snippet")
+        self.builder.set_snippet_comment(self.document, "<text>Comment</text>")
 
     @testing_utils.raises(builders.OrderError)
     def test_snippet_comment_order(self):
-        self.builder.set_snippet_comment(self.document, '<text>Comment</text>')
+        self.builder.set_snippet_comment(self.document, "<text>Comment</text>")
 
     @testing_utils.raises(builders.SPDXValueError)
     def test_snippet_comment_text_value(self):
-        self.builder.create_snippet(self.document, 'SPDXRef-Snippet')
-        self.builder.set_snippet_comment(self.document, 'Comment.')
+        self.builder.create_snippet(self.document, "SPDXRef-Snippet")
+        self.builder.set_snippet_comment(self.document, "Comment.")
 
     def test_snippet_copyright(self):
-        self.builder.create_snippet(self.document, 'SPDXRef-Snippet')
-        self.builder.set_snippet_copyright(self.document, '<text>Copyright 2008-2010 John Smith</text>')
+        self.builder.create_snippet(self.document, "SPDXRef-Snippet")
+        self.builder.set_snippet_copyright(
+            self.document, "<text>Copyright 2008-2010 John Smith</text>"
+        )
 
     @testing_utils.raises(builders.SPDXValueError)
     def test_snippet_copyright_text_value(self):
-        self.builder.create_snippet(self.document, 'SPDXRef-Snippet')
-        self.builder.set_snippet_copyright(self.document,
-                                           'Copyright 2008-2010 John Smith')
+        self.builder.create_snippet(self.document, "SPDXRef-Snippet")
+        self.builder.set_snippet_copyright(
+            self.document, "Copyright 2008-2010 John Smith"
+        )
 
     @testing_utils.raises(builders.OrderError)
     def test_snippet_copyright_order(self):
-        self.builder.set_snippet_copyright(self.document,
-                                           '<text>Copyright 2008-2010 John Smith</text>')
+        self.builder.set_snippet_copyright(
+            self.document, "<text>Copyright 2008-2010 John Smith</text>"
+        )
 
     def test_snippet_lic_comment(self):
-        self.builder.create_snippet(self.document, 'SPDXRef-Snippet')
-        self.builder.set_snippet_lic_comment(self.document,
-                                             '<text>Lic comment</text>')
+        self.builder.create_snippet(self.document, "SPDXRef-Snippet")
+        self.builder.set_snippet_lic_comment(self.document, "<text>Lic comment</text>")
 
     @testing_utils.raises(builders.SPDXValueError)
     def test_snippet_lic_comment_text_value(self):
-        self.builder.create_snippet(self.document, 'SPDXRef-Snippet')
-        self.builder.set_snippet_lic_comment(self.document,
-                                             'Lic comment')
+        self.builder.create_snippet(self.document, "SPDXRef-Snippet")
+        self.builder.set_snippet_lic_comment(self.document, "Lic comment")
 
     @testing_utils.raises(builders.OrderError)
     def test_snippet_lic_comment_order(self):
-        self.builder.set_snippet_lic_comment(self.document,
-                                             '<text>Lic comment</text>')
+        self.builder.set_snippet_lic_comment(self.document, "<text>Lic comment</text>")
 
     def test_snippet_from_file_spdxid(self):
-        self.builder.create_snippet(self.document, 'SPDXRef-Snippet')
-        self.builder.set_snip_from_file_spdxid(self.document,
-                                               'SPDXRef-DoapSource')
+        self.builder.create_snippet(self.document, "SPDXRef-Snippet")
+        self.builder.set_snip_from_file_spdxid(self.document, "SPDXRef-DoapSource")
 
     @testing_utils.raises(builders.SPDXValueError)
     def test_snippet_from_file_spdxid_value(self):
-        self.builder.create_snippet(self.document, 'SPDXRef-Snippet')
-        self.builder.set_snip_from_file_spdxid(self.document,
-                                               '#_$random_chars')
+        self.builder.create_snippet(self.document, "SPDXRef-Snippet")
+        self.builder.set_snip_from_file_spdxid(self.document, "#_$random_chars")
 
     @testing_utils.raises(builders.OrderError)
     def test_snippet_from_file_spdxid_order(self):
-        self.builder.set_snip_from_file_spdxid(self.document,
-                                               'SPDXRef-DoapSource')
+        self.builder.set_snip_from_file_spdxid(self.document, "SPDXRef-DoapSource")
 
     @testing_utils.raises(builders.CardinalityError)
     def test_snippet_from_file_spdxid_cardinality(self):
-        self.builder.create_snippet(self.document, 'SPDXRef-Snippet')
-        self.builder.set_snip_from_file_spdxid(self.document,
-                                               'SPDXRef-DoapSource')
-        self.builder.set_snip_from_file_spdxid(self.document,
-                                               'SPDXRef-somevalue')
+        self.builder.create_snippet(self.document, "SPDXRef-Snippet")
+        self.builder.set_snip_from_file_spdxid(self.document, "SPDXRef-DoapSource")
+        self.builder.set_snip_from_file_spdxid(self.document, "SPDXRef-somevalue")
 
     def test_snippet_conc_lics(self):
-        self.builder.create_snippet(self.document, 'SPDXRef-Snippet')
-        self.builder.set_snip_concluded_license(self.document,
-                                                License.from_identifier(
-                                                    'Apache-2.0'))
+        self.builder.create_snippet(self.document, "SPDXRef-Snippet")
+        self.builder.set_snip_concluded_license(
+            self.document, License.from_identifier("Apache-2.0")
+        )
 
     @testing_utils.raises(builders.SPDXValueError)
     def test_snippet_conc_lics_value(self):
-        self.builder.create_snippet(self.document, 'SPDXRef-Snippet')
-        self.builder.set_snip_concluded_license(self.document, 'Apache-2.0')
+        self.builder.create_snippet(self.document, "SPDXRef-Snippet")
+        self.builder.set_snip_concluded_license(self.document, "Apache-2.0")
 
     @testing_utils.raises(builders.OrderError)
     def test_snippet_conc_lics_order(self):
-        self.builder.set_snip_concluded_license(self.document,
-                                                License.from_identifier(
-                                                    'Apache-2.0'))
+        self.builder.set_snip_concluded_license(
+            self.document, License.from_identifier("Apache-2.0")
+        )
 
     @testing_utils.raises(builders.CardinalityError)
     def test_snippet_conc_lics_cardinality(self):
-        self.builder.create_snippet(self.document, 'SPDXRef-Snippet')
-        self.builder.set_snip_concluded_license(self.document,
-                                                License.from_identifier(
-                                                    'Apache-2.0'))
-        self.builder.set_snip_concluded_license(self.document,
-                                                License.from_identifier(
-                                                    'Apache-2.0'))
+        self.builder.create_snippet(self.document, "SPDXRef-Snippet")
+        self.builder.set_snip_concluded_license(
+            self.document, License.from_identifier("Apache-2.0")
+        )
+        self.builder.set_snip_concluded_license(
+            self.document, License.from_identifier("Apache-2.0")
+        )
 
     def test_snippet_lics_info(self):
-        self.builder.create_snippet(self.document, 'SPDXRef-Snippet')
-        self.builder.set_snippet_lics_info(self.document,
-                                           License.from_identifier(
-                                               'Apache-2.0'))
-        self.builder.set_snippet_lics_info(self.document,
-                                           License.from_identifier(
-                                               'GPL-2.0-or-later'))
+        self.builder.create_snippet(self.document, "SPDXRef-Snippet")
+        self.builder.set_snippet_lics_info(
+            self.document, License.from_identifier("Apache-2.0")
+        )
+        self.builder.set_snippet_lics_info(
+            self.document, License.from_identifier("GPL-2.0-or-later")
+        )
 
     @testing_utils.raises(builders.SPDXValueError)
     def test_snippet_lics_info_value(self):
-        self.builder.create_snippet(self.document, 'SPDXRef-Snippet')
-        self.builder.set_snippet_lics_info(self.document, 'Apache-2.0')
+        self.builder.create_snippet(self.document, "SPDXRef-Snippet")
+        self.builder.set_snippet_lics_info(self.document, "Apache-2.0")
 
     @testing_utils.raises(builders.OrderError)
     def test_snippet_lics_info_order(self):
-        self.builder.set_snippet_lics_info(self.document,
-                                           License.from_identifier(
-                                               'Apache-2.0'))
+        self.builder.set_snippet_lics_info(
+            self.document, License.from_identifier("Apache-2.0")
+        )


### PR DESCRIPTION
Reference: #138 
# Summary
this P.R. is a part of my communitybridge project (1st evaluation). I am pretty much done with code but it needs to be debugged & reviewed. 
This P.R. adds relationship (parser, builder & writer) to every format (rdf, tag, jsonyamlxml).

When running the tests, the relationship shows ERROR:
(mostly this)
```
doc.add_relationship(relationship.Relationship(relationship=relationship))
AttributeError: 'str' object has no attribute 'Relationship'

``` 


## Files Created/Changed:
1. spdx/relationship.py
2. spdx/parsers/rdf.py
3. spdx/parsers/rdfbuilder.py
4. spdx/parsers/tagvalue.py
5. spdx/parser/tagvaluebuilder.py
6. spdx/parser/jsonyamlxml.py
7. spdx/parser/jsonyamlxmlbuilder.py
8. spdx/writers/rdf.py
9. spdx/writers/tagvalue.py
10. spdx/writers/jsonyamlxml.py
11. tests/test_builder.py

## Status
- [x]  Debugging 

- [ ]  Ready to Merge

## Update
1. Above error (AttributeError) has been resolved from rdf & tagvalue builders (json & others left), also now, all the builders test are passing for relationship
2. parsers for relationships (all formats) are now passing all the tests.

> Used 'Black' formatter for all python files edited.