### PR TITLE
introduce message handler

### DIFF
--- a/examples/pp_tv.py
+++ b/examples/pp_tv.py
@@ -8,6 +8,7 @@ if __name__ == "__main__":
     from spdx.writers.tagvalue import write_document, InvalidDocumentError
     from spdx.parsers.tagvalue import Parser
     from spdx.parsers.loggers import StandardLogger
+    from spdx.parsers.loggers import ErrorMessages
     from spdx.parsers.tagvaluebuilders import Builder
 
     source = sys.argv[1]
@@ -24,8 +25,8 @@ if __name__ == "__main__":
                     write_document(document, out)
                 except InvalidDocumentError:
                     print("Document is Invalid")
-                    messages = []
+                    messages = ErrorMessages()
                     document.validate(messages)
-                    print("\n".join(messages))
+                    print("\n".join(messages.messages))
         else:
             print("Errors encountered while parsing")

--- a/examples/write_tv.py
+++ b/examples/write_tv.py
@@ -6,6 +6,7 @@ if __name__ == "__main__":
     import sys
     import codecs
     from spdx.writers.tagvalue import write_document, InvalidDocumentError
+    from spdx.parsers.loggers import ErrorMessages
     from spdx.document import Document, License, LicenseConjunction, ExtractedLicense
     from spdx.version import Version
     from spdx.creationinfo import Person
@@ -88,6 +89,6 @@ if __name__ == "__main__":
         except InvalidDocumentError as e:
             print("Document is Invalid:\n\t", end="")
             print("\n\t".join(e.args[0]))
-            messages = []
+            messages = ErrorMessages()
             doc.validate(messages)
-            print("\n".join(messages))
+            print("\n".join(messages.messages))

--- a/spdx/annotation.py
+++ b/spdx/annotation.py
@@ -79,33 +79,23 @@ class Annotation(object):
         """Returns True if all the fields are valid.
         Appends any error messages to messages parameter.
         """
-        messages = self.validate_annotator(messages)
-        messages = self.validate_annotation_date(messages)
-        messages = self.validate_annotation_type(messages)
-        messages = self.validate_spdx_id(messages)
-
-        return messages
+        self.validate_annotator(messages)
+        self.validate_annotation_date(messages)
+        self.validate_annotation_type(messages)
+        self.validate_spdx_id(messages)
 
     def validate_annotator(self, messages):
         if self.annotator is None:
-            messages = messages + ["Annotation missing annotator."]
-
-        return messages
+            messages.append("Annotation missing annotator.")
 
     def validate_annotation_date(self, messages):
         if self.annotation_date is None:
-            messages = messages + ["Annotation missing annotation date."]
-
-        return messages
+            messages.append("Annotation missing annotation date.")
 
     def validate_annotation_type(self, messages):
         if self.annotation_type is None:
-            messages = messages + ["Annotation missing annotation type."]
-
-        return messages
+            messages.append("Annotation missing annotation type.")
 
     def validate_spdx_id(self, messages):
         if self.spdx_id is None:
-            messages = messages + ["Annotation missing SPDX Identifier Reference."]
-
-        return messages
+            messages.append("Annotation missing SPDX Identifier Reference.")

--- a/spdx/annotation.py
+++ b/spdx/annotation.py
@@ -76,8 +76,9 @@ class Annotation(object):
         return self.comment is not None
 
     def validate(self, messages):
-        """Returns True if all the fields are valid.
-        Appends any error messages to messages parameter.
+        """
+        Check that all the fields are valid.
+        Appends any error messages to messages parameter shall be a ErrorMessages.
         """
         self.validate_annotator(messages)
         self.validate_annotation_date(messages)

--- a/spdx/creationinfo.py
+++ b/spdx/creationinfo.py
@@ -175,12 +175,12 @@ class CreationInfo(object):
 
     def validate_creators(self, messages):
         if len(self.creators) == 0:
-            messages = messages + ["No creators defined, must have at least one."]
+            messages.append("No creators defined, must have at least one.")
 
         return messages
 
     def validate_created(self, messages):
         if self.created is None:
-            messages = messages + ["Creation info missing created date."]
+            messages.append("Creation info missing created date.")
 
         return messages

--- a/spdx/creationinfo.py
+++ b/spdx/creationinfo.py
@@ -165,22 +165,17 @@ class CreationInfo(object):
         return self.comment is not None
 
     def validate(self, messages):
-        """Returns True if the fields are valid according to the SPDX standard.
-        Appends user friendly messages to the messages parameter.
         """
-        messages = self.validate_creators(messages)
-        messages = self.validate_created(messages)
-
-        return messages
+        Check that all the fields are valid.
+        Appends any error messages to messages parameter shall be a ErrorMessages.
+        """
+        self.validate_creators(messages)
+        self.validate_created(messages)
 
     def validate_creators(self, messages):
         if len(self.creators) == 0:
             messages.append("No creators defined, must have at least one.")
 
-        return messages
-
     def validate_created(self, messages):
         if self.created is None:
             messages.append("Creation info missing created date.")
-
-        return messages

--- a/spdx/document.py
+++ b/spdx/document.py
@@ -53,29 +53,21 @@ class ExternalDocumentRef(object):
         Validate all fields of the ExternalDocumentRef class and update the
         messages list with user friendly error messages for display.
         """
-        messages = self.validate_ext_doc_id(messages)
-        messages = self.validate_spdx_doc_uri(messages)
-        messages = self.validate_checksum(messages)
-
-        return messages
+        self.validate_ext_doc_id(messages)
+        self.validate_spdx_doc_uri(messages)
+        self.validate_checksum(messages)
 
     def validate_ext_doc_id(self, messages):
         if not self.external_document_id:
-            messages = messages + ["ExternalDocumentRef has no External Document ID."]
-
-        return messages
+            messages.append("ExternalDocumentRef has no External Document ID.")
 
     def validate_spdx_doc_uri(self, messages):
         if not self.spdx_document_uri:
-            messages = messages + ["ExternalDocumentRef has no SPDX Document URI."]
-
-        return messages
+            messages.append("ExternalDocumentRef has no SPDX Document URI.")
 
     def validate_checksum(self, messages):
         if not self.check_sum:
-            messages = messages + ["ExternalDocumentRef has no Checksum."]
-
-        return messages
+            messages.append("ExternalDocumentRef has no Checksum.")
 
 
 def _add_parens(required, text):
@@ -268,9 +260,7 @@ class ExtractedLicense(License):
 
     def validate(self, messages):
         if self.text is None:
-            messages = messages + ["ExtractedLicense text can not be None"]
-
-        return messages
+            messages.append("ExtractedLicense text can not be None")
 
 
 class Document(object):
@@ -391,58 +381,47 @@ class Document(object):
         Validate all fields of the document and update the
         messages list with user friendly error messages for display.
         """
