### PR TITLE
[issue-222] fix parsing of tv-files with multiple packages

### DIFF
--- a/spdx/parsers/parse_anything.py
+++ b/spdx/parsers/parse_anything.py
@@ -27,10 +27,7 @@ def parse_file(fn):
     if fn.endswith(".rdf") or fn.endswith(".rdf.xml"):
         parsing_module = rdf
         buildermodule = rdfbuilders
-    elif fn.endswith(".spdx"):
-        parsing_module = rdf
-        buildermodule = rdfbuilders
-    elif fn.endswith(".tag"):
+    elif fn.endswith(".tag") or fn.endswith(".spdx"):
         parsing_module = tagvalue
         buildermodule = tagvaluebuilders
         read_data = True

--- a/spdx/parsers/tagvaluebuilders.py
+++ b/spdx/parsers/tagvaluebuilders.py
@@ -602,6 +602,7 @@ class PackageBuilder(object):
         name - any string.
         Raise CardinalityError if package already defined.
         """
+        self.reset_package()
         self.package_set = True
         doc.add_package(package.Package(name=name))
         return True

--- a/tests/data/formats/SPDXSBOMExample.tag
+++ b/tests/data/formats/SPDXSBOMExample.tag
@@ -1,0 +1,64 @@
+# Document Information
+
+SPDXVersion: SPDX-2.2
+DataLicense: CC0-1.0
+DocumentNamespace: http://spdx.org/spdxdocs/spdx-document-xyz
+DocumentName: xyz-0.1.0
+SPDXID: SPDXRef-DOCUMENT
+
+
+# Creation Info
+
+Creator: Organization: Example Inc.
+Creator: Person: Thomas Steenbergen
+Created: 2020-07-23T18:30:22Z
+
+
+# Relationships
+
+Relationship: SPDXRef-Package-xyz CONTAINS SPDXRef-Package-curl
+Relationship: SPDXRef-Package-xyz CONTAINS SPDXRef-Package-openssl
+
+
+# Package
+
+PackageName: xyz
+SPDXID: SPDXRef-Package-xyz
+PackageVersion: 0.1.0
+PackageDownloadLocation: git+ssh://gitlab.example.com:3389/products/xyz.git@b2c358080011af6a366d2512a25a379fbe7b1f78
+FilesAnalyzed: False
+PackageSummary: <text>Awesome product created by Example Inc.</text>
+PackageLicenseDeclared: (Apache-2.0 AND curl AND LicenseRef-Proprietary-ExampleInc)
+PackageLicenseConcluded: NOASSERTION
+PackageCopyrightText: <text>copyright 2004-2020 Example Inc. All Rights Reserved.</text>
+PackageHomePage: https://example.com/products/xyz
+
+
+# Package
+
+PackageName: curl
+SPDXID: SPDXRef-Package-curl
+PackageVersion: 7.70.0
+PackageDownloadLocation: https://github.com/curl/curl/releases/download/curl-7_70_0/curl-7.70.0.tar.gz
+FilesAnalyzed: False
+PackageFileName: ./libs/curl
+PackageDescription: <text>A command line tool and library for transferring data with URL syntax, supporting HTTP, HTTPS, FTP, FTPS, GOPHER, TFTP, SCP, SFTP, SMB, TELNET, DICT, LDAP, LDAPS, MQTT, FILE, IMAP, SMTP, POP3, RTSP and RTMP. libcurl offers a myriad of powerful features.</text>
+PackageLicenseDeclared: curl
+PackageLicenseConcluded: NOASSERTION
+PackageCopyrightText: <text>Copyright (c) 1996 - 2020, Daniel Stenberg, <daniel@haxx.se>, and many contributors, see the THANKS file.</text>
+PackageHomePage: https://curl.haxx.se/
+
+
+# Package
+
+PackageName: openssl
+SPDXID: SPDXRef-Package-openssl
+PackageVersion: 1.1.1g
+PackageDownloadLocation: git+ssh://github.com/openssl/openssl.git@e2e09d9fba1187f8d6aafaa34d4172f56f1ffb72
+FilesAnalyzed: False
+PackageFileName: ./libs/openssl
+PackageDescription: <text>OpenSSL is a robust, commercial-grade, full-featured Open Source Toolkit for the Transport Layer Security (TLS) protocol formerly known as the Secure Sockets Layer (SSL) protocol. The protocol implementation is based on a full-strength general purpose cryptographic library, which can also be used stand-alone.</text>
+PackageLicenseDeclared: Apache-2.0
+PackageLicenseConcluded: NOASSERTION
+PackageCopyrightText: <text>copyright 2004-2020 The OpenSSL Project Authors. All Rights Reserved.</text>
+PackageHomePage: https://www.openssl.org/

--- a/tests/test_write_anything.py
+++ b/tests/test_write_anything.py
@@ -42,7 +42,7 @@ UNSTABLE_CONVERSIONS = {
 @pytest.mark.parametrize("in_file", test_files, ids=lambda x: os.path.basename(x))
 def test_write_anything(in_file, out_format, tmpdir):
     in_basename = os.path.basename(in_file)
-    if in_basename == "SPDXSBOMExample.spdx.yml":
+    if in_basename == "SPDXSBOMExample.spdx.yml" or in_basename == "SPDXSBOMExample.tag":
         # conversion of spdx2.2 is not yet done
         return
     doc, error = parse_anything.parse_file(in_file)


### PR DESCRIPTION
fixes #222 

I also added a new testfile so that parsing of TV-files with multiple packages is also tested. The new testfile needs to be skipped in the [test_write_anything.py](https://github.com/spdx/tools-python/blob/main/tests/test_write_anything.py) since conversion of SPDX 2.2 files is not implemented yet and yields to failures of the test.  
This PR also fixes parsing of .spdx files which were parsed as .rdf files before. 

Signed-off-by: Meret Behrens <meret.behrens@tngtech.com>