### PR TITLE
fix validation errors when files_analyzed is false

### DIFF
--- a/spdx/package.py
+++ b/spdx/package.py
@@ -250,7 +250,7 @@ class Package(object):
         return messages
 
     def validate_checksum(self, messages):
-        if self.check_sum is not None: # optional
+        if self.check_sum is not None:
             if not isinstance(self.check_sum, checksum.Algorithm):
                 messages = messages + [
                     'Package checksum must be instance of spdx.checksum.Algorithm'

--- a/spdx/package.py
+++ b/spdx/package.py
@@ -124,7 +124,7 @@ class Package(object):
             messages = messages + [
                 'Package files_analyzed must be True or False or None (omitted)'
             ]
-        if self.files_analyzed == False and self.verif_code is not None:
+        if self.files_analyzed is False and self.verif_code is not None:
             messages = messages + [
                 'Package verif_code must be None (omitted) when files_analyzed is False'
             ]

--- a/spdx/parsers/tagvalue.py
+++ b/spdx/parsers/tagvalue.py
@@ -81,6 +81,7 @@ ERROR_MESSAGES = {
     'PKG_COMMENT_VALUE': 'PackageComment must be free form text, line: {0}',
     'PKG_EXT_REF_VALUE': 'ExternalRef must contain category, type, and locator in the standard format, line:{0}.',
     'PKG_EXT_REF_COMMENT_VALUE' : 'ExternalRefComment must be free form text, line:{0}',
+    'PKG_VERF_CODE_VALUE': 'VerificationCode doesn\'t match verifcode form, line:{0}',
     'FILE_NAME_VALUE': 'FileName must be a single line of text, line: {0}',
     'FILE_COMMENT_VALUE': 'FileComment must be free form text, line:{0}',
     'FILE_TYPE_VALUE': 'FileType must be one of OTHER, BINARY, SOURCE or ARCHIVE, line: {0}',

--- a/spdx/parsers/tagvaluebuilders.py
+++ b/spdx/parsers/tagvaluebuilders.py
@@ -683,8 +683,10 @@ class PackageBuilder(object):
             if files_analyzed:
                 if validations.validate_pkg_files_analyzed(files_analyzed):
                     self.package_files_analyzed_set = True
-                    doc.package.files_analyzed = files_analyzed
-                    print(doc.package.files_analyzed)
+                    doc.package.files_analyzed = (files_analyzed.lower() == 'true')
+                    # convert to boolean;
+                    # validate_pkg_files_analyzed already checked if
+                    # files_analyzed is in ['True', 'true', 'False', 'false']
                     return True
                 else:
                     raise SPDXValueError('Package::FilesAnalyzed')

--- a/spdx/writers/rdf.py
+++ b/spdx/writers/rdf.py
@@ -589,7 +589,8 @@ class PackageWriter(LicenseWriter):
         down_loc_node = (package_node, self.spdx_namespace.downloadLocation, self.to_special_value(package.download_location))
         self.graph.add(down_loc_node)
         # Handle package verification
-        verif_node = self.package_verif_node(package)
+        if package.files_analyzed != False:
+            verif_node = self.package_verif_node(package)
         verif_triple = (package_node, self.spdx_namespace.packageVerificationCode, verif_node)
         self.graph.add(verif_triple)
         # Handle concluded license

--- a/spdx/writers/tagvalue.py
+++ b/spdx/writers/tagvalue.py
@@ -210,7 +210,8 @@ def write_package(package, out):
     if package.has_optional_field('check_sum'):
         write_value('PackageChecksum', package.check_sum.to_tv(), out)
 
-    write_value('PackageVerificationCode', format_verif_code(package), out)
+    if package.has_optional_field('verif_code'):
+        write_value('PackageVerificationCode', format_verif_code(package), out)
 
     if package.has_optional_field('description'):
         write_text_value('PackageDescription', package.description, out)

--- a/tests/data/doc_write/tv-mini.tv
+++ b/tests/data/doc_write/tv-mini.tv
@@ -5,7 +5,6 @@ SPDXID: SPDXRef-DOCUMENT
 # Creation Info
 # Package
 PackageDownloadLocation: NOASSERTION
-PackageVerificationCode: None
 PackageLicenseDeclared: NOASSERTION
 PackageLicenseConcluded: NOASSERTION
 # Extracted Licenses

--- a/tests/data/formats/SPDXRdfExample.rdf
+++ b/tests/data/formats/SPDXRdfExample.rdf
@@ -134,7 +134,7 @@
       <Package rdf:about="http://www.spdx.org/tools#SPDXRef-Package">
         <licenseInfoFromFiles rdf:resource="http://spdx.org/licenses/Apache-1.0"/>
         <downloadLocation>http://www.spdx.org/tools</downloadLocation>
-        <filesAnalyzed>false</filesAnalyzed>
+        <filesAnalyzed>true</filesAnalyzed>
         <supplier>Organization:Linux Foundation</supplier>
         <hasFile rdf:nodeID="A0"/>
         <licenseInfoFromFiles rdf:resource="http://spdx.org/licenses/Apache-2.0"/>

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -80,6 +80,7 @@ class TestDocument(TestCase):
                        'Sample_Document-V2.1', spdx_id='SPDXRef-DOCUMENT',
                        namespace='https://spdx.org/spdxdocs/spdx-example-444504E0-4F89-41D3-9A0C-0305E82C3301')
         pack = doc.package = Package('some/path', NoAssert())
+        pack.check_sum = 'SOME-SHA1'
         file1 = File('./some/path/tofile')
         file1.name = './some/path/tofile'
         file1.spdx_id = 'SPDXRef-File'
@@ -102,7 +103,7 @@ class TestDocument(TestCase):
             'Package declared license must be instance of spdx.utils.SPDXNone '
             'or spdx.utils.NoAssert or spdx.document.License'
         ]