-        messages = self.validate_version(messages)
-        messages = self.validate_data_lics(messages)
-        messages = self.validate_name(messages)
-        messages = self.validate_spdx_id(messages)
-        messages = self.validate_namespace(messages)
-        messages = self.validate_ext_document_references(messages)
-        messages = self.validate_creation_info(messages)
-        messages = self.validate_packages(messages)
-        messages = self.validate_extracted_licenses(messages)
-        messages = self.validate_reviews(messages)
-        messages = self.validate_snippet(messages)
-        # messages = self.validate_annotations(messages)
-        # messages = self.validate_relationships(messages)
-
+        self.validate_version(messages)
+        self.validate_data_lics(messages)
+        self.validate_name(messages)
+        self.validate_spdx_id(messages)
+        self.validate_namespace(messages)
+        self.validate_ext_document_references(messages)
+        self.validate_creation_info(messages)
+        self.validate_packages(messages)
+        self.validate_extracted_licenses(messages)
+        self.validate_reviews(messages)
+        self.validate_snippet(messages)
+        # self.validate_annotations(messages)
+        # self.validate_relationships(messages)
         return messages
-
+        
     def validate_version(self, messages):
         if self.version is None:
-            messages = messages + ["Document has no version."]
-
-        return messages
+            messages.append("Document has no version.")
 
     def validate_data_lics(self, messages):
         if self.data_license is None:
-            messages = messages + ["Document has no data license."]
+            messages.append("Document has no data license.")
         else:
             # FIXME: REALLY? what if someone wants to use something else?
             if self.data_license.identifier != "CC0-1.0":
-                messages = messages + ["Document data license must be CC0-1.0."]
-
-        return messages
+                messages.append("Document data license must be CC0-1.0.")
 
     def validate_name(self, messages):
         if self.name is None:
-            messages = messages + ["Document has no name."]
-
-        return messages
+            messages.append("Document has no name.")
 
     def validate_namespace(self, messages):
         if self.namespace is None:
-            messages = messages + ["Document has no namespace."]
-
-        return messages
+            messages.append("Document has no namespace.")
 
     def validate_spdx_id(self, messages):
         if self.spdx_id is None:
-            messages = messages + ["Document has no SPDX Identifier."]
+            messages.append("Document has no SPDX Identifier.")
         else:
             if not self.spdx_id.endswith("SPDXRef-DOCUMENT"):
-                messages = messages + ["Invalid Document SPDX Identifier value."]
-
-        return messages
+                messages.append("Invalid Document SPDX Identifier value.")
 
     def validate_ext_document_references(self, messages):
         for doc in self.ext_document_references:
@@ -453,64 +432,47 @@ class Document(object):
                     "External document references must be of the type "
                     "spdx.document.ExternalDocumentRef and not " + str(type(doc))
                 ]
-        return messages
-
     def validate_reviews(self, messages):
         for review in self.reviews:
             messages = review.validate(messages)
-
-        return messages
 
     def validate_annotations(self, messages):
         for annotation in self.annotations:
             messages = annotation.validate(messages)
 
-        return messages
-
     def validate_relationships(self, messages):
         for relationship in self.relationships:
             messages = relationship.validate(messages)
 
-        return messages
-
     def validate_snippet(self, messages=None):
         for snippet in self.snippet:
-            messages = snippet.validate(messages)
-
-        return messages
+            snippet.validate(messages)
 
     def validate_creation_info(self, messages):
         if self.creation_info is not None:
-            messages = self.creation_info.validate(messages)
+            self.creation_info.validate(messages)
         else:
-            messages = messages + ["Document has no creation information."]
-
-        return messages
+            messages.append("Document has no creation information.")
 
     def validate_packages(self, messages):
         if len(self.packages) > 0:
             for package in self.packages:
                 messages = package.validate(messages)
         else:
-            messages = messages + ["Document has no packages."]
-
-        return messages
+            messages.append("Document has no packages.")
 
     def validate_package(self, messages):
         if self.package is not None:
-            messages = self.package.validate(messages)
+            self.package.validate(messages)
         else:
-            messages = messages + ["Document has no packages."]
-
-        return messages
+            messages.append("Document has no packages.")
 
     def validate_extracted_licenses(self, messages):
         for lic in self.extracted_licenses:
             if isinstance(lic, ExtractedLicense):
                 messages = lic.validate(messages)
             else:
-                messages = messages + [
+                messages.append(
                     "Document extracted licenses must be of type "
                     "spdx.document.ExtractedLicense and not " + type(lic)
-                ]
-        return messages
+                )

--- a/spdx/document.py
+++ b/spdx/document.py
@@ -52,8 +52,8 @@ class ExternalDocumentRef(object):
 
     def validate(self, messages):
         """
-        Validate all fields of the ExternalDocumentRef class and update the
-        messages list with user friendly error messages for display.
+        Check that all the fields are valid.
+        Appends any error messages to messages parameter shall be a ErrorMessages.
         """
         self.validate_ext_doc_id(messages)
         self.validate_spdx_doc_uri(messages)
@@ -378,12 +378,14 @@ class Document(object):
     def has_comment(self):
         return self.comment is not None
 
