### PR TITLE
add spdxlite 2.2 SBOM parsing support

### DIFF
--- a/spdx/package.py
+++ b/spdx/package.py
@@ -97,6 +97,12 @@ class Package(object):
         self.verif_exc_files = []
         self.pkg_ext_refs = []
 
+    @property
+    def are_files_analyzed(self):
+        return self.files_analyzed is not False
+        # as default None Value is False, previous line is simplification of
+        # return self.files_analyzed or self.files_analyzed is None
+
     def add_file(self, fil):
         self.files.append(fil)
 
@@ -132,7 +138,7 @@ class Package(object):
             messages.append(
                 'Package files_analyzed must be True or False or None (omitted)'
             )
-        if self.files_analyzed is False and self.verif_code is not None:
+        if not self.are_files_analyzed and self.verif_code is not None:
             messages.append(
                 'Package verif_code must be None (omitted) when files_analyzed is False'
             )
@@ -200,13 +206,13 @@ class Package(object):
                 "spdx.document.License"
             )
 
-        if not self.licenses_from_files:
+        if not self.licenses_from_files and self.are_files_analyzed:
             messages.append("Package licenses_from_files can not be empty")
 
         return messages
 
     def validate_files(self, messages):
-        if self.files_analyzed != False:
+        if self.are_files_analyzed:
             if not self.files:
                 messages.append(
                     "Package must have at least one file."
@@ -240,7 +246,7 @@ class Package(object):
         docstring must be of a type that provides __str__ method.
         """
         FIELDS = ["name", "spdx_id", "download_location", "cr_text"]
-        if self.files_analyzed != False:
+        if self.are_files_analyzed:
             FIELDS = FIELDS + ["verif_code"]
         self.validate_str_fields(FIELDS, False, messages)
 

--- a/spdx/parsers/jsonparser.py
+++ b/spdx/parsers/jsonparser.py
@@ -25,5 +25,5 @@ class Parser(jsonyamlxml.Parser):
         super(Parser, self).__init__(builder, logger)
 
     def parse(self, file):
-        self.document_object = json.load(file).get("Document")
+        self.json_yaml_set_document(json.load(file))
         return super(Parser, self).parse()

--- a/spdx/parsers/parse_anything.py
+++ b/spdx/parsers/parse_anything.py
@@ -38,7 +38,7 @@ def parse_file(fn):
         parsing_module = jsonparser
     elif fn.endswith(".xml"):
         parsing_module = xmlparser
-    elif fn.endswith(".yaml"):
+    elif fn.endswith(".yaml") or fn.endswith(".yml"):
         parsing_module = yamlparser
     else:
         raise FileTypeError("FileType Not Supported" + str(fn))

--- a/spdx/parsers/tagvaluebuilders.py
+++ b/spdx/parsers/tagvaluebuilders.py
@@ -712,10 +712,12 @@ class PackageBuilder(object):
         """
         self.assert_package_exists()
         if not self.package_files_analyzed_set:
-            if files_analyzed:
+            if files_analyzed is not None:
                 if validations.validate_pkg_files_analyzed(files_analyzed):
                     self.package_files_analyzed_set = True
-                    doc.packages[-1].files_analyzed = (files_analyzed.lower() == "true")
+                    if isinstance(files_analyzed, str):
+                        files_analyzed = files_analyzed.lower() == "true"
+                    doc.packages[-1].files_analyzed = files_analyzed
                     # convert to boolean;
                     # validate_pkg_files_analyzed already checked if
                     # files_analyzed is in ['True', 'true', 'False', 'false']

--- a/spdx/parsers/validations.py
+++ b/spdx/parsers/validations.py
@@ -204,7 +204,7 @@ def validate_pkg_spdx_id(value, optional=False):
 
 
 def validate_pkg_files_analyzed(value, optional=False):
-    if value in ["True", "true", "False", "false"]:
+    if value in ["True", "true", "False", "false", True, False]:
         return True
     else:
         return optional

--- a/spdx/parsers/yamlparser.py
+++ b/spdx/parsers/yamlparser.py
@@ -25,5 +25,5 @@ class Parser(jsonyamlxml.Parser):
         super(Parser, self).__init__(builder, logger)
 
     def parse(self, file):
-        self.document_object = yaml.safe_load(file).get("Document")
+        self.json_yaml_set_document(yaml.safe_load(file))
         return super(Parser, self).parse()

--- a/spdx/writers/rdf.py
+++ b/spdx/writers/rdf.py
@@ -798,12 +798,12 @@ class PackageWriter(LicenseWriter):
         # Handle package verification
         if package.files_analyzed != False:
             verif_node = self.package_verif_node(package)
-        verif_triple = (
-            package_node,
-            self.spdx_namespace.packageVerificationCode,
-            verif_node,
-        )
-        self.graph.add(verif_triple)
+            verif_triple = (
+                package_node,
+                self.spdx_namespace.packageVerificationCode,
+                verif_node,
+            )
+            self.graph.add(verif_triple)
         # Handle concluded license
         conc_lic_node = self.license_or_special(package.conc_lics)
         conc_lic_triple = (

--- a/tests/data/doc_parse/SBOMexpected.json
+++ b/tests/data/doc_parse/SBOMexpected.json
@@ -1,0 +1,144 @@
+{
+  "id": "SPDXRef-DOCUMENT",
+  "specVersion": {
+    "major": 2,
+    "minor": 2
+  },
+  "documentNamespace": "http://spdx.org/spdxdocs/spdx-document-xyz",
+  "name": "xyz-0.1.0",
+  "comment": null,
+  "dataLicense": {
+    "type": "Single",
+    "identifier": "CC0-1.0",
+    "name": "Creative Commons Zero v1.0 Universal"
+  },
+  "licenseListVersion": {
+    "major": 3,
+    "minor": 9
+  },
+  "creators": [
+    {
+      "name": "Example Inc.",
+      "email": null,
+      "type": "Organization"
+    },
+    {
+      "name": "Thomas Steenbergen",
+      "email": null,
+      "type": "Person"
+    }
+  ],
+  "created": "2020-07-23T18:30:22Z",
+  "creatorComment": null,
+  "packages": [
+    {
+      "id": "SPDXRef-Package-xyz",
+      "name": "xyz",
+      "packageFileName": null,
+      "summary": "Awesome product created by Example Inc.",
+      "description": null,
+      "versionInfo": "0.1.0",
+      "sourceInfo": null,
+      "downloadLocation": "git+ssh://gitlab.example.com:3389/products/xyz.git@b2c358080011af6a366d2512a25a379fbe7b1f78",
+      "homepage": "https://example.com/products/xyz",
+      "originator": null,
+      "supplier": null,
+      "licenseConcluded": {
+        "type": "Single",
+        "identifier": "NOASSERTION",
+        "name": "NOASSERTION"
+      },
+      "licenseDeclared": {
+        "type": "Conjunction",
+        "identifier": [
+          "Apache-2.0",
+          "LicenseRef-Proprietary-ExampleInc",
+          "curl"
+        ],
+        "name": [
+          "Apache License 2.0",
+          "LicenseRef-Proprietary-ExampleInc",
+          "curl License"
+        ]
+      },
+      "copyrightText": "copyright 2004-2020 Example Inc. All Rights Reserved.",
+      "licenseComment": null,
+      "checksum": null,
+      "files": [],
+      "licenseInfoFromFiles": [],
+      "verificationCode": {
+        "value": null,
+        "excludedFilesNames": []
+      }
+    },
+    {
+      "id": "SPDXRef-Package-curl",
+      "name": "curl",
+      "packageFileName": "./libs/curl",
+      "summary": null,
+      "description": "A command line tool and library for transferring data with URL syntax, supporting HTTP, HTTPS, FTP, FTPS, GOPHER, TFTP, SCP, SFTP, SMB, TELNET, DICT, LDAP, LDAPS, MQTT, FILE, IMAP, SMTP, POP3, RTSP and RTMP. libcurl offers a myriad of powerful features.",
+      "versionInfo": "7.70.0",
+      "sourceInfo": null,
+      "downloadLocation": "https://github.com/curl/curl/releases/download/curl-7_70_0/curl-7.70.0.tar.gz",
+      "homepage": "https://curl.haxx.se/",
+      "originator": null,
+      "supplier": null,
+      "licenseConcluded": {
+        "type": "Single",
+        "identifier": "NOASSERTION",
+        "name": "NOASSERTION"
+      },
+      "licenseDeclared": {
+        "type": "Single",
+        "identifier": "curl",
+        "name": "curl License"
+      },
+      "copyrightText": "Copyright (c) 1996 - 2020, Daniel Stenberg, <daniel@haxx.se>, and many contributors, see the THANKS file.",
+      "licenseComment": null,
+      "checksum": null,
+      "files": [],
+      "licenseInfoFromFiles": [],
+      "verificationCode": {
+        "value": null,
+        "excludedFilesNames": []
+      }
+    },
+    {
+      "id": "SPDXRef-Package-openssl",
+      "name": "openssl",
+      "packageFileName": "./libs/openssl",
+      "summary": null,
+      "description": "OpenSSL is a robust, commercial-grade, full-featured Open Source Toolkit for the Transport Layer Security (TLS) protocol formerly known as the Secure Sockets Layer (SSL) protocol. The protocol implementation is based on a full-strength general purpose cryptographic library, which can also be used stand-alone.",
+      "versionInfo": "1.1.1g",
+      "sourceInfo": null,
+      "downloadLocation": "git+ssh://github.com/openssl/openssl.git@e2e09d9fba1187f8d6aafaa34d4172f56f1ffb72",
+      "homepage": "https://www.openssl.org/",
+      "originator": null,
+      "supplier": null,
+      "licenseConcluded": {
+        "type": "Single",
+        "identifier": "NOASSERTION",
+        "name": "NOASSERTION"
+      },
+      "licenseDeclared": {
+        "type": "Single",
+        "identifier": "Apache-2.0",
+        "name": "Apache License 2.0"
+      },
+      "copyrightText": "copyright 2004-2020 The OpenSSL Project Authors. All Rights Reserved.",
+      "licenseComment": null,
+      "checksum": null,
+      "files": [],
+      "licenseInfoFromFiles": [],
+      "verificationCode": {
+        "value": null,
+        "excludedFilesNames": []
+      }
+    }
+  ],
+  "externalDocumentRefs": [],
+  "extractedLicenses": [],
+  "annotations": [],
+  "reviews": [],
+  "snippets": []
+}

--- a/tests/data/doc_parse/expected.json
+++ b/tests/data/doc_parse/expected.json
@@ -34,185 +34,187 @@
   ],
   "created": "2010-02-03T00:00:00Z",
   "creatorComment": "This is an example of an SPDX spreadsheet format",
-  "package": {
-    "id": "SPDXRef-Package",
-    "name": "SPDX Translator",
-    "packageFileName": "spdxtranslator-1.0.zip",
-    "summary": "SPDX Translator utility",
-    "description": "This utility translates and SPDX RDF XML document to a spreadsheet, translates a spreadsheet to an SPDX RDF XML document and translates an SPDX RDFa document to an SPDX RDF XML document.",
-    "versionInfo": "Version 0.9.2",
-    "sourceInfo": "Version 1.0 of the SPDX Translator application",
-    "downloadLocation": "http://www.spdx.org/tools",
-    "homepage": null,
-    "originator": {
-      "name": "SPDX",
-      "email": null,
-      "type": "Organization"
-    },
-    "supplier": {
-      "name": "Linux Foundation",
-      "email": null,
-      "type": "Organization"
-    },
-    "licenseConcluded": {
-      "type": "Conjunction",
-      "identifier": [
-        "Apache-1.0",
-        "Apache-2.0",
-        "LicenseRef-1",
-        "LicenseRef-2",
-        "LicenseRef-3",
-        "LicenseRef-4",
-        "MPL-1.1"
-      ],
-      "name": [
-        "Apache License 1.0",
-        "Apache License 2.0",
-        "CyberNeko License",
-        "LicenseRef-1",
-        "LicenseRef-2",
-        "LicenseRef-4",
-        "Mozilla Public License 1.1"
-      ]
-    },
-    "licenseDeclared": {
-      "type": "Conjunction",
-      "identifier": [
-        "Apache-2.0",
-        "LicenseRef-1",
-        "LicenseRef-2",
-        "LicenseRef-3",
-        "LicenseRef-4",
-        "MPL-1.1"
-      ],
-      "name": [
-        "Apache License 2.0",
-        "CyberNeko License",
-        "LicenseRef-1",
-        "LicenseRef-2",
-        "LicenseRef-4",
-        "Mozilla Public License 1.1"
-      ]
-    },
-    "copyrightText": " Copyright 2010, 2011 Source Auditor Inc.",
-    "licenseComment": "The declared license information can be found in the NOTICE file at the root of the archive file",
-    "checksum": {
-      "identifier": "SHA1",
-      "value": "2fd4e1c67a2d28fced849ee1bb76e7391b93eb12"
-    },
-    "files": [
-      {
-        "id": "SPDXRef-File1",
-        "name": "Jenna-2.6.3/jena-2.6.3-sources.jar",
-        "type": 3,
-        "comment": "This file belongs to Jena",
-        "licenseConcluded": {
-          "type": "Single",
-          "identifier": "LicenseRef-1",
-          "name": "LicenseRef-1"
-        },
-        "copyrightText": "(c) Copyright 2000, 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009 Hewlett-Packard Development Company, LP",
-        "licenseComment": "This license is used by Jena",
-        "notice": null,
-        "checksum": {
-          "identifier": "SHA1",
-          "value": "3ab4e1c67a2d28fced849ee1bb76e7391b93f125"
-        },
-        "licenseInfoFromFiles": [
-          {
+  "packages": [
+    {
+      "id": "SPDXRef-Package",
+      "name": "SPDX Translator",
+      "packageFileName": "spdxtranslator-1.0.zip",
+      "summary": "SPDX Translator utility",
+      "description": "This utility translates and SPDX RDF XML document to a spreadsheet, translates a spreadsheet to an SPDX RDF XML document and translates an SPDX RDFa document to an SPDX RDF XML document.",
+      "versionInfo": "Version 0.9.2",
+      "sourceInfo": "Version 1.0 of the SPDX Translator application",
+      "downloadLocation": "http://www.spdx.org/tools",
+      "homepage": null,
+      "originator": {
+        "name": "SPDX",
+        "email": null,
+        "type": "Organization"
+      },
+      "supplier": {
+        "name": "Linux Foundation",
+        "email": null,
+        "type": "Organization"
+      },
+      "licenseConcluded": {
+        "type": "Conjunction",
+        "identifier": [
+          "Apache-1.0",
+          "Apache-2.0",
+          "LicenseRef-1",
+          "LicenseRef-2",
+          "LicenseRef-3",
+          "LicenseRef-4",
+          "MPL-1.1"
+        ],
+        "name": [
+          "Apache License 1.0",
+          "Apache License 2.0",
+          "CyberNeko License",
+          "LicenseRef-1",
+          "LicenseRef-2",
+          "LicenseRef-4",
+          "Mozilla Public License 1.1"
+        ]
+      },
+      "licenseDeclared": {
+        "type": "Conjunction",
+        "identifier": [
+          "Apache-2.0",
+          "LicenseRef-1",
+          "LicenseRef-2",
+          "LicenseRef-3",
+          "LicenseRef-4",
+          "MPL-1.1"
+        ],
+        "name": [
+          "Apache License 2.0",
+          "CyberNeko License",
+          "LicenseRef-1",
+          "LicenseRef-2",
+          "LicenseRef-4",
+          "Mozilla Public License 1.1"
+        ]
+      },
+      "copyrightText": " Copyright 2010, 2011 Source Auditor Inc.",
+      "licenseComment": "The declared license information can be found in the NOTICE file at the root of the archive file",
+      "checksum": {
+        "identifier": "SHA1",
+        "value": "2fd4e1c67a2d28fced849ee1bb76e7391b93eb12"
+      },
+      "files": [
+        {
+          "id": "SPDXRef-File1",
+          "name": "Jenna-2.6.3/jena-2.6.3-sources.jar",
+          "type": 3,
+          "comment": "This file belongs to Jena",
+          "licenseConcluded": {
             "type": "Single",
             "identifier": "LicenseRef-1",
             "name": "LicenseRef-1"
-          }
-        ],
-        "contributors": [],
-        "dependencies": [],
-        "artifactOfProjectName": [
-          "Jena"
-        ],
-        "artifactOfProjectHome": [
-          "http://www.openjena.org/"
-        ],
-        "artifactOfProjectURI": [
-          "http://subversion.apache.org/doap.rdf"
-        ]
-      },
-      {
-        "id": "SPDXRef-File2",
-        "name": "src/org/spdx/parser/DOAPProject.java",
-        "type": 1,
-        "comment": null,
-        "licenseConcluded": {
+          },
+          "copyrightText": "(c) Copyright 2000, 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009 Hewlett-Packard Development Company, LP",
+          "licenseComment": "This license is used by Jena",
+          "notice": null,
+          "checksum": {
+            "identifier": "SHA1",
+            "value": "3ab4e1c67a2d28fced849ee1bb76e7391b93f125"
+          },
+          "licenseInfoFromFiles": [
+            {
+              "type": "Single",
+              "identifier": "LicenseRef-1",
+              "name": "LicenseRef-1"
+            }
+          ],
+          "contributors": [],
+          "dependencies": [],
+          "artifactOfProjectName": [
+            "Jena"
+          ],
+          "artifactOfProjectHome": [
+            "http://www.openjena.org/"
+          ],
+          "artifactOfProjectURI": [
+            "http://subversion.apache.org/doap.rdf"
+          ]
+        },
+        {
+          "id": "SPDXRef-File2",
+          "name": "src/org/spdx/parser/DOAPProject.java",
+          "type": 1,
+          "comment": null,
+          "licenseConcluded": {
+            "type": "Single",
+            "identifier": "Apache-2.0",
+            "name": "Apache License 2.0"
+          },
+          "copyrightText": "Copyright 2010, 2011 Source Auditor Inc.",
+          "licenseComment": null,
+          "notice": null,
+          "checksum": {
+            "identifier": "SHA1",
+            "value": "2fd4e1c67a2d28fced849ee1bb76e7391b93eb12"
+          },
+          "licenseInfoFromFiles": [
+            {
+              "type": "Single",
+              "identifier": "Apache-2.0",
+              "name": "Apache License 2.0"
+            }
+          ],
+          "contributors": [],
+          "dependencies": [],
+          "artifactOfProjectName": [],
+          "artifactOfProjectHome": [],
+          "artifactOfProjectURI": []
+        }
+      ],
+      "licenseInfoFromFiles": [
+        {
+          "type": "Single",
+          "identifier": "Apache-1.0",
+          "name": "Apache License 1.0"
+        },
+        {
           "type": "Single",
           "identifier": "Apache-2.0",
           "name": "Apache License 2.0"
         },
-        "copyrightText": "Copyright 2010, 2011 Source Auditor Inc.",
-        "licenseComment": null,
-        "notice": null,
-        "checksum": {
-          "identifier": "SHA1",
-          "value": "2fd4e1c67a2d28fced849ee1bb76e7391b93eb12"
+        {
+          "type": "Single",
+          "identifier": "LicenseRef-1",
+          "name": "LicenseRef-1"
         },
-        "licenseInfoFromFiles": [
-          {
-            "type": "Single",
-            "identifier": "Apache-2.0",
-            "name": "Apache License 2.0"
-          }
-        ],
-        "contributors": [],
-        "dependencies": [],
-        "artifactOfProjectName": [],
-        "artifactOfProjectHome": [],
-        "artifactOfProjectURI": []
+        {
+          "type": "Single",
+          "identifier": "LicenseRef-2",
+          "name": "LicenseRef-2"
+        },
+        {
+          "type": "Single",
+          "identifier": "LicenseRef-3",
+          "name": "CyberNeko License"
+        },
+        {
+          "type": "Single",
+          "identifier": "LicenseRef-4",
+          "name": "LicenseRef-4"
+        },
+        {
+          "type": "Single",
+          "identifier": "MPL-1.1",
+          "name": "Mozilla Public License 1.1"
+        }
+      ],
+      "verificationCode": {
+        "value": "4e3211c67a2d28fced849ee1bb76e7391b93feba",
+        "excludedFilesNames": [
+          "SpdxTranslatorSpdx.rdf",
+          "SpdxTranslatorSpdx.txt"
+        ]
       }
-    ],
-    "licenseInfoFromFiles": [
-      {
-        "type": "Single",
-        "identifier": "Apache-1.0",
-        "name": "Apache License 1.0"
-      },
-      {
-        "type": "Single",
-        "identifier": "Apache-2.0",
-        "name": "Apache License 2.0"
-      },
-      {
-        "type": "Single",
-        "identifier": "LicenseRef-1",
-        "name": "LicenseRef-1"
-      },
-      {
-        "type": "Single",
-        "identifier": "LicenseRef-2",
-        "name": "LicenseRef-2"
-      },
-      {
-        "type": "Single",
-        "identifier": "LicenseRef-3",
-        "name": "CyberNeko License"
-      },
-      {
-        "type": "Single",
-        "identifier": "LicenseRef-4",
-        "name": "LicenseRef-4"
-      },
-      {
-        "type": "Single",
-        "identifier": "MPL-1.1",
-        "name": "Mozilla Public License 1.1"
-      }
-    ],
-    "verificationCode": {
-      "value": "4e3211c67a2d28fced849ee1bb76e7391b93feba",
-      "excludedFilesNames": [
-        "SpdxTranslatorSpdx.rdf",
-        "SpdxTranslatorSpdx.txt"
-      ]
     }
-  },
+  ],
   "externalDocumentRefs": [
     {
       "externalDocumentId": "DocumentRef-spdx-tool-2.1",

--- a/tests/data/doc_parse/spdx-expected.json
+++ b/tests/data/doc_parse/spdx-expected.json
@@ -34,183 +34,185 @@
   ],
   "created": "2010-02-03T00:00:00Z",
   "creatorComment": "This is an example of an SPDX spreadsheet format",
-  "package": {
-    "id": "SPDXRef-Package",
-    "name": "SPDX Translator",
-    "packageFileName": "spdxtranslator-1.0.zip",
-    "summary": "SPDX Translator utility",
-    "description": "This utility translates and SPDX RDF XML document to a spreadsheet, translates a spreadsheet to an SPDX RDF XML document and translates an SPDX RDFa document to an SPDX RDF XML document.",
-    "versionInfo": "Version 0.9.2",
-    "sourceInfo": "Version 1.0 of the SPDX Translator application",
-    "downloadLocation": "http://www.spdx.org/tools",
-    "homepage": null,
-    "originator": {
-      "name": "SPDX",
-      "email": null,
-      "type": "Organization"
-    },
-    "supplier": {
-      "name": "Linux Foundation",
-      "email": null,
-      "type": "Organization"
-    },
-    "licenseConcluded": {
-      "type": "Conjunction",
-      "identifier": [
-        "Apache-1.0",
-        "Apache-2.0",
-        "LicenseRef-1",
-        "LicenseRef-2",
-        "LicenseRef-3",
-        "LicenseRef-4",
-        "MPL-1.1"
-      ],
-      "name": [
-        "Apache License 1.0",
-        "Apache License 2.0",
-        "CyberNeko License",
-        "LicenseRef-1",
-        "LicenseRef-2",
-        "LicenseRef-4",
-        "Mozilla Public License 1.1"
-      ]
-    },
-    "licenseDeclared": {
-      "type": "Conjunction",
-      "identifier": [
-        "Apache-2.0",
-        "LicenseRef-1",
-        "LicenseRef-2",
-        "LicenseRef-3",
-        "LicenseRef-4",
-        "MPL-1.1"
-      ],
-      "name": [
-        "Apache License 2.0",
-        "CyberNeko License",
-        "LicenseRef-1",
-        "LicenseRef-2",
-        "LicenseRef-4",
-        "Mozilla Public License 1.1"
-      ]
-    },
-    "copyrightText": " Copyright 2010, 2011 Source Auditor Inc.",
-    "licenseComment": "The declared license information can be found in the NOTICE file at the root of the archive file",
-    "checksum": {
-      "identifier": "SHA1",
-      "value": "2fd4e1c67a2d28fced849ee1bb76e7391b93eb12"
-    },
-    "files": [
-      {
-        "id": "https://spdx.org/spdxdocs/spdx-example-444504E0-4F89-41D3-9A0C-0305E82C3301#SPDXRef-File1",
-        "name": "Jenna-2.6.3/jena-2.6.3-sources.jar",
-        "type": 3,
-        "comment": "This file belongs to Jena",
-        "licenseConcluded": {
-          "type": "Single",
-          "identifier": "LicenseRef-1",
-          "name": "LicenseRef-1"
-        },
-        "copyrightText": "(c) Copyright 2000, 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009 Hewlett-Packard Development Company, LP",
-        "licenseComment": "This license is used by Jena",
-        "notice": null,
-        "checksum": {
-          "identifier": "SHA1",
-          "value": "3ab4e1c67a2d28fced849ee1bb76e7391b93f125"
-        },
-        "licenseInfoFromFiles": [
-          {
+  "packages": [
+    {
+      "id": "SPDXRef-Package",
+      "name": "SPDX Translator",
+      "packageFileName": "spdxtranslator-1.0.zip",
+      "summary": "SPDX Translator utility",
+      "description": "This utility translates and SPDX RDF XML document to a spreadsheet, translates a spreadsheet to an SPDX RDF XML document and translates an SPDX RDFa document to an SPDX RDF XML document.",
+      "versionInfo": "Version 0.9.2",
+      "sourceInfo": "Version 1.0 of the SPDX Translator application",
+      "downloadLocation": "http://www.spdx.org/tools",
+      "homepage": null,
+      "originator": {
+        "name": "SPDX",
+        "email": null,
+        "type": "Organization"
+      },
+      "supplier": {
+        "name": "Linux Foundation",
+        "email": null,
+        "type": "Organization"
+      },
+      "licenseConcluded": {
+        "type": "Conjunction",
+        "identifier": [
+          "Apache-1.0",
+          "Apache-2.0",
+          "LicenseRef-1",
+          "LicenseRef-2",
+          "LicenseRef-3",
+          "LicenseRef-4",
+          "MPL-1.1"
+        ],
+        "name": [
+          "Apache License 1.0",
+          "Apache License 2.0",
+          "CyberNeko License",
+          "LicenseRef-1",
+          "LicenseRef-2",
+          "LicenseRef-4",
+          "Mozilla Public License 1.1"
+        ]
+      },
+      "licenseDeclared": {
+        "type": "Conjunction",
+        "identifier": [
+          "Apache-2.0",
+          "LicenseRef-1",
+          "LicenseRef-2",
+          "LicenseRef-3",
+          "LicenseRef-4",
+          "MPL-1.1"
+        ],
+        "name": [
+          "Apache License 2.0",
+          "CyberNeko License",
+          "LicenseRef-1",
+          "LicenseRef-2",
+          "LicenseRef-4",
+          "Mozilla Public License 1.1"
+        ]
+      },
+      "copyrightText": " Copyright 2010, 2011 Source Auditor Inc.",
+      "licenseComment": "The declared license information can be found in the NOTICE file at the root of the archive file",
+      "checksum": {
+        "identifier": "SHA1",
+        "value": "2fd4e1c67a2d28fced849ee1bb76e7391b93eb12"
+      },
+      "files": [
+        {
+          "id": "https://spdx.org/spdxdocs/spdx-example-444504E0-4F89-41D3-9A0C-0305E82C3301#SPDXRef-File1",
+          "name": "Jenna-2.6.3/jena-2.6.3-sources.jar",
+          "type": 3,
+          "comment": "This file belongs to Jena",
+          "licenseConcluded": {
             "type": "Single",
             "identifier": "LicenseRef-1",
             "name": "LicenseRef-1"
-          }
-        ],
-        "contributors": [],
-        "dependencies": [],
-        "artifactOfProjectName": [
-          "Jena"
-        ],
-        "artifactOfProjectHome": [
-          "http://www.openjena.org/"
-        ],
-        "artifactOfProjectURI": []
-      },
-      {
-        "id": "https://spdx.org/spdxdocs/spdx-example-444504E0-4F89-41D3-9A0C-0305E82C3301#SPDXRef-File2",
-        "name": "src/org/spdx/parser/DOAPProject.java",
-        "type": 1,
-        "comment": null,
-        "licenseConcluded": {
+          },
+          "copyrightText": "(c) Copyright 2000, 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009 Hewlett-Packard Development Company, LP",
+          "licenseComment": "This license is used by Jena",
+          "notice": null,
+          "checksum": {
+            "identifier": "SHA1",
+            "value": "3ab4e1c67a2d28fced849ee1bb76e7391b93f125"
+          },
+          "licenseInfoFromFiles": [
+            {
+              "type": "Single",
+              "identifier": "LicenseRef-1",
+              "name": "LicenseRef-1"
+            }
+          ],
+          "contributors": [],
+          "dependencies": [],
+          "artifactOfProjectName": [
+            "Jena"
+          ],
+          "artifactOfProjectHome": [
+            "http://www.openjena.org/"
+          ],
+          "artifactOfProjectURI": []
+        },
+        {
+          "id": "https://spdx.org/spdxdocs/spdx-example-444504E0-4F89-41D3-9A0C-0305E82C3301#SPDXRef-File2",
+          "name": "src/org/spdx/parser/DOAPProject.java",
+          "type": 1,
+          "comment": null,
+          "licenseConcluded": {
+            "type": "Single",
+            "identifier": "Apache-2.0",
+            "name": "Apache License 2.0"
+          },
+          "copyrightText": "Copyright 2010, 2011 Source Auditor Inc.",
+          "licenseComment": null,
+          "notice": null,
+          "checksum": {
+            "identifier": "SHA1",
+            "value": "2fd4e1c67a2d28fced849ee1bb76e7391b93eb12"
+          },
+          "licenseInfoFromFiles": [
+            {
+              "type": "Single",
+              "identifier": "Apache-2.0",
+              "name": "Apache License 2.0"
+            }
+          ],
+          "contributors": [],
+          "dependencies": [],
+          "artifactOfProjectName": [],
+          "artifactOfProjectHome": [],
+          "artifactOfProjectURI": []
+        }
+      ],
+      "licenseInfoFromFiles": [
+        {
+          "type": "Single",
+          "identifier": "Apache-1.0",
+          "name": "Apache License 1.0"
+        },
+        {
           "type": "Single",
           "identifier": "Apache-2.0",
           "name": "Apache License 2.0"
         },
-        "copyrightText": "Copyright 2010, 2011 Source Auditor Inc.",
-        "licenseComment": null,
-        "notice": null,
-        "checksum": {
-          "identifier": "SHA1",
-          "value": "2fd4e1c67a2d28fced849ee1bb76e7391b93eb12"
+        {
+          "type": "Single",
+          "identifier": "LicenseRef-1",
+          "name": "LicenseRef-1"
         },
-        "licenseInfoFromFiles": [
-          {
-            "type": "Single",
-            "identifier": "Apache-2.0",
-            "name": "Apache License 2.0"
-          }
-        ],
-        "contributors": [],
-        "dependencies": [],
-        "artifactOfProjectName": [],
-        "artifactOfProjectHome": [],
-        "artifactOfProjectURI": []
+        {
+          "type": "Single",
+          "identifier": "LicenseRef-2",
+          "name": "LicenseRef-2"
+        },
+        {
+          "type": "Single",
+          "identifier": "LicenseRef-3",
+          "name": "CyberNeko License"
+        },
+        {
+          "type": "Single",
+          "identifier": "LicenseRef-4",
+          "name": "LicenseRef-4"
+        },
+        {
+          "type": "Single",
+          "identifier": "MPL-1.1",
+          "name": "Mozilla Public License 1.1"
+        }
+      ],
+      "verificationCode": {
+        "value": "4e3211c67a2d28fced849ee1bb76e7391b93feba",
+        "excludedFilesNames": [
+          "SpdxTranslatorSpdx.rdf",
+          "SpdxTranslatorSpdx.txt"
+        ]
       }
-    ],
-    "licenseInfoFromFiles": [
-      {
-        "type": "Single",
-        "identifier": "Apache-1.0",
-        "name": "Apache License 1.0"
-      },
-      {
-        "type": "Single",
-        "identifier": "Apache-2.0",
-        "name": "Apache License 2.0"
-      },
-      {
-        "type": "Single",
-        "identifier": "LicenseRef-1",
-        "name": "LicenseRef-1"
-      },
-      {
-        "type": "Single",
-        "identifier": "LicenseRef-2",
-        "name": "LicenseRef-2"
-      },
-      {
-        "type": "Single",
-        "identifier": "LicenseRef-3",
-        "name": "CyberNeko License"
-      },
-      {
-        "type": "Single",
-        "identifier": "LicenseRef-4",
-        "name": "LicenseRef-4"
-      },
-      {
-        "type": "Single",
-        "identifier": "MPL-1.1",
-        "name": "Mozilla Public License 1.1"
-      }
-    ],
-    "verificationCode": {
-      "value": "4e3211c67a2d28fced849ee1bb76e7391b93feba",
-      "excludedFilesNames": [
-        "SpdxTranslatorSpdx.rdf",
-        "SpdxTranslatorSpdx.txt"
-      ]
     }
-  },
+  ],
   "externalDocumentRefs": [
     {
       "externalDocumentId": "DocumentRef-spdx-tool-2.1",

--- a/tests/data/formats/SPDXSBOMExample.spdx.yml
+++ b/tests/data/formats/SPDXSBOMExample.spdx.yml
@@ -1,0 +1,58 @@
+# example of an SBOM with several packages and filesAnalyzed=False
+# from https://github.com/spdx/spdx-spec/issues/439
+SPDXID: "SPDXRef-DOCUMENT"
+spdxVersion: "SPDX-2.2"
+creationInfo:
+  created: "2020-07-23T18:30:22Z"
+  creators:
+  - "Organization: Example Inc."
+  - "Person: Thomas Steenbergen"
+  licenseListVersion: "3.9"
+name: "xyz-0.1.0"
+dataLicense: "CC0-1.0"
+documentNamespace: "http://spdx.org/spdxdocs/spdx-document-xyz"
+documentDescribes:
+- "SPDXRef-Package-xyz"
+packages:
+- SPDXID: "SPDXRef-Package-xyz"
+  summary: "Awesome product created by Example Inc."
+  copyrightText: "copyright 2004-2020 Example Inc. All Rights Reserved."
+  downloadLocation: "git+ssh://gitlab.example.com:3389/products/xyz.git@b2c358080011af6a366d2512a25a379fbe7b1f78"
+  filesAnalyzed: false
+  homepage: "https://example.com/products/xyz"
+  licenseConcluded:  "NOASSERTION"
+  licenseDeclared: "Apache-2.0 AND curl AND LicenseRef-Proprietary-ExampleInc"
+  name: "xyz"
+  versionInfo: "0.1.0"
+- SPDXID: "SPDXRef-Package-curl"
+  description: "A command line tool and library for transferring data with URL syntax, supporting \
+     HTTP, HTTPS, FTP, FTPS, GOPHER, TFTP, SCP, SFTP, SMB, TELNET, DICT, LDAP, LDAPS, MQTT, FILE, \
+     IMAP, SMTP, POP3, RTSP and RTMP. libcurl offers a myriad of powerful features."
+  copyrightText: "Copyright (c) 1996 - 2020, Daniel Stenberg, <daniel@haxx.se>, and many
+    contributors, see the THANKS file."
+  downloadLocation: "https://github.com/curl/curl/releases/download/curl-7_70_0/curl-7.70.0.tar.gz"
+  filesAnalyzed: false
+  homepage: "https://curl.haxx.se/"
+  licenseConcluded: "NOASSERTION"
+  licenseDeclared: "curl"
+  name: "curl"
+  packageFileName: "./libs/curl"
+  versionInfo: "7.70.0"
+- SPDXID: "SPDXRef-Package-openssl"
+  description: "OpenSSL is a robust, commercial-grade, full-featured Open Source Toolkit for the Transport Layer Security (TLS) protocol formerly known as the Secure Sockets Layer (SSL) protocol. The protocol implementation is based on a full-strength general purpose cryptographic library, which can also be used stand-alone."
+  copyrightText: "copyright 2004-2020 The OpenSSL Project Authors. All Rights Reserved."
+  downloadLocation: "git+ssh://github.com/openssl/openssl.git@e2e09d9fba1187f8d6aafaa34d4172f56f1ffb72"
+  filesAnalyzed: false
+  homepage: "https://www.openssl.org/"
+  licenseConcluded: "NOASSERTION"
+  licenseDeclared: "Apache-2.0"
+  packageFileName: "./libs/openssl"
+  name: "openssl"
+  versionInfo: "1.1.1g"
+relationships:
+- spdxElementId: "SPDXRef-Package-xyz"
+  relatedSpdxElement: "SPDXRef-Package-curl"
+  relationshipType: "CONTAINS"
+- spdxElementId: "SPDXRef-Package-xyz"
+  relatedSpdxElement: "SPDXRef-Package-openssl"
+  relationshipType: "CONTAINS"

--- a/tests/test_jsonyamlxml_parser.py
+++ b/tests/test_jsonyamlxml_parser.py
@@ -61,3 +61,12 @@ class TestParser(TestCase):
             document, _ = parser.parse(f)
         expected_loc = utils_test.get_test_loc('doc_parse/expected.json')
         self.check_document(document, expected_loc)
+
+    def test_sbomyaml_parser(self):
+        parser = yamlparser.Parser(Builder(), StandardLogger())
+        test_file = utils_test.get_test_loc('formats/SPDXSBOMExample.spdx.yml')
+        with io.open(test_file, encoding='utf-8') as f:
+            document, errors = parser.parse(f)
+            assert not errors
+        expected_loc = utils_test.get_test_loc('doc_parse/SBOMexpected.json')
+        self.check_document(document, expected_loc)

--- a/tests/test_parse_anything.py
+++ b/tests/test_parse_anything.py
@@ -30,5 +30,5 @@ def test_parse_anything(test_file):
     assert not error
 
     # test a few fields, the core of the tests are per parser
-    assert doc.name == 'Sample_Document-V2.1'
-    assert doc.comment in ('This is a sample spreadsheet', 'Sample Comment')
+    assert doc.name in ('Sample_Document-V2.1', 'xyz-0.1.0')
+    assert doc.comment in (None, 'This is a sample spreadsheet', 'Sample Comment')

--- a/tests/test_rdf_parser.py
+++ b/tests/test_rdf_parser.py
@@ -31,7 +31,7 @@ class TestParser(unittest.TestCase):
         with io.open(test_file, 'rb') as f:
             document, _ = parser.parse(f)
         expected_loc = utils_test.get_test_loc('doc_parse/spdx-expected.json', test_data_dir=utils_test.test_data_dir)
-        self.check_document(document, expected_loc)
+        self.check_document(document, expected_loc, regen=regen)
 
     def check_document(self, document, expected_loc, regen=False):
         result = TestParserUtils.to_dict(document)

--- a/tests/test_write_anything.py
+++ b/tests/test_write_anything.py
@@ -37,13 +37,16 @@ UNSTABLE_CONVERSIONS = {
     "SPDXRdfExample.rdf-yaml",
     "SPDXRdfExample.rdf-xml",
     "SPDXRdfExample.rdf-json",
-    "SPDXRdfExample.rdf-tag",
+    "SPDXRdfExample.rdf-tag"
 }
 
 @pytest.mark.parametrize("out_format", ['rdf', 'yaml', 'xml', 'json', 'tag'])
 @pytest.mark.parametrize("in_file", test_files, ids=lambda x: os.path.basename(x))
 def test_write_anything(in_file, out_format, tmpdir):
     in_basename = os.path.basename(in_file)
+    if in_basename == "SPDXSBOMExample.spdx.yml":
+        # conversion of spdx2.2 is not yet done
+        return
     doc, error = parse_anything.parse_file(in_file)
 
     assert not error

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -279,7 +279,8 @@ class TestParserUtils(object):
         """
         CONJ_SEP = re.compile(' AND | and ')
         DISJ_SEP = re.compile(' OR | or ')
-
+        if license is None:
+            return None
         license_dict = OrderedDict()
 
         if isinstance(license, spdx.document.LicenseConjunction):
@@ -314,6 +315,8 @@ class TestParserUtils(object):
         """
         Represents spdx.creationInfo.Creator subclasses as a dictionary
         """
+        if entity is None:
+            return None
         entity_dict = OrderedDict(name=entity.name)
 
         if isinstance(entity, spdx.creationinfo.Tool):
@@ -334,6 +337,8 @@ class TestParserUtils(object):
         """
         Represents spdx.checksum.Algorithm as a Python dictionary
         """
+        if checksum is None:
+            return None
         return OrderedDict([
             ('identifier', checksum.identifier),
             ('value', checksum.value)])
@@ -343,7 +348,9 @@ class TestParserUtils(object):
         """
         Represents spdx.package.Package as a Python dictionary
         """
-        lics_from_files = sorted(package.licenses_from_files, key=lambda lic: lic.identifier)
+        lics_from_files = []
+        if package.are_files_analyzed:
+            lics_from_files = sorted(package.licenses_from_files, key=lambda lic: lic.identifier)
         return OrderedDict([
             ('id', package.spdx_id),
             ('name', package.name),
@@ -513,7 +520,7 @@ class TestParserUtils(object):
             ('creators', [cls.entity_to_dict(creator) for creator in creators]),
             ('created', utils.datetime_iso_format(doc.creation_info.created)),
             ('creatorComment', doc.creation_info.comment),
-            ('package', cls.package_to_dict(doc.package)),
+            ('packages', [cls.package_to_dict(p) for p in doc.packages]),
             ('externalDocumentRefs', cls.ext_document_references_to_list(sorted(doc.ext_document_references))),
             ('extractedLicenses', cls.extracted_licenses_to_list(sorted(doc.extracted_licenses))),
             ('annotations', cls.annotations_to_list(sorted(doc.annotations))),


### PR DESCRIPTION
example taken from https://github.com/spdx/spdx-spec/issues/439
coming from ART people

I came into some of the issues of #180 like multiple package support and pkgFilesAnalyzed, so it will probably override it.