-        assert expected == messages
+        assert sorted(expected) == sorted(messages)
 
     def test_document_is_valid_when_using_or_later_licenses(self):
         doc = Document(Version(2, 1), License.from_identifier('CC0-1.0'),
@@ -131,8 +132,7 @@ class TestDocument(TestCase):
         package.add_lics_from_file(lic1)
         package.add_file(file1)
         messages = []
-        is_valid = doc.validate(messages)
-        assert is_valid
+        messages = doc.validate(messages)
         assert not messages
 
 

--- a/tests/test_tag_value_parser.py
+++ b/tests/test_tag_value_parser.py
@@ -216,7 +216,7 @@ class TestParser(TestCase):
         'SPDXID: SPDXRef-Package',
         'PackageVersion: Version 0.9.2',
         'PackageDownloadLocation: http://example.com/test',
-        'FilesAnalyzed: False',
+        'FilesAnalyzed: True',
         'PackageSummary: <text>Test package</text>',
         'PackageSourceInfo: <text>Version 1.0 of test</text>',
         'PackageFileName: test-1.0.zip',
@@ -303,7 +303,7 @@ class TestParser(TestCase):
         assert document.package.version == 'Version 0.9.2'
         assert len(document.package.licenses_from_files) == 2
         assert (document.package.conc_lics.identifier == 'LicenseRef-2.0 AND Apache-2.0')
-        assert document.package.files_analyzed == 'False'
+        assert document.package.files_analyzed == True
         assert document.package.comment == 'Comment on the package.'
         assert document.package.pkg_ext_refs[-1].category == 'SECURITY'
         assert document.package.pkg_ext_refs[-1].pkg_ext_ref_type == 'cpe23Type'


### PR DESCRIPTION
( solves issue #149 )

According to **SPDX 2.2 specs**, when files_analyzed is false in a package:

- there *must* be *no* files in the package, so files must *not* be validated (**section 3.8.1**)
- there *must* be *no* verif_code (**section 3.9.3**)
- there may be no check_sum (which is optional, anyway - **section 3.10.3**)

Finally, also files_analyzed should be validated (must be True, False or None, (None="omitted")

This patch covers all the above, and fixes an error in tagvaluebuilder.py, where files_analyzed was stored as string in the package object, while it should be stored as boolean.

Moreover, rdf and tagvalue writers, as well as test files, have been patched accordingly.