-    def validate(self, messages):
+    def validate(self, messages=None):
         """
         Validate all fields of the document and update the
         messages list with user friendly error messages for display.
         """
         if isinstance(messages, list):
+            raise TypeError("messages should be None or an instance of ErrorMessages")
+        if messages is None:
             messages = ErrorMessages()
 
         messages.push_context(self.name)
@@ -398,8 +400,8 @@ class Document(object):
         self.validate_extracted_licenses(messages)
         self.validate_reviews(messages)
         self.validate_snippet(messages)
-        # self.validate_annotations(messages)
-        # self.validate_relationships(messages)
+        self.validate_annotations(messages)
+        self.validate_relationships(messages)
         messages.pop_context()
         return messages
 

--- a/spdx/document.py
+++ b/spdx/document.py
@@ -9,6 +9,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from spdx.parsers.loggers import ErrorMessages
+
 import warnings
 
 from functools import total_ordering
@@ -381,6 +383,10 @@ class Document(object):
         Validate all fields of the document and update the
         messages list with user friendly error messages for display.
         """
+        if isinstance(messages, list):
+            messages = ErrorMessages()
+
+        messages.push_context(self.name)
         self.validate_version(messages)
         self.validate_data_lics(messages)
         self.validate_name(messages)
@@ -394,8 +400,9 @@ class Document(object):
         self.validate_snippet(messages)
         # self.validate_annotations(messages)
         # self.validate_relationships(messages)
+        messages.pop_context()
         return messages
-        
+
     def validate_version(self, messages):
         if self.version is None:
             messages.append("Document has no version.")

--- a/spdx/file.py
+++ b/spdx/file.py
@@ -103,6 +103,7 @@ class File(object):
         """Validates the fields and appends user friendly messages
         to messages parameter if there are errors.
         """
+        messages.push_context(self.name)
         self.validate_concluded_license(messages)
         self.validate_type(messages)
         self.validate_checksum(messages)
@@ -110,7 +111,7 @@ class File(object):
         self.validate_copyright(messages)
         self.validate_artifacts(messages)
         self.validate_spdx_id(messages)
-
+        messages.pop_context()
         return messages
 
     def validate_spdx_id(self, messages):

--- a/spdx/file.py
+++ b/spdx/file.py
@@ -100,8 +100,9 @@ class File(object):
         artifact.append(value)
 
     def validate(self, messages):
-        """Validates the fields and appends user friendly messages
-        to messages parameter if there are errors.
+        """
+        Check that all the fields are valid.
+        Appends any error messages to messages parameter shall be a ErrorMessages.
         """
         messages.push_context(self.name)
         self.validate_concluded_license(messages)

--- a/spdx/file.py
+++ b/spdx/file.py
@@ -103,19 +103,19 @@ class File(object):
         """Validates the fields and appends user friendly messages
         to messages parameter if there are errors.
         """
-        messages = self.validate_concluded_license(messages)
-        messages = self.validate_type(messages)
-        messages = self.validate_checksum(messages)
-        messages = self.validate_licenses_in_file(messages)
-        messages = self.validate_copyright(messages)
-        messages = self.validate_artifacts(messages)
-        messages = self.validate_spdx_id(messages)
+        self.validate_concluded_license(messages)
+        self.validate_type(messages)
+        self.validate_checksum(messages)
+        self.validate_licenses_in_file(messages)
+        self.validate_copyright(messages)
+        self.validate_artifacts(messages)
+        self.validate_spdx_id(messages)
 
         return messages
 
     def validate_spdx_id(self, messages):
         if self.spdx_id is None:
-            messages = messages + ["File has no SPDX Identifier."]
+            messages.append("File has no SPDX Identifier.")
 
         return messages
 
@@ -124,10 +124,10 @@ class File(object):
             self.copyright,
             (str, utils.NoAssert, utils.SPDXNone),
         ):
-            messages = messages + [
+            messages.append(
                 "File copyright must be str or unicode or "
                 "utils.NoAssert or utils.SPDXNone"
-            ]
+            )
 
         return messages
 
@@ -135,16 +135,16 @@ class File(object):
         if len(self.artifact_of_project_home) < max(
             len(self.artifact_of_project_uri), len(self.artifact_of_project_name)
         ):
-            messages = messages + [
+            messages.append(
                 "File must have as much artifact of project as uri or homepage"
-            ]
+            )
 
         return messages
 
     def validate_licenses_in_file(self, messages):
         # FIXME: what are we testing the length of a list? or?
         if len(self.licenses_in_file) == 0:
-            messages = messages + ["File must have at least one license in file."]
+            messages.append("File must have at least one license in file.")
 
         return messages
 
@@ -153,10 +153,10 @@ class File(object):
         if not isinstance(
             self.conc_lics, (document.License, utils.NoAssert, utils.SPDXNone)
         ):
-            messages = messages + [
+            messages.append(
                 "File concluded license must be one of "
                 "document.License, utils.NoAssert or utils.SPDXNone"
-            ]
+            )
 
         return messages
 
@@ -168,21 +168,21 @@ class File(object):
             FileType.BINARY,
             FileType.ARCHIVE,
         ]:
-            messages = messages + [
+            messages.append(
                 "File type must be one of the constants defined in "
                 "class spdx.file.FileType"
-            ]
+            )
 
         return messages
 
     def validate_checksum(self, messages):
         if not isinstance(self.chk_sum, checksum.Algorithm):
-            messages = messages + [
+            messages.append(
                 "File checksum must be instance of spdx.checksum.Algorithm"
-            ]
+            )
         else:
             if not self.chk_sum.identifier == "SHA1":
-                messages = messages + ["File checksum algorithm must be SHA1"]
+                messages.append("File checksum algorithm must be SHA1")
 
         return messages
 

