### PR TITLE
python3.9 is only present on 2019 images which is not the default

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,6 @@
 version: "{build}"
-
+image:
+  - Visual Studio 2019
 environment:
   matrix:
     - PYTHON_EXE: "C:\\Python36-x64\\python.exe"


### PR DESCRIPTION
https://www.appveyor.com/docs/build-environment/ : says 2015 is the default

https://www.appveyor.com/docs/windows-images-software/ : says 3.9 is only on 2019