--- a/spdx/package.py
+++ b/spdx/package.py
@@ -114,26 +114,26 @@ class Package(object):
         Validate the package fields.
         Append user friendly error messages to the `messages` list.
         """
-        messages = self.validate_files_analyzed(messages)
-        messages = self.validate_checksum(messages)
-        messages = self.validate_optional_str_fields(messages)
-        messages = self.validate_mandatory_str_fields(messages)
-        messages = self.validate_files(messages)
-        messages = self.validate_pkg_ext_refs(messages)
-        messages = self.validate_mandatory_fields(messages)
-        messages = self.validate_optional_fields(messages)
+        self.validate_files_analyzed(messages)
+        self.validate_checksum(messages)
+        self.validate_optional_str_fields(messages)
+        self.validate_mandatory_str_fields(messages)
+        self.validate_files(messages)
+        self.validate_pkg_ext_refs(messages)
+        self.validate_mandatory_fields(messages)
+        self.validate_optional_fields(messages)
 
         return messages
 
     def validate_files_analyzed(self, messages):
         if self.files_analyzed not in [ True, False, None ]:
-            messages = messages + [
+            messages.append(
                 'Package files_analyzed must be True or False or None (omitted)'
-            ]
+            )
         if self.files_analyzed is False and self.verif_code is not None:
-            messages = messages + [
+            messages.append(
                 'Package verif_code must be None (omitted) when files_analyzed is False'
-            ]
+            )
 
         return messages
 
@@ -141,18 +141,18 @@ class Package(object):
         if self.originator and not isinstance(
             self.originator, (utils.NoAssert, creationinfo.Creator)
         ):
-            messages = messages + [
+            messages.append(
                 "Package originator must be instance of "
                 "spdx.utils.NoAssert or spdx.creationinfo.Creator"
-            ]
+            )
 
         if self.supplier and not isinstance(
             self.supplier, (utils.NoAssert, creationinfo.Creator)
         ):
-            messages = messages + [
+            messages.append(
                 "Package supplier must be instance of "
                 "spdx.utils.NoAssert or spdx.creationinfo.Creator"
-            ]
+            )
 
         return messages
 
@@ -161,10 +161,10 @@ class Package(object):
             if isinstance(ref, ExternalPackageRef):
                 messages = ref.validate(messages)
             else:
-                messages = messages + [
+                messages.append(
                     "External package references must be of the type "
                     "spdx.package.ExternalPackageRef and not " + str(type(ref))
-                ]
+                )
 
         return messages
 
@@ -172,43 +172,43 @@ class Package(object):
         if not isinstance(
             self.conc_lics, (utils.SPDXNone, utils.NoAssert, document.License)
         ):
-            messages = messages + [
+            messages.append(
                 "Package concluded license must be instance of "
                 "spdx.utils.SPDXNone or spdx.utils.NoAssert or "
                 "spdx.document.License"
-            ]
+            )
 
         if not isinstance(
             self.license_declared, (utils.SPDXNone, utils.NoAssert, document.License)
         ):
-            messages = messages + [
+            messages.append(
                 "Package declared license must be instance of "
                 "spdx.utils.SPDXNone or spdx.utils.NoAssert or "
                 "spdx.document.License"
-            ]
+            )
 
         # FIXME: this is obscure and unreadable
         license_from_file_check = lambda prev, el: prev and isinstance(
             el, (document.License, utils.SPDXNone, utils.NoAssert)
         )
         if not reduce(license_from_file_check, self.licenses_from_files, True):
-            messages = messages + [
+            messages.append(
                 "Each element in licenses_from_files must be instance of "
                 "spdx.utils.SPDXNone or spdx.utils.NoAssert or "
                 "spdx.document.License"
-            ]
+            )
 
         if not self.licenses_from_files:
-            messages = messages + ["Package licenses_from_files can not be empty"]
+            messages.append("Package licenses_from_files can not be empty")
 
         return messages
 
     def validate_files(self, messages):
         if self.files_analyzed != False:
             if not self.files:
-                messages = messages + [
+                messages.append(
                     "Package must have at least one file."
-                ]
+                )
             else:
                 for f in self.files:
                     messages = f.validate(messages)
@@ -229,7 +229,7 @@ class Package(object):
             "attribution_text",
             "comment",
         ]
-        messages = self.validate_str_fields(FIELDS, True, messages)
+        self.validate_str_fields(FIELDS, True, messages)
 
         return messages
 
@@ -240,7 +240,7 @@ class Package(object):
         FIELDS = ["name", "spdx_id", "download_location", "cr_text"]
         if self.files_analyzed != False:
             FIELDS = FIELDS + ["verif_code"]
-        messages = self.validate_str_fields(FIELDS, False, messages)
+        self.validate_str_fields(FIELDS, False, messages)
 
         return messages
 
@@ -253,24 +253,24 @@ class Package(object):
                 # FIXME: this does not make sense???
                 attr = getattr(field, "__str__", None)
                 if not callable(attr):
-                    messages = messages + [
+                    messages.append(
                         "{0} must provide __str__ method.".format(field)
-                    ]
+                    )
                     # Continue checking.
             elif not optional:
-                messages = messages + ["Package {0} can not be None.".format(field_str)]
+                messages.append("Package {0} can not be None.".format(field_str))
 
         return messages
 
     def validate_checksum(self, messages):
         if self.check_sum is not None:
             if not isinstance(self.check_sum, checksum.Algorithm):
-                messages = messages + [
+                messages.append(
                     "Package checksum must be instance of spdx.checksum.Algorithm"
-                ]
+                )
             else:
                 if self.check_sum.identifier != "SHA1":
-                    messages = messages + ["File checksum algorithm must be SHA1"]
+                    messages.append("File checksum algorithm must be SHA1")
 
         return messages
 
@@ -325,26 +325,26 @@ class ExternalPackageRef(object):
         Validate all fields of the ExternalPackageRef class and update the
         messages list with user friendly error messages for display.
         """
-        messages = self.validate_category(messages)
-        messages = self.validate_pkg_ext_ref_type(messages)
-        messages = self.validate_locator(messages)
+        self.validate_category(messages)
+        self.validate_pkg_ext_ref_type(messages)
+        self.validate_locator(messages)
 
         return messages
 
     def validate_category(self, messages=None):
         if self.category is None:
-            messages = messages + ["ExternalPackageRef has no category."]
+            messages.append("ExternalPackageRef has no category.")
 
         return messages
 
     def validate_pkg_ext_ref_type(self, messages=None):
         if self.pkg_ext_ref_type is None:
-            messages = messages + ["ExternalPackageRef has no type."]
+            messages.append("ExternalPackageRef has no type.")
 
         return messages
 
     def validate_locator(self, messages=None):
         if self.locator is None:
-            messages = messages + ["ExternalPackageRef has no locator."]
+            messages.append("ExternalPackageRef has no locator.")
 
         return messages

--- a/spdx/package.py
+++ b/spdx/package.py
@@ -324,8 +324,8 @@ class ExternalPackageRef(object):
 
     def validate(self, messages):
         """
-        Validate all fields of the ExternalPackageRef class and update the
-        messages list with user friendly error messages for display.
+        Check that all the fields are valid.
+        Appends any error messages to messages parameter shall be a ErrorMessages.
         """
         self.validate_category(messages)
         self.validate_pkg_ext_ref_type(messages)

--- a/spdx/package.py
+++ b/spdx/package.py
@@ -109,11 +109,12 @@ class Package(object):
     def add_pkg_ext_refs(self, pkg_ext_ref):
         self.pkg_ext_refs.append(pkg_ext_ref)
 
-    def validate(self, messages=None):
+    def validate(self, messages):
         """
         Validate the package fields.
         Append user friendly error messages to the `messages` list.
         """
+        messages.push_context(self.name)
         self.validate_files_analyzed(messages)
         self.validate_checksum(messages)
         self.validate_optional_str_fields(messages)
@@ -122,6 +123,7 @@ class Package(object):
         self.validate_pkg_ext_refs(messages)
         self.validate_mandatory_fields(messages)
         self.validate_optional_fields(messages)
+        messages.pop_context()
 
         return messages
 
@@ -156,7 +158,7 @@ class Package(object):
 
         return messages
 
-    def validate_pkg_ext_refs(self, messages=None):
+    def validate_pkg_ext_refs(self, messages):
         for ref in self.pkg_ext_refs:
             if isinstance(ref, ExternalPackageRef):
                 messages = ref.validate(messages)
@@ -320,7 +322,7 @@ class ExternalPackageRef(object):
         self.locator = locator
         self.comment = comment
 
-    def validate(self, messages=None):
+    def validate(self, messages):
         """
         Validate all fields of the ExternalPackageRef class and update the
         messages list with user friendly error messages for display.
@@ -331,19 +333,19 @@ class ExternalPackageRef(object):
 
         return messages
 
-    def validate_category(self, messages=None):
+    def validate_category(self, messages):
         if self.category is None:
             messages.append("ExternalPackageRef has no category.")
 
         return messages
 
-    def validate_pkg_ext_ref_type(self, messages=None):
+    def validate_pkg_ext_ref_type(self, messages):
         if self.pkg_ext_ref_type is None:
             messages.append("ExternalPackageRef has no type.")
 
         return messages
 
-    def validate_locator(self, messages=None):
+    def validate_locator(self, messages):
         if self.locator is None:
             messages.append("ExternalPackageRef has no locator.")
 

--- a/spdx/parsers/jsonyamlxml.py
+++ b/spdx/parsers/jsonyamlxml.py
@@ -14,6 +14,7 @@ from spdx.document import LicenseConjunction
 from spdx.document import LicenseDisjunction
 from spdx.parsers.builderexceptions import SPDXValueError, CardinalityError, OrderError
 from spdx.parsers import rdf
+from spdx.parsers.loggers import ErrorMessages
 from spdx import utils
 from spdx.utils import UnKnown
 
@@ -1485,7 +1486,7 @@ class Parser(
 
         self.parse_doc_described_objects(self.document_object.get("documentDescribes"))
 
-        validation_messages = []
+        validation_messages = ErrorMessages()
         # Report extra errors if self.error is False otherwise there will be
         # redundent messages
         validation_messages = self.document.validate(validation_messages)

--- a/spdx/parsers/loggers.py
+++ b/spdx/parsers/loggers.py
@@ -42,7 +42,7 @@ class ErrorMessages:
         the current context is prefixed to the message
         """
         message = message.format(*args, **kwargs)
-        message = "".join([c + ": " for c in self.context]) + message
+        message = "".join([c + ": " for c in self.context if c]) + message
         self.messages.append(message)
 
     def __iter__(self):
@@ -53,3 +53,8 @@ class ErrorMessages:
 
     def __nonzero__(self):
         return len(self.messages)>0
+    
+    def __eq__(self, b):
+        if isinstance(b, ErrorMessages):
+            return self.messages == b.messages
+        return self.messages == b

--- a/spdx/parsers/loggers.py
+++ b/spdx/parsers/loggers.py
@@ -21,3 +21,26 @@ class FileLogger(object):
 
     def log(self, msg):
         self.dest.write(msg + "\n")
+
+
+class ErrorMessages:
+
+    def __init__(self):
+        self.messages = []
+        self.context = []
+    
+    def push_context(self, context):
+        """push some context information to better indentify where is the problem"""
+        self.context.append(context)
+
+    def pop_context(self):
+        """pop the last context information"""
+        self.context.pop()
+    
+    def append(self, message, *args, **kwargs):
+        """add a message with standard python format
+        the current context is prefixed to the message
+        """
+        message = message.format(*args, **kwargs)
+        message = "".join([c + ": " for c in self.context]) + message
+        self.messages.append(message)

--- a/spdx/parsers/loggers.py
+++ b/spdx/parsers/loggers.py
@@ -44,3 +44,12 @@ class ErrorMessages:
         message = message.format(*args, **kwargs)
         message = "".join([c + ": " for c in self.context]) + message
         self.messages.append(message)
+
+    def __iter__(self):
+        return self.messages.__iter__()
+
+    def __bool__(self):
+        return len(self.messages)>0
+
+    def __nonzero__(self):
+        return len(self.messages)>0

--- a/spdx/parsers/rdf.py
+++ b/spdx/parsers/rdf.py
@@ -1333,7 +1333,7 @@ class Parser(
         ):
             self.parse_relationship(s, o)
 
-        validation_messages = []
+        validation_messages = ErrorMessages()
         # Report extra errors if self.error is False otherwise there will be
         # redundant messages
         validation_messages = self.doc.validate(validation_messages)

--- a/spdx/parsers/rdf.py
+++ b/spdx/parsers/rdf.py
@@ -22,6 +22,7 @@ from spdx import document
 from spdx import utils
 from spdx.parsers.builderexceptions import CardinalityError
 from spdx.parsers.builderexceptions import SPDXValueError
+from spdx.parsers.loggers import ErrorMessages
 
 
 ERROR_MESSAGES = {

--- a/spdx/parsers/tagvalue.py
+++ b/spdx/parsers/tagvalue.py
@@ -18,6 +18,7 @@ from spdx.parsers.builderexceptions import CardinalityError
 from spdx.parsers.builderexceptions import OrderError
 from spdx.parsers.builderexceptions import SPDXValueError
 from spdx.parsers.lexers.tagvalue import Lexer
+from spdx.parsers.loggers import ErrorMessages
 from spdx import document
 
 
@@ -1619,7 +1620,7 @@ class Parser(object):
         self.yacc.parse(text, lexer=self.lex)
         # FIXME: this state does not make sense
         self.builder.reset()
-        validation_messages = []
+        validation_messages = ErrorMessages()
         # Report extra errors if self.error is False otherwise there will be
         # redundant messages
         validation_messages = self.document.validate(validation_messages)

--- a/spdx/relationship.py
+++ b/spdx/relationship.py
@@ -99,10 +99,11 @@ class Relationship(object):
         return self.relationship.split(" ")[2]
 
     def validate(self, messages):
-        """Returns True if all the fields are valid.
-        Appends any error messages to messages parameter.
         """
-        return self.validate_relationship(messages)
+        Check that all the fields are valid.
+        Appends any error messages to messages parameter shall be a ErrorMessages.
+        """
+        self.validate_relationship(messages)
 
     def validate_relationship(self, messages):
         r_type = self.relationship.split(" ")[1]
@@ -111,6 +112,3 @@ class Relationship(object):
                 "Relationship type must be one of the constants defined in "
                 "class spdx.relationship.Relationship"
             )
-            return False
-        else:
-            return True

--- a/spdx/relationship.py
+++ b/spdx/relationship.py
@@ -11,6 +11,7 @@
 # limitations under the License.
 
 from enum import Enum
+from spdx.parsers.loggers import ErrorMessages
 
 # Implement the auto feature that becomes available in 3.6	
 autoinc = 0	
@@ -101,18 +102,15 @@ class Relationship(object):
         """Returns True if all the fields are valid.
         Appends any error messages to messages parameter.
         """
-        messages = self.validate_relationship(messages)
-
-        return messages
+        return self.validate_relationship(messages)
 
     def validate_relationship(self, messages):
-        messages = messages if messages is not None else []
         r_type = self.relationship.split(" ")[1]
         if r_type not in [name for name, _ in RelationshipType.__members__.items()]:
-            messages = messages + [
+            messages.append(
                 "Relationship type must be one of the constants defined in "
                 "class spdx.relationship.Relationship"
-            ]
-            return messages
+            )
+            return False
         else:
             return True

--- a/spdx/review.py
+++ b/spdx/review.py
@@ -59,11 +59,12 @@ class Review(object):
         return self.comment is not None
 
     def validate(self, messages):
-        """Returns True if all the fields are valid.
-        Appends any error messages to messages parameter.
         """
-        messages = self.validate_reviewer(messages)
-        messages = self.validate_review_date(messages)
+        Check that all the fields are valid.
+        Appends any error messages to messages parameter shall be a ErrorMessages.
+        """
+        self.validate_reviewer(messages)
+        self.validate_review_date(messages)
 
         return messages
 

--- a/spdx/snippet.py
+++ b/spdx/snippet.py
@@ -54,26 +54,24 @@ class Snippet(object):
     def add_lics(self, lics):
         self.licenses_in_snippet.append(lics)
 
-    def validate(self, messages=None):
+    def validate(self, messages):
         """
         Validate fields of the snippet and update the messages list with user
         friendly error messages for display.
         """
-        messages = self.validate_spdx_id(messages)
-        messages = self.validate_copyright_text(messages)
-        messages = self.validate_snip_from_file_spdxid(messages)
-        messages = self.validate_concluded_license(messages)
-        messages = self.validate_licenses_in_snippet(messages)
+        self.validate_spdx_id(messages)
+        self.validate_copyright_text(messages)
+        self.validate_snip_from_file_spdxid(messages)
+        self.validate_concluded_license(messages)
+        self.validate_licenses_in_snippet(messages)
 
         return messages
 
-    def validate_spdx_id(self, messages=None):
+    def validate_spdx_id(self, messages):
         if self.spdx_id is None:
             messages.append("Snippet has no SPDX Identifier.")
 
-        return messages
-
-    def validate_copyright_text(self, messages=None):
+    def validate_copyright_text(self, messages):
         if not isinstance(
             self.copyright,
             (str, utils.NoAssert, utils.SPDXNone),
@@ -82,15 +80,11 @@ class Snippet(object):
                 "Snippet copyright must be str or unicode or utils.NoAssert or utils.SPDXNone"
             )
 
-        return messages
-
-    def validate_snip_from_file_spdxid(self, messages=None):
+    def validate_snip_from_file_spdxid(self, messages):
         if self.snip_from_file_spdxid is None:
             messages.append("Snippet has no Snippet from File SPDX Identifier.")
 
-        return messages
-
-    def validate_concluded_license(self, messages=None):
+    def validate_concluded_license(self, messages):
         if not isinstance(
             self.conc_lics, (document.License, utils.NoAssert, utils.SPDXNone)
         ):
@@ -99,9 +93,7 @@ class Snippet(object):
                 "document.License, utils.NoAssert or utils.SPDXNone"
             )
 
-        return messages
-
-    def validate_licenses_in_snippet(self, messages=None):
+    def validate_licenses_in_snippet(self, messages):
         if len(self.licenses_in_snippet) == 0:
             messages.append("Snippet must have at least one license in file.")
         else:
@@ -113,8 +105,6 @@ class Snippet(object):
                         "Licenses in Snippet must be one of "
                         "document.License, utils.NoAssert or utils.SPDXNone"
                     )
-
-        return messages
 
     def has_optional_field(self, field):
         return getattr(self, field, None) is not None

--- a/spdx/snippet.py
+++ b/spdx/snippet.py
@@ -69,7 +69,7 @@ class Snippet(object):
 
     def validate_spdx_id(self, messages=None):
         if self.spdx_id is None:
-            messages = messages + ["Snippet has no SPDX Identifier."]
+            messages.append("Snippet has no SPDX Identifier.")
 
         return messages
 
@@ -78,15 +78,15 @@ class Snippet(object):
             self.copyright,
             (str, utils.NoAssert, utils.SPDXNone),
         ):
-            messages = messages + [
+            messages.append(
                 "Snippet copyright must be str or unicode or utils.NoAssert or utils.SPDXNone"
-            ]
+            )
 
         return messages
 
     def validate_snip_from_file_spdxid(self, messages=None):
         if self.snip_from_file_spdxid is None:
-            messages = messages + ["Snippet has no Snippet from File SPDX Identifier."]
+            messages.append("Snippet has no Snippet from File SPDX Identifier.")
 
         return messages
 
@@ -94,25 +94,25 @@ class Snippet(object):
         if not isinstance(
             self.conc_lics, (document.License, utils.NoAssert, utils.SPDXNone)
         ):
-            messages = messages + [
+            messages.append(
                 "Snippet Concluded License must be one of "
                 "document.License, utils.NoAssert or utils.SPDXNone"
-            ]
+            )
 
         return messages
 
     def validate_licenses_in_snippet(self, messages=None):
         if len(self.licenses_in_snippet) == 0:
-            messages = messages + ["Snippet must have at least one license in file."]
+            messages.append("Snippet must have at least one license in file.")
         else:
             for lic in self.licenses_in_snippet:
                 if not isinstance(
                     lic, (document.License, utils.NoAssert, utils.SPDXNone)
                 ):
-                    messages = messages + [
+                    messages.append(
                         "Licenses in Snippet must be one of "
                         "document.License, utils.NoAssert or utils.SPDXNone"
-                    ]
+                    )
 
         return messages
 

--- a/spdx/tv_to_rdf.py
+++ b/spdx/tv_to_rdf.py
@@ -18,6 +18,7 @@ from spdx.parsers.loggers import StandardLogger
 from spdx.writers.rdf import write_document
 from spdx.parsers.tagvalue import Parser
 from spdx.parsers.tagvaluebuilders import Builder
+from spdx.parsers.loggers import ErrorMessages
 
 
 def tv_to_rdf(infile_name, outfile_name):
@@ -36,9 +37,9 @@ def tv_to_rdf(infile_name, outfile_name):
             return True
         else:
             print("Errors encountered while parsing RDF file.")
-            messages = []
+            messages = ErrorMessages()
             document.validate(messages)
-            print("\n".join(messages))
+            print("\n".join(messages.messages))
             return False
 
 

--- a/spdx/writers/json.py
+++ b/spdx/writers/json.py
@@ -13,12 +13,13 @@ import json
 
 from spdx.writers.tagvalue import InvalidDocumentError
 from spdx.writers.jsonyamlxml import Writer
+from spdx.parsers.loggers import ErrorMessages
 
 
 def write_document(document, out, validate=True):
 
     if validate:
-        messages = []
+        messages = ErrorMessages()
         messages = document.validate(messages)
         if messages:
             raise InvalidDocumentError(messages)

--- a/spdx/writers/rdf.py
+++ b/spdx/writers/rdf.py
@@ -22,6 +22,7 @@ from spdx import file
 from spdx import document
 from spdx import config
 from spdx import utils
+from spdx.parsers.loggers import ErrorMessages
 from spdx.writers.tagvalue import InvalidDocumentError
 
 import warnings
@@ -1041,7 +1042,7 @@ def write_document(document, out, validate=True):
     """
 
     if validate:
-        messages = []
+        messages = ErrorMessages()
         messages = document.validate(messages)
         if messages:
             raise InvalidDocumentError(messages)

--- a/spdx/writers/tagvalue.py
+++ b/spdx/writers/tagvalue.py
@@ -13,6 +13,7 @@ from itertools import zip_longest
 
 from spdx import document
 from spdx import file as spdx_file
+from spdx.parsers.loggers import ErrorMessages
 
 
 class InvalidDocumentError(Exception):
@@ -310,7 +311,7 @@ def write_document(document, out, validate=True):
     Optionally `validate` the document before writing and raise
     InvalidDocumentError if document.validate returns False.
     """
-    messages = []
+    messages = ErrorMessages()
     messages = document.validate(messages)
     if validate and messages:
         raise InvalidDocumentError(messages)

--- a/spdx/writers/xml.py
+++ b/spdx/writers/xml.py
@@ -13,12 +13,13 @@ import xmltodict
 
 from spdx.writers.tagvalue import InvalidDocumentError
 from spdx.writers.jsonyamlxml import Writer
+from spdx.parsers.loggers import ErrorMessages
 
 
 def write_document(document, out, validate=True):
 
     if validate:
-        messages = []
+        messages = ErrorMessages()
         messages = document.validate(messages)
         if messages:
             raise InvalidDocumentError(messages)

--- a/spdx/writers/yaml.py
+++ b/spdx/writers/yaml.py
@@ -13,12 +13,13 @@ import yaml
 
 from spdx.writers.tagvalue import InvalidDocumentError
 from spdx.writers.jsonyamlxml import Writer
+from spdx.parsers.loggers import ErrorMessages
 
 
 def write_document(document, out, validate=True):
 
     if validate:
-        messages = []
+        messages = ErrorMessages()
         messages = document.validate(messages)
         if messages:
             raise InvalidDocumentError(messages)

--- a/tests/test_conversion.py
+++ b/tests/test_conversion.py
@@ -55,7 +55,7 @@ class TestConversions(TestCase):
             rdfparser = RDFParser(RDFBuilder(), StandardLogger())
             doc, error = rdfparser.parse(infile)
         assert not error
-        assert doc.validate([]) == []
+        assert doc.validate() == []
         return doc
 
     def parse_tagvalue_file(self, file_name):
@@ -64,7 +64,7 @@ class TestConversions(TestCase):
             tvparser.build()
             doc, error = tvparser.parse(infile.read())
         assert not error
-        assert doc.validate([]) == []
+        assert doc.validate() == []
         return doc
 
     def parse_json_file(self, file_name):
@@ -72,7 +72,7 @@ class TestConversions(TestCase):
             jsonparser = JSONParser(JSONYAMLXMLBuilder(), StandardLogger())
             doc, error = jsonparser.parse(infile)
         assert not error
-        assert doc.validate([]) == []
+        assert doc.validate() == []
         return doc
 
     def parse_yaml_file(self, file_name):
@@ -80,7 +80,7 @@ class TestConversions(TestCase):
             yamlparser = YAMLParser(JSONYAMLXMLBuilder(), StandardLogger())
             doc, error = yamlparser.parse(infile)
         assert not error
-        assert doc.validate([]) == []
+        assert doc.validate() == []
         return doc
 
     def parse_xml_file(self, file_name):
@@ -88,7 +88,7 @@ class TestConversions(TestCase):
             xmlparser = XMLParser(JSONYAMLXMLBuilder(), StandardLogger())
             doc, error = xmlparser.parse(infile)        
         assert not error
-        assert doc.validate([]) == []
+        assert doc.validate() == []
         return doc
 
     def write_tagvalue_file(self, document, file_name):

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -21,6 +21,7 @@ from spdx.document import Document, ExternalDocumentRef
 from spdx.document import License
 from spdx.file import File
 from spdx.package import Package
+from spdx.parsers.loggers import ErrorMessages
 from spdx.utils import NoAssert
 from spdx.version import Version
 
@@ -84,7 +85,7 @@ class TestDocument(TestCase):
         lic1 = License.from_identifier('LGPL-2.1-only')
         file1.add_lics(lic1)
         pack.add_lics_from_file(lic1)
-        messages = []
+        messages = ErrorMessages()
         messages = doc.validate(messages)
         expected = [
             'No creators defined, must have at least one.',
@@ -127,7 +128,7 @@ class TestDocument(TestCase):
 
         package.add_lics_from_file(lic1)
         package.add_file(file1)
-        messages = []
+        messages = ErrorMessages()
         messages = doc.validate(messages)
         assert not messages
 

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -88,17 +88,18 @@ class TestDocument(TestCase):
         messages = ErrorMessages()
         messages = doc.validate(messages)
         expected = [
-            'No creators defined, must have at least one.',
-            'Creation info missing created date.',
-            'Package checksum must be instance of spdx.checksum.Algorithm',
-            'Package download_location can not be None.',
-            'Package verif_code can not be None.',
-            'Package cr_text can not be None.',
-            'Package must have at least one file.',
-            'Package concluded license must be instance of spdx.utils.SPDXNone '
-            'or spdx.utils.NoAssert or spdx.document.License',
-            'Package declared license must be instance of spdx.utils.SPDXNone '
-            'or spdx.utils.NoAssert or spdx.document.License'
+            'Sample_Document-V2.1: Creation info missing created date.',
+            'Sample_Document-V2.1: No creators defined, must have at least one.',
+            'Sample_Document-V2.1: some/path: Package checksum must be instance of '
+            'spdx.checksum.Algorithm',
+            'Sample_Document-V2.1: some/path: Package concluded license must be instance '
+            'of spdx.utils.SPDXNone or spdx.utils.NoAssert or spdx.document.License',
+            'Sample_Document-V2.1: some/path: Package cr_text can not be None.',
+            'Sample_Document-V2.1: some/path: Package declared license must be instance '
+            'of spdx.utils.SPDXNone or spdx.utils.NoAssert or spdx.document.License',
+            'Sample_Document-V2.1: some/path: Package download_location can not be None.',
+            'Sample_Document-V2.1: some/path: Package must have at least one file.',
+            'Sample_Document-V2.1: some/path: Package verif_code can not be None.'
         ]
         assert sorted(expected) == sorted(messages)
 

--- a/tests/test_error_messages.py
+++ b/tests/test_error_messages.py
@@ -1,0 +1,34 @@
+# Copyright (c) 2021 spdx tool contributors
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import
+from __future__ import print_function
+from __future__ import unicode_literals
+
+from spdx.parsers.loggers import ErrorMessages
+
+
+def test_error_message_context():
+    messages = ErrorMessages()
+    messages.push_context("package1")
+    messages.append("missing value: {0} {bar}", "foo", bar="bar")
+    messages.append("missing key")
+    messages.pop_context()
+    messages.append("lone message")
+    messages.push_context("package2")
+    messages.push_context("file1")
+    messages.append("more message")
+    assert messages.messages == [
+        "package1: missing value: foo bar",
+        "package1: missing key",
+        "lone message",
+        "package2: file1: more message",
+    ]


### PR DESCRIPTION
There are a lot of 

```
            messages = messages + ["ExternalPackageRef has no category."]
```

in this codebase..

This is not very pythonic, and does not contain much context information, which makes it difficult to understand what part of the 8MB spdx dump file generated by proprietary tool is not recognised.

This is a first simple code to start discussion on the problematic.
Will integrate in the rest of the code when we agree on the API.


