### PR TITLE
ISSUES-196 parse spdx 2.2

### DIFF
--- a/spdx/annotation.py
+++ b/spdx/annotation.py
@@ -83,7 +83,6 @@ class Annotation(object):
         self.validate_annotator(messages)
         self.validate_annotation_date(messages)
         self.validate_annotation_type(messages)
-        self.validate_spdx_id(messages)
 
     def validate_annotator(self, messages):
         if self.annotator is None:
@@ -97,6 +96,3 @@ class Annotation(object):
         if self.annotation_type is None:
             messages.append("Annotation missing annotation type.")
 
-    def validate_spdx_id(self, messages):
-        if self.spdx_id is None:
-            messages.append("Annotation missing SPDX Identifier Reference.")

--- a/spdx/document.py
+++ b/spdx/document.py
@@ -449,11 +449,11 @@ class Document(object):
 
     def validate_annotations(self, messages):
         for annotation in self.annotations:
-            messages = annotation.validate(messages)
+            annotation.validate(messages)
 
     def validate_relationships(self, messages):
         for relationship in self.relationships:
-            messages = relationship.validate(messages)
+            relationship.validate(messages)
 
     def validate_snippet(self, messages=None):
         for snippet in self.snippet:

--- a/spdx/package.py
+++ b/spdx/package.py
@@ -127,7 +127,6 @@ class Package(object):
         self.validate_checksum(messages)
         self.validate_optional_str_fields(messages)
         self.validate_mandatory_str_fields(messages)
-        self.validate_files(messages)
         self.validate_pkg_ext_refs(messages)
         self.validate_mandatory_fields(messages)
         self.validate_optional_fields(messages)
@@ -213,17 +212,6 @@ class Package(object):
 
         return messages
 
-    def validate_files(self, messages):
-        if self.are_files_analyzed:
-            if not self.files:
-                messages.append(
-                    "Package must have at least one file."
-                )
-            else:
-                for f in self.files:
-                    messages = f.validate(messages)
-
-        return messages
 
     def validate_optional_str_fields(self, messages):
         """Fields marked as optional and of type string in class

--- a/spdx/package.py
+++ b/spdx/package.py
@@ -39,8 +39,10 @@ class Package(object):
      If set to "false", the package must not contain any files.
      Optional, boolean.
      - homepage: Optional, URL as string or NONE or NO_ASSERTION.
-     - verif_code: string. Mandatory if files_analyzed is True or None (omitted)
-       Must be None (omitted) if files_analyzed is False
+     - verif_code: string. According to the specification, this is Mandatory
+     whenever files_analyzed is True or None (omitted) and Must be None (omitted)
+     if files_analyzed is False. However, as a convenience within this library,
+     we allow this to be Optional even when files_analyzed is True/None.
      - check_sum: Optional , spdx.checksum.Algorithm.
      - source_info: Optional string.
      - conc_lics: Mandatory spdx.document.License or spdx.utils.SPDXNone or
@@ -246,8 +248,6 @@ class Package(object):
         docstring must be of a type that provides __str__ method.
         """
         FIELDS = ["name", "spdx_id", "download_location", "cr_text"]
-        if self.are_files_analyzed:
-            FIELDS = FIELDS + ["verif_code"]
         self.validate_str_fields(FIELDS, False, messages)
 
         return messages

--- a/spdx/parsers/jsonyamlxml.py
+++ b/spdx/parsers/jsonyamlxml.py
@@ -1192,6 +1192,15 @@ class PackageParser(BaseParser):
         # Files Analyzed optional
         if pkg_files_analyzed is None:
             return
+
+        # For XML, this is a string, not a boolean.
+        # xmltodict doesn't do this translation for us, so we do it here.
+        if isinstance(pkg_files_analyzed, str):
+            if pkg_files_analyzed.lower() in ['true', '1']:
+                pkg_files_analyzed = True
+            elif pkg_files_analyzed.lower() in ['false', '0']:
+                pkg_files_analyzed = False
+
         if isinstance(pkg_files_analyzed, bool):
             try:
                 return self.builder.set_pkg_files_analyzed(

--- a/spdx/parsers/rdf.py
+++ b/spdx/parsers/rdf.py
@@ -585,11 +585,8 @@ class PackageParser(LicenseParser):
 
     def p_pkg_vinfo(self, p_term, predicate):
         for _s, _p, o in self.graph.triples((p_term, predicate, None)):
-            try:
-                self.builder.set_pkg_vers(self.doc, str(o))
-            except CardinalityError:
-                self.more_than_one_error("Package version info")
-                break
+            self.builder.set_pkg_vers(self.doc, str(o))
+
 
 
 class FileParser(LicenseParser):

--- a/spdx/parsers/xmlparser.py
+++ b/spdx/parsers/xmlparser.py
@@ -43,6 +43,8 @@ class Parser(jsonyamlxml.Parser):
             "excludedFilesNames",
             "files",
             "documentDescribes",
+            "packageVerificationCodeExcludedFiles",
+            "licenseInfoInSnippets"
         }
 
     def parse(self, file):
@@ -50,7 +52,7 @@ class Parser(jsonyamlxml.Parser):
             file.read(), strip_whitespace=False, encoding="utf-8"
         )
         fixed_object = self._set_in_list(parsed_xml, self.LIST_LIKE_FIELDS)
-        self.document_object = fixed_object.get("SpdxDocument").get("Document")
+        self.document_object = fixed_object.get("Document")
         return super(Parser, self).parse()
 
     def _set_in_list(self, data, keys):

--- a/spdx/writers/jsonyamlxml.py
+++ b/spdx/writers/jsonyamlxml.py
@@ -112,13 +112,16 @@ class PackageWriter(BaseWriter):
         package_object["SPDXID"] = self.spdx_id(package.spdx_id)
         package_object["name"] = package.name
         package_object["downloadLocation"] = package.download_location.__str__()
-        package_object["packageVerificationCode"] = self.package_verification_code(
-            package
-        )
+        if package.files_analyzed is not None:
+            package_object["filesAnalyzed"] = package.files_analyzed
+        if package.files_analyzed is None or package.files_analyzed is True:
+            package_object["packageVerificationCode"] = self.package_verification_code(
+                package
+            )
+            package_object["licenseInfoFromFiles"] = list(
+                map(self.license, package.licenses_from_files)
+            )
         package_object["licenseConcluded"] = self.license(package.conc_lics)
-        package_object["licenseInfoFromFiles"] = list(
-            map(self.license, package.licenses_from_files)
-        )
         package_object["licenseDeclared"] = self.license(package.license_declared)
         package_object["copyrightText"] = package.cr_text.__str__()
 
@@ -474,7 +477,9 @@ class Writer(
         package_objects = []
         for package in self.document.packages:
             package_info_object = self.create_package_info(package)
-            package_info_object["files"] = self.create_file_info(package)
+            # SPDX 2.2 says to omit if filesAnalyzed = False
+            if package.files:
+                package_info_object["files"] = self.create_file_info(package)
             package_objects.append({"Package": package_info_object})
 
         self.document_object["documentDescribes"] = package_objects

--- a/spdx/writers/jsonyamlxml.py
+++ b/spdx/writers/jsonyamlxml.py
@@ -115,9 +115,10 @@ class PackageWriter(BaseWriter):
         if package.files_analyzed is not None:
             package_object["filesAnalyzed"] = package.files_analyzed
         if package.files_analyzed is None or package.files_analyzed is True:
-            package_object["packageVerificationCode"] = self.package_verification_code(
-                package
-            )
+            if package.verif_code:
+                package_object["packageVerificationCode"] = self.package_verification_code(
+                    package
+                )
             package_object["licenseInfoFromFiles"] = list(
                 map(self.license, package.licenses_from_files)
             )

--- a/spdx/writers/jsonyamlxml.py
+++ b/spdx/writers/jsonyamlxml.py
@@ -342,9 +342,9 @@ class SnippetWriter(BaseWriter):
             snippet_object = dict()
             snippet_object["SPDXID"] = self.spdx_id(snippet.spdx_id)
             snippet_object["copyrightText"] = snippet.copyright
-            snippet_object["fileId"] = self.spdx_id(snippet.snip_from_file_spdxid)
+            snippet_object["snippetFromFile"] = self.spdx_id(snippet.snip_from_file_spdxid)
             snippet_object["licenseConcluded"] = self.license(snippet.conc_lics)
-            snippet_object["licenseInfoFromSnippet"] = list(
+            snippet_object["licenseInfoInSnippets"] = list(
                 map(self.license, snippet.licenses_in_snippet)
             )
 

--- a/spdx/writers/xml.py
+++ b/spdx/writers/xml.py
@@ -25,6 +25,6 @@ def write_document(document, out, validate=True):
             raise InvalidDocumentError(messages)
 
     writer = Writer(document)
-    document_object = {"SpdxDocument": writer.create_document()}
+    document_object = writer.create_document()
 
     xmltodict.unparse(document_object, out, encoding="utf-8", pretty=True)

--- a/tests/data/doc_parse/expected.json
+++ b/tests/data/doc_parse/expected.json
@@ -2,11 +2,11 @@
   "id": "SPDXRef-DOCUMENT",
   "specVersion": {
     "major": 2,
-    "minor": 1
+    "minor": 2
   },
-  "documentNamespace": "https://spdx.org/spdxdocs/spdx-example-444504E0-4F89-41D3-9A0C-0305E82C3301",
-  "name": "Sample_Document-V2.1",
-  "comment": "This is a sample spreadsheet",
+  "documentNamespace": "http://spdx.org/spdxdocs/spdx-example-444504E0-4F89-41D3-9A0C-0305E82C3301",
+  "name": "SPDX-Tools-v2.0",
+  "comment": "This document was created using SPDX 2.0 using licenses from the web site.",
   "dataLicense": {
     "type": "Single",
     "identifier": "CC0-1.0",
@@ -14,171 +14,78 @@
   },
   "licenseListVersion": {
     "major": 3,
-    "minor": 6
+    "minor": 9
   },
   "creators": [
     {
-      "name": "Gary O'Neall",
-      "email": null,
-      "type": "Person"
-    },
-    {
-      "name": "Source Auditor Inc.",
+      "name": "ExampleCodeInspect",
       "email": null,
       "type": "Organization"
     },
     {
-      "name": "SourceAuditor-V1.2",
+      "name": "Jane Doe",
+      "email": null,
+      "type": "Person"
+    },
+    {
+      "name": "LicenseFind-1.0",
       "type": "Tool"
     }
   ],
-  "created": "2010-02-03T00:00:00Z",
-  "creatorComment": "This is an example of an SPDX spreadsheet format",
+  "created": "2010-01-29T18:30:22Z",
+  "creatorComment": "This package has been shipped in source and binary form.\nThe binaries were created with gcc 4.5.1 and expect to link to\ncompatible system run time libraries.",
   "packages": [
     {
       "id": "SPDXRef-Package",
-      "name": "SPDX Translator",
-      "packageFileName": "spdxtranslator-1.0.zip",
-      "summary": "SPDX Translator utility",
-      "description": "This utility translates and SPDX RDF XML document to a spreadsheet, translates a spreadsheet to an SPDX RDF XML document and translates an SPDX RDFa document to an SPDX RDF XML document.",
-      "versionInfo": "Version 0.9.2",
-      "sourceInfo": "Version 1.0 of the SPDX Translator application",
-      "downloadLocation": "http://www.spdx.org/tools",
-      "homepage": null,
+      "name": "glibc",
+      "packageFileName": "glibc-2.11.1.tar.gz",
+      "summary": "GNU C library.",
+      "description": "The GNU C Library defines functions that are specified by the ISO C standard, as well as additional features specific to POSIX and other derivatives of the Unix operating system, and extensions specific to GNU systems.",
+      "versionInfo": "2.11.1",
+      "sourceInfo": "uses glibc-2_11-branch from git://sourceware.org/git/glibc.git.",
+      "downloadLocation": "http://ftp.gnu.org/gnu/glibc/glibc-ports-2.15.tar.gz",
+      "homepage": "http://ftp.gnu.org/gnu/glibc",
       "originator": {
-        "name": "SPDX",
-        "email": null,
+        "name": "ExampleCodeInspect",
+        "email": "contact@example.com",
         "type": "Organization"
       },
       "supplier": {
-        "name": "Linux Foundation",
-        "email": null,
-        "type": "Organization"
+        "name": "Jane Doe",
+        "email": "jane.doe@example.com",
+        "type": "Person"
       },
       "licenseConcluded": {
-        "type": "Conjunction",
+        "type": "Disjunction",
         "identifier": [
-          "Apache-1.0",
-          "Apache-2.0",
-          "LicenseRef-1",
-          "LicenseRef-2",
-          "LicenseRef-3",
-          "LicenseRef-4",
-          "MPL-1.1"
+          "LGPL-2.0-only",
+          "LicenseRef-3"
         ],
         "name": [
-          "Apache License 1.0",
-          "Apache License 2.0",
           "CyberNeko License",
-          "LicenseRef-1",
-          "LicenseRef-2",
-          "LicenseRef-4",
-          "Mozilla Public License 1.1"
+          "GNU Library General Public License v2 only"
         ]
       },
       "licenseDeclared": {
         "type": "Conjunction",
         "identifier": [
-          "Apache-2.0",
-          "LicenseRef-1",
-          "LicenseRef-2",
-          "LicenseRef-3",
-          "LicenseRef-4",
-          "MPL-1.1"
+          "LGPL-2.0-only",
+          "LicenseRef-3"
         ],
         "name": [
-          "Apache License 2.0",
           "CyberNeko License",
-          "LicenseRef-1",
-          "LicenseRef-2",
-          "LicenseRef-4",
-          "Mozilla Public License 1.1"
+          "GNU Library General Public License v2 only"
         ]
       },
-      "copyrightText": " Copyright 2010, 2011 Source Auditor Inc.",
-      "licenseComment": "The declared license information can be found in the NOTICE file at the root of the archive file",
-      "checksum": {
-        "identifier": "SHA1",
-        "value": "2fd4e1c67a2d28fced849ee1bb76e7391b93eb12"
-      },
-      "files": [
-        {
-          "id": "SPDXRef-File1",
-          "name": "Jenna-2.6.3/jena-2.6.3-sources.jar",
-          "type": 3,
-          "comment": "This file belongs to Jena",
-          "licenseConcluded": {
-            "type": "Single",
-            "identifier": "LicenseRef-1",
-            "name": "LicenseRef-1"
-          },
-          "copyrightText": "(c) Copyright 2000, 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009 Hewlett-Packard Development Company, LP",
-          "licenseComment": "This license is used by Jena",
-          "notice": null,
-          "checksum": {
-            "identifier": "SHA1",
-            "value": "3ab4e1c67a2d28fced849ee1bb76e7391b93f125"
-          },
-          "licenseInfoFromFiles": [
-            {
-              "type": "Single",
-              "identifier": "LicenseRef-1",
-              "name": "LicenseRef-1"
-            }
-          ],
-          "contributors": [],
-          "dependencies": [],
-          "artifactOfProjectName": [
-            "Jena"
-          ],
-          "artifactOfProjectHome": [
-            "http://www.openjena.org/"
-          ],
-          "artifactOfProjectURI": [
-            "http://subversion.apache.org/doap.rdf"
-          ]
-        },
-        {
-          "id": "SPDXRef-File2",
-          "name": "src/org/spdx/parser/DOAPProject.java",
-          "type": 1,
-          "comment": null,
-          "licenseConcluded": {
-            "type": "Single",
-            "identifier": "Apache-2.0",
-            "name": "Apache License 2.0"
-          },
-          "copyrightText": "Copyright 2010, 2011 Source Auditor Inc.",
-          "licenseComment": null,
-          "notice": null,
-          "checksum": {
-            "identifier": "SHA1",
-            "value": "2fd4e1c67a2d28fced849ee1bb76e7391b93eb12"
-          },
-          "licenseInfoFromFiles": [
-            {
-              "type": "Single",
-              "identifier": "Apache-2.0",
-              "name": "Apache License 2.0"
-            }
-          ],
-          "contributors": [],
-          "dependencies": [],
-          "artifactOfProjectName": [],
-          "artifactOfProjectHome": [],
-          "artifactOfProjectURI": []
-        }
-      ],
+      "copyrightText": "Copyright 2008-2010 John Smith",
+      "licenseComment": "The license for this project changed with the release of version x.y.  The version of the project included here post-dates the license change.",
+      "checksum": null,
+      "files": [],
       "licenseInfoFromFiles": [
         {
           "type": "Single",
-          "identifier": "Apache-1.0",
-          "name": "Apache License 1.0"
-        },
-        {
-          "type": "Single",
-          "identifier": "Apache-2.0",
-          "name": "Apache License 2.0"
+          "identifier": "GPL-2.0-only",
+          "name": "GNU General Public License v2.0 only"
         },
         {
           "type": "Single",
@@ -189,36 +96,116 @@
           "type": "Single",
           "identifier": "LicenseRef-2",
           "name": "LicenseRef-2"
-        },
-        {
-          "type": "Single",
-          "identifier": "LicenseRef-3",
-          "name": "CyberNeko License"
-        },
-        {
-          "type": "Single",
-          "identifier": "LicenseRef-4",
-          "name": "LicenseRef-4"
-        },
-        {
-          "type": "Single",
-          "identifier": "MPL-1.1",
-          "name": "Mozilla Public License 1.1"
         }
       ],
       "verificationCode": {
-        "value": "4e3211c67a2d28fced849ee1bb76e7391b93feba",
+        "value": "d6a770ba38583ed4bb4525bd96e50461655d2758",
         "excludedFilesNames": [
-          "SpdxTranslatorSpdx.rdf",
-          "SpdxTranslatorSpdx.txt"
+          "./package.spdx"
         ]
+      }
+    },
+    {
+      "id": "SPDXRef-fromDoap-1",
+      "name": "Apache Commons Lang",
+      "packageFileName": null,
+      "summary": null,
+      "description": null,
+      "versionInfo": null,
+      "sourceInfo": null,
+      "downloadLocation": "NOASSERTION",
+      "homepage": "http://commons.apache.org/proper/commons-lang/",
+      "originator": null,
+      "supplier": null,
+      "licenseConcluded": {
+        "type": "Single",
+        "identifier": "NOASSERTION",
+        "name": "NOASSERTION"
+      },
+      "licenseDeclared": {
+        "type": "Single",
+        "identifier": "NOASSERTION",
+        "name": "NOASSERTION"
+      },
+      "copyrightText": "NOASSERTION",
+      "licenseComment": null,
+      "checksum": null,
+      "files": [],
+      "licenseInfoFromFiles": [],
+      "verificationCode": {
+        "value": null,
+        "excludedFilesNames": []
+      }
+    },
+    {
+      "id": "SPDXRef-fromDoap-0",
+      "name": "Jena",
+      "packageFileName": null,
+      "summary": null,
+      "description": null,
+      "versionInfo": "3.12.0",
+      "sourceInfo": null,
+      "downloadLocation": "https://search.maven.org/remotecontent?filepath=org/apache/jena/apache-jena/3.12.0/apache-jena-3.12.0.tar.gz",
+      "homepage": "http://www.openjena.org/",
+      "originator": null,
+      "supplier": null,
+      "licenseConcluded": {
+        "type": "Single",
+        "identifier": "NOASSERTION",
+        "name": "NOASSERTION"
+      },
+      "licenseDeclared": {
+        "type": "Single",
+        "identifier": "NOASSERTION",
+        "name": "NOASSERTION"
+      },
+      "copyrightText": "NOASSERTION",
+      "licenseComment": null,
+      "checksum": null,
+      "files": [],
+      "licenseInfoFromFiles": [],
+      "verificationCode": {
+        "value": null,
+        "excludedFilesNames": []
+      }
+    },
+    {
+      "id": "SPDXRef-Saxon",
+      "name": "Saxon",
+      "packageFileName": "saxonB-8.8.zip",
+      "summary": null,
+      "description": "The Saxon package is a collection of tools for processing XML documents.",
+      "versionInfo": "8.8",
+      "sourceInfo": null,
+      "downloadLocation": "https://sourceforge.net/projects/saxon/files/Saxon-B/8.8.0.7/saxonb8-8-0-7j.zip/download",
+      "homepage": "http://saxon.sourceforge.net/",
+      "originator": null,
+      "supplier": null,
+      "licenseConcluded": {
+        "type": "Single",
+        "identifier": "MPL-1.0",
+        "name": "Mozilla Public License 1.0"
+      },
+      "licenseDeclared": {
+        "type": "Single",
+        "identifier": "MPL-1.0",
+        "name": "Mozilla Public License 1.0"
+      },
+      "copyrightText": "Copyright Saxonica Ltd",
+      "licenseComment": "Other versions available for a commercial license",
+      "checksum": null,
+      "files": [],
+      "licenseInfoFromFiles": [],
+      "verificationCode": {
+        "value": null,
+        "excludedFilesNames": []
       }
     }
   ],
   "externalDocumentRefs": [
     {
-      "externalDocumentId": "DocumentRef-spdx-tool-2.1",
-      "spdxDocument": "https://spdx.org/spdxdocs/spdx-tools-v2.1-3F2504E0-4F89-41D3-9A0C-0305E82C3301",
+      "externalDocumentId": "DocumentRef-spdx-tool-1.2",
+      "spdxDocument": "http://spdx.org/spdxdocs/spdx-tools-v1.2-3F2504E0-4F89-41D3-9A0C-0305E82C3301",
       "checksum": {
         "identifier": "SHA1",
         "value": "d6a770ba38583ed4bb4525bd96e50461655d2759"
@@ -229,14 +216,14 @@
     {
       "name": "LicenseRef-1",
       "identifier": "LicenseRef-1",
-      "text": "/*\n * (c) Copyright 2000, 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009 Hewlett-Packard Development Company, LP\n * All rights reserved.\n *\n * Redistribution and use in source and binary forms, with or without\n * modification, are permitted provided that the following conditions\n * are met:\n * 1. Redistributions of source code must retain the above copyright\n *    notice, this list of conditions and the following disclaimer.\n * 2. Redistributions in binary form must reproduce the above copyright\n *    notice, this list of conditions and the following disclaimer in the\n *    documentation and/or other materials provided with the distribution.\n * 3. The name of the author may not be used to endorse or promote products\n *    derived from this software without specific prior written permission.\n *\n * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR\n * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES\n * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.\n * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,\n * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT\n * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,\n * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY\n * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT\n * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF\n * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.\n */",
+      "text": "/*\n * (c) Copyright 2000, 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009 Hewlett-Packard Development Company, LP\n * All rights reserved.\n *\n * Redistribution and use in source and binary forms, with or without\n * modification, are permitted provided that the following conditions\n * are met:\n * 1. Redistributions of source code must retain the above copyright\n *    notice, this list of conditions and the following disclaimer.\n * 2. Redistributions in binary form must reproduce the above copyright\n *    notice, this list of conditions and the following disclaimer in the\n *    documentation and/or other materials provided with the distribution.\n * 3. The name of the author may not be used to endorse or promote products\n *    derived from this software without specific prior written permission.\n *\n * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR\n * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES\n * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.\n * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,\n * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT\n * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,\n * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY\n * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT\n * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF\n * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.\n*/",
       "comment": null,
       "cross_refs": []
     },
     {
       "name": "LicenseRef-2",
       "identifier": "LicenseRef-2",
-      "text": "This package includes the GRDDL parser developed by Hewlett Packard under the following license:\n\u00a9 Copyright 2007 Hewlett-Packard Development Company, LP\n\nRedistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met: \n\nRedistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer. \nRedistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution. \nThe name of the author may not be used to endorse or promote products derived from this software without specific prior written permission. \nTHIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. ",
+      "text": "This package includes the GRDDL parser developed by Hewlett Packard under the following license:\n\ufffd Copyright 2007 Hewlett-Packard Development Company, LP\n\nRedistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met: \n\nRedistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer. \nRedistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution. \nThe name of the author may not be used to endorse or promote products derived from this software without specific prior written permission. \nTHIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.",
       "comment": null,
       "cross_refs": []
     },
@@ -245,36 +232,40 @@
       "identifier": "LicenseRef-3",
       "text": "The CyberNeko Software License, Version 1.0\n\n \n(C) Copyright 2002-2005, Andy Clark.  All rights reserved.\n \nRedistribution and use in source and binary forms, with or without\nmodification, are permitted provided that the following conditions\nare met:\n\n1. Redistributions of source code must retain the above copyright\n   notice, this list of conditions and the following disclaimer. \n\n2. Redistributions in binary form must reproduce the above copyright\n   notice, this list of conditions and the following disclaimer in\n   the documentation and/or other materials provided with the\n   distribution.\n\n3. The end-user documentation included with the redistribution,\n   if any, must include the following acknowledgment:  \n     \"This product includes software developed by Andy Clark.\"\n   Alternately, this acknowledgment may appear in the software itself,\n   if and wherever such third-party acknowledgments normally appear.\n\n4. The names \"CyberNeko\" and \"NekoHTML\" must not be used to endorse\n   or promote products derived from this software without prior \n   written permission. For written permission, please contact \n   andyc@cyberneko.net.\n\n5. Products derived from this software may not be called \"CyberNeko\",\n   nor may \"CyberNeko\" appear in their name, without prior written\n   permission of the author.\n\nTHIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESSED OR IMPLIED\nWARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES\nOF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE\nDISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR OTHER CONTRIBUTORS\nBE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, \nOR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT \nOF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR \nBUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, \nWHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE \nOR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, \nEVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.",
       "comment": "This is tye CyperNeko License",
-      "cross_refs": [
-        "http://justasample.url.com",
-        "http://people.apache.org/~andyc/neko/LICENSE"
-      ]
+      "cross_refs": []
     },
     {
       "name": "LicenseRef-4",
       "identifier": "LicenseRef-4",
-      "text": "/*\n * (c) Copyright 2009 University of Bristol\n * All rights reserved.\n *\n * Redistribution and use in source and binary forms, with or without\n * modification, are permitted provided that the following conditions\n * are met:\n * 1. Redistributions of source code must retain the above copyright\n *    notice, this list of conditions and the following disclaimer.\n * 2. Redistributions in binary form must reproduce the above copyright\n *    notice, this list of conditions and the following disclaimer in the\n *    documentation and/or other materials provided with the distribution.\n * 3. The name of the author may not be used to endorse or promote products\n *    derived from this software without specific prior written permission.\n *\n * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR\n * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES\n * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.\n * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,\n * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT\n * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,\n * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY\n * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT\n * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF\n * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.\n */  ",
+      "text": "/*\n * (c) Copyright 2009 University of Bristol\n * All rights reserved.\n *\n * Redistribution and use in source and binary forms, with or without\n * modification, are permitted provided that the following conditions\n * are met:\n * 1. Redistributions of source code must retain the above copyright\n *    notice, this list of conditions and the following disclaimer.\n * 2. Redistributions in binary form must reproduce the above copyright\n *    notice, this list of conditions and the following disclaimer in the\n *    documentation and/or other materials provided with the distribution.\n * 3. The name of the author may not be used to endorse or promote products\n *    derived from this software without specific prior written permission.\n *\n * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR\n * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES\n * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.\n * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,\n * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT\n * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,\n * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY\n * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT\n * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF\n * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.\n*/",
       "comment": null,
+      "cross_refs": []
+    },
+    {
+      "name": "Beer-Ware License (Version 42)",
+      "identifier": "LicenseRef-Beerware-4.2",
+      "text": "\"THE BEER-WARE LICENSE\" (Revision 42):\nphk@FreeBSD.ORG wrote this file. As long as you retain this notice you\ncan do whatever you want with this stuff. If we meet some day, and you think this stuff is worth it, you can buy me a beer in return Poul-Henning Kamp",
+      "comment": "The beerware license has a couple of other standard variants.",
       "cross_refs": []
     }
   ],
   "annotations": [
     {
-      "id": "SPDXRef-45",
-      "comment": "This is just an example. Some of the non-standard licenses look like they are actually BSD 3 clause licenses",
-      "type": "REVIEW",
+      "id": null,
+      "comment": "Document level annotation",
+      "type": "OTHER",
       "annotator": {
-        "name": "Jim Reviewer",
+        "name": "Jane Doe",
         "email": null,
         "type": "Person"
       },
-      "date": "2012-06-13T00:00:00Z"
-    }
-  ],
-  "reviews": [
+      "date": "2010-01-29T18:30:22Z"
+    },
     {
+      "id": null,
       "comment": "This is just an example.  Some of the non-standard licenses look like they are actually BSD 3 clause licenses",
-      "reviewer": {
+      "type": "REVIEW",
+      "annotator": {
         "name": "Joe Reviewer",
         "email": null,
         "type": "Person"
@@ -282,8 +273,21 @@
       "date": "2010-02-10T00:00:00Z"
     },
     {
+      "id": null,
+      "comment": "Package level annotation",
+      "type": "OTHER",
+      "annotator": {
+        "name": "Package Commenter",
+        "email": null,
+        "type": "Person"
+      },
+      "date": "2011-01-29T18:30:22Z"
+    },
+    {
+      "id": null,
       "comment": "Another example reviewer.",
-      "reviewer": {
+      "type": "REVIEW",
+      "annotator": {
         "name": "Suzanne Reviewer",
         "email": null,
         "type": "Person"
@@ -291,24 +295,25 @@
       "date": "2011-03-13T00:00:00Z"
     }
   ],
+  "reviews": [],
   "snippets": [
     {
       "id": "SPDXRef-Snippet",
       "name": "from linux kernel",
-      "comment": "This snippet was identified as significant and highlighted in this Apache-2.0 file, when a commercial scanner identified it as being derived from file foo.c in package xyz which is licensed under GPL-2.0-or-later.",
+      "comment": "This snippet was identified as significant and highlighted in this Apache-2.0 file, when a commercial scanner identified it as being derived from file foo.c in package xyz which is licensed under GPL-2.0.",
       "copyrightText": "Copyright 2008-2010 John Smith",
       "licenseComments": "The concluded license was taken from package xyz, from which the snippet was copied into the current file. The concluded license information was found in the COPYING.txt file in package xyz.",
       "fileId": "SPDXRef-DoapSource",
       "licenseConcluded": {
         "type": "Single",
-        "identifier": "Apache-2.0",
-        "name": "Apache License 2.0"
+        "identifier": "GPL-2.0-only",
+        "name": "GNU General Public License v2.0 only"
       },
       "licenseInfoFromSnippet": [
         {
           "type": "Single",
-          "identifier": "Apache-2.0",
-          "name": "Apache License 2.0"
+          "identifier": "GPL-2.0-only",
+          "name": "GNU General Public License v2.0 only"
         }
       ]
     }

--- a/tests/data/doc_write/json-simple-multi-package.json
+++ b/tests/data/doc_write/json-simple-multi-package.json
@@ -59,6 +59,39 @@
                         }
                     ]
                 }
+            },
+            {
+                "Package": {
+                    "SPDXID": "SPDXRef-Package3",
+                    "name": "some/path3",
+                    "downloadLocation": "NOASSERTION",
+                    "licenseInfoFromFiles": [
+                        "LGPL-2.1-or-later"
+                    ],
+                    "licenseConcluded": "NOASSERTION",
+                    "licenseDeclared": "NOASSERTION",
+                    "copyrightText": "Some copyright",
+                    "files": [
+                        {
+                            "File": {
+                                "name": "./some/path/tofile",
+                                "SPDXID": "SPDXRef-File",
+                                "checksums": [
+                                    {
+                                        "algorithm": "checksumAlgorithm_sha1",
+                                        "checksumValue": "SOME-SHA1"
+                                    }
+                                ],
+                                "licenseConcluded": "NOASSERTION",
+                                "licenseInfoFromFiles": [
+                                    "LGPL-2.1-or-later"
+                                ],
+                                "copyrightText": "NOASSERTION",
+                                "sha1": "SOME-SHA1"
+                            }
+                        }
+                    ]
+                }
             }
         ]
     }

--- a/tests/data/doc_write/json-simple-multi-package.json
+++ b/tests/data/doc_write/json-simple-multi-package.json
@@ -1,0 +1,65 @@
+{
+    "Document": {
+        "spdxVersion": "SPDX-2.1",
+        "documentNamespace": "https://spdx.org/spdxdocs/spdx-example-444504E0-4F89-41D3-9A0C-0305E82C3301",
+        "creationInfo": {
+            "creators": [
+                "Tool: ScanCode"
+            ],
+            "created": "2021-10-21T17:09:37Z",
+            "licenseListVersion": "3.6"
+        },
+        "dataLicense": "CC0-1.0",
+        "SPDXID": "SPDXRef-DOCUMENT",
+        "name": "Sample_Document-V2.1",
+        "documentDescribes": [
+            {
+                "Package": {
+                    "SPDXID": "SPDXRef-Package1",
+                    "name": "some/path1",
+                    "downloadLocation": "NOASSERTION",
+                    "filesAnalyzed": false,
+                    "licenseConcluded": "NOASSERTION",
+                    "licenseDeclared": "NOASSERTION",
+                    "copyrightText": "Some copyright"
+                }
+            },
+            {
+                "Package": {
+                    "SPDXID": "SPDXRef-Package2",
+                    "name": "some/path2",
+                    "downloadLocation": "NOASSERTION",
+                    "packageVerificationCode": {
+                        "packageVerificationCodeValue": "SOME code"
+                    },
+                    "licenseInfoFromFiles": [
+                        "LGPL-2.1-or-later"
+                    ],
+                    "licenseConcluded": "NOASSERTION",
+                    "licenseDeclared": "NOASSERTION",
+                    "copyrightText": "Some copyright",
+                    "files": [
+                        {
+                            "File": {
+                                "name": "./some/path/tofile",
+                                "SPDXID": "SPDXRef-File",
+                                "checksums": [
+                                    {
+                                        "algorithm": "checksumAlgorithm_sha1",
+                                        "checksumValue": "SOME-SHA1"
+                                    }
+                                ],
+                                "licenseConcluded": "NOASSERTION",
+                                "licenseInfoFromFiles": [
+                                    "LGPL-2.1-or-later"
+                                ],
+                                "copyrightText": "NOASSERTION",
+                                "sha1": "SOME-SHA1"
+                            }
+                        }
+                    ]
+                }
+            }
+        ]
+    }
+}

--- a/tests/data/doc_write/xml-simple-multi-package.xml
+++ b/tests/data/doc_write/xml-simple-multi-package.xml
@@ -1,79 +1,77 @@
 <?xml version="1.0" encoding="utf-8"?>
-<SpdxDocument>
-	<Document>
-		<spdxVersion>SPDX-2.1</spdxVersion>
-		<documentNamespace>https://spdx.org/spdxdocs/spdx-example-444504E0-4F89-41D3-9A0C-0305E82C3301</documentNamespace>
-		<creationInfo>
-			<creators>Tool: ScanCode</creators>
-			<created>2021-10-21T17:02:23Z</created>
-			<licenseListVersion>3.6</licenseListVersion>
-		</creationInfo>
-		<dataLicense>CC0-1.0</dataLicense>
-		<SPDXID>SPDXRef-DOCUMENT</SPDXID>
-		<name>Sample_Document-V2.1</name>
-		<documentDescribes>
-			<Package>
-				<SPDXID>SPDXRef-Package1</SPDXID>
-				<name>some/path1</name>
-				<downloadLocation>NOASSERTION</downloadLocation>
-				<filesAnalyzed>false</filesAnalyzed>
-				<licenseConcluded>NOASSERTION</licenseConcluded>
-				<licenseDeclared>NOASSERTION</licenseDeclared>
-				<copyrightText>Some copyright</copyrightText>
-			</Package>
-		</documentDescribes>
-		<documentDescribes>
-			<Package>
-				<SPDXID>SPDXRef-Package2</SPDXID>
-				<name>some/path2</name>
-				<downloadLocation>NOASSERTION</downloadLocation>
-				<packageVerificationCode>
-					<packageVerificationCodeValue>SOME code</packageVerificationCodeValue>
-				</packageVerificationCode>
-				<licenseInfoFromFiles>LGPL-2.1-or-later</licenseInfoFromFiles>
-				<licenseConcluded>NOASSERTION</licenseConcluded>
-				<licenseDeclared>NOASSERTION</licenseDeclared>
-				<copyrightText>Some copyright</copyrightText>
-				<files>
-					<File>
-						<name>./some/path/tofile</name>
-						<SPDXID>SPDXRef-File</SPDXID>
-						<checksums>
-							<algorithm>checksumAlgorithm_sha1</algorithm>
-							<checksumValue>SOME-SHA1</checksumValue>
-						</checksums>
-						<licenseConcluded>NOASSERTION</licenseConcluded>
-						<licenseInfoFromFiles>LGPL-2.1-or-later</licenseInfoFromFiles>
-						<copyrightText>NOASSERTION</copyrightText>
-						<sha1>SOME-SHA1</sha1>
-					</File>
-				</files>
-			</Package>
-		</documentDescribes>
-		<documentDescribes>
-			<Package>
-				<SPDXID>SPDXRef-Package3</SPDXID>
-				<name>some/path3</name>
-				<downloadLocation>NOASSERTION</downloadLocation>
-				<licenseInfoFromFiles>LGPL-2.1-or-later</licenseInfoFromFiles>
-				<licenseConcluded>NOASSERTION</licenseConcluded>
-				<licenseDeclared>NOASSERTION</licenseDeclared>
-				<copyrightText>Some copyright</copyrightText>
-				<files>
-					<File>
-						<name>./some/path/tofile</name>
-						<SPDXID>SPDXRef-File</SPDXID>
-						<checksums>
-							<algorithm>checksumAlgorithm_sha1</algorithm>
-							<checksumValue>SOME-SHA1</checksumValue>
-						</checksums>
-						<licenseConcluded>NOASSERTION</licenseConcluded>
-						<licenseInfoFromFiles>LGPL-2.1-or-later</licenseInfoFromFiles>
-						<copyrightText>NOASSERTION</copyrightText>
-						<sha1>SOME-SHA1</sha1>
-					</File>
-				</files>
-			</Package>
-		</documentDescribes>
-	</Document>
-</SpdxDocument>
+<Document>
+	<spdxVersion>SPDX-2.1</spdxVersion>
+	<documentNamespace>https://spdx.org/spdxdocs/spdx-example-444504E0-4F89-41D3-9A0C-0305E82C3301</documentNamespace>
+	<creationInfo>
+		<creators>Tool: ScanCode</creators>
+		<created>2021-10-21T17:02:23Z</created>
+		<licenseListVersion>3.6</licenseListVersion>
+	</creationInfo>
+	<dataLicense>CC0-1.0</dataLicense>
+	<SPDXID>SPDXRef-DOCUMENT</SPDXID>
+	<name>Sample_Document-V2.1</name>
+	<documentDescribes>
+		<Package>
+			<SPDXID>SPDXRef-Package1</SPDXID>
+			<name>some/path1</name>
+			<downloadLocation>NOASSERTION</downloadLocation>
+			<filesAnalyzed>false</filesAnalyzed>
+			<licenseConcluded>NOASSERTION</licenseConcluded>
+			<licenseDeclared>NOASSERTION</licenseDeclared>
+			<copyrightText>Some copyright</copyrightText>
+		</Package>
+	</documentDescribes>
+	<documentDescribes>
+		<Package>
+			<SPDXID>SPDXRef-Package2</SPDXID>
+			<name>some/path2</name>
+			<downloadLocation>NOASSERTION</downloadLocation>
+			<packageVerificationCode>
+				<packageVerificationCodeValue>SOME code</packageVerificationCodeValue>
+			</packageVerificationCode>
+			<licenseInfoFromFiles>LGPL-2.1-or-later</licenseInfoFromFiles>
+			<licenseConcluded>NOASSERTION</licenseConcluded>
+			<licenseDeclared>NOASSERTION</licenseDeclared>
+			<copyrightText>Some copyright</copyrightText>
+			<files>
+				<File>
+					<name>./some/path/tofile</name>
+					<SPDXID>SPDXRef-File</SPDXID>
+					<checksums>
+						<algorithm>checksumAlgorithm_sha1</algorithm>
+						<checksumValue>SOME-SHA1</checksumValue>
+					</checksums>
+					<licenseConcluded>NOASSERTION</licenseConcluded>
+					<licenseInfoFromFiles>LGPL-2.1-or-later</licenseInfoFromFiles>
+					<copyrightText>NOASSERTION</copyrightText>
+					<sha1>SOME-SHA1</sha1>
+				</File>
+			</files>
+		</Package>
+	</documentDescribes>
+	<documentDescribes>
+		<Package>
+			<SPDXID>SPDXRef-Package3</SPDXID>
+			<name>some/path3</name>
+			<downloadLocation>NOASSERTION</downloadLocation>
+			<licenseInfoFromFiles>LGPL-2.1-or-later</licenseInfoFromFiles>
+			<licenseConcluded>NOASSERTION</licenseConcluded>
+			<licenseDeclared>NOASSERTION</licenseDeclared>
+			<copyrightText>Some copyright</copyrightText>
+			<files>
+				<File>
+					<name>./some/path/tofile</name>
+					<SPDXID>SPDXRef-File</SPDXID>
+					<checksums>
+						<algorithm>checksumAlgorithm_sha1</algorithm>
+						<checksumValue>SOME-SHA1</checksumValue>
+					</checksums>
+					<licenseConcluded>NOASSERTION</licenseConcluded>
+					<licenseInfoFromFiles>LGPL-2.1-or-later</licenseInfoFromFiles>
+					<copyrightText>NOASSERTION</copyrightText>
+					<sha1>SOME-SHA1</sha1>
+				</File>
+			</files>
+		</Package>
+	</documentDescribes>
+</Document>

--- a/tests/data/doc_write/xml-simple-multi-package.xml
+++ b/tests/data/doc_write/xml-simple-multi-package.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="utf-8"?>
+<SpdxDocument>
+	<Document>
+		<spdxVersion>SPDX-2.1</spdxVersion>
+		<documentNamespace>https://spdx.org/spdxdocs/spdx-example-444504E0-4F89-41D3-9A0C-0305E82C3301</documentNamespace>
+		<creationInfo>
+			<creators>Tool: ScanCode</creators>
+			<created>2021-10-21T17:02:23Z</created>
+			<licenseListVersion>3.6</licenseListVersion>
+		</creationInfo>
+		<dataLicense>CC0-1.0</dataLicense>
+		<SPDXID>SPDXRef-DOCUMENT</SPDXID>
+		<name>Sample_Document-V2.1</name>
+		<documentDescribes>
+			<Package>
+				<SPDXID>SPDXRef-Package1</SPDXID>
+				<name>some/path1</name>
+				<downloadLocation>NOASSERTION</downloadLocation>
+				<filesAnalyzed>false</filesAnalyzed>
+				<licenseConcluded>NOASSERTION</licenseConcluded>
+				<licenseDeclared>NOASSERTION</licenseDeclared>
+				<copyrightText>Some copyright</copyrightText>
+			</Package>
+		</documentDescribes>
+		<documentDescribes>
+			<Package>
+				<SPDXID>SPDXRef-Package2</SPDXID>
+				<name>some/path2</name>
+				<downloadLocation>NOASSERTION</downloadLocation>
+				<packageVerificationCode>
+					<packageVerificationCodeValue>SOME code</packageVerificationCodeValue>
+				</packageVerificationCode>
+				<licenseInfoFromFiles>LGPL-2.1-or-later</licenseInfoFromFiles>
+				<licenseConcluded>NOASSERTION</licenseConcluded>
+				<licenseDeclared>NOASSERTION</licenseDeclared>
+				<copyrightText>Some copyright</copyrightText>
+				<files>
+					<File>
+						<name>./some/path/tofile</name>
+						<SPDXID>SPDXRef-File</SPDXID>
+						<checksums>
+							<algorithm>checksumAlgorithm_sha1</algorithm>
+							<checksumValue>SOME-SHA1</checksumValue>
+						</checksums>
+						<licenseConcluded>NOASSERTION</licenseConcluded>
+						<licenseInfoFromFiles>LGPL-2.1-or-later</licenseInfoFromFiles>
+						<copyrightText>NOASSERTION</copyrightText>
+						<sha1>SOME-SHA1</sha1>
+					</File>
+				</files>
+			</Package>
+		</documentDescribes>
+	</Document>
+</SpdxDocument>

--- a/tests/data/doc_write/xml-simple-multi-package.xml
+++ b/tests/data/doc_write/xml-simple-multi-package.xml
@@ -50,5 +50,30 @@
 				</files>
 			</Package>
 		</documentDescribes>
+		<documentDescribes>
+			<Package>
+				<SPDXID>SPDXRef-Package3</SPDXID>
+				<name>some/path3</name>
+				<downloadLocation>NOASSERTION</downloadLocation>
+				<licenseInfoFromFiles>LGPL-2.1-or-later</licenseInfoFromFiles>
+				<licenseConcluded>NOASSERTION</licenseConcluded>
+				<licenseDeclared>NOASSERTION</licenseDeclared>
+				<copyrightText>Some copyright</copyrightText>
+				<files>
+					<File>
+						<name>./some/path/tofile</name>
+						<SPDXID>SPDXRef-File</SPDXID>
+						<checksums>
+							<algorithm>checksumAlgorithm_sha1</algorithm>
+							<checksumValue>SOME-SHA1</checksumValue>
+						</checksums>
+						<licenseConcluded>NOASSERTION</licenseConcluded>
+						<licenseInfoFromFiles>LGPL-2.1-or-later</licenseInfoFromFiles>
+						<copyrightText>NOASSERTION</copyrightText>
+						<sha1>SOME-SHA1</sha1>
+					</File>
+				</files>
+			</Package>
+		</documentDescribes>
 	</Document>
 </SpdxDocument>

--- a/tests/data/doc_write/xml-simple-plus.xml
+++ b/tests/data/doc_write/xml-simple-plus.xml
@@ -1,43 +1,41 @@
 <?xml version="1.0" encoding="utf-8"?>
-<SpdxDocument>
-	<Document>
-        <spdxVersion>SPDX-2.1</spdxVersion>
-        <dataLicense>CC0-1.0</dataLicense>
-		<name>Sample_Document-V2.1</name>
-		<SPDXID>SPDXRef-DOCUMENT</SPDXID>
-		<documentNamespace>https://spdx.org/spdxdocs/spdx-example-444504E0-4F89-41D3-9A0C-0305E82C3301</documentNamespace>
-        <documentDescribes>
-            <Package>
-				<SPDXID>SPDXRef-Package</SPDXID>
-                <name>some/path</name>
-                <downloadLocation>NOASSERTION</downloadLocation>
-                <copyrightText>Some copyrught</copyrightText>
-                <packageVerificationCode>
-					<packageVerificationCodeValue>SOME code</packageVerificationCodeValue>
-				</packageVerificationCode>
-                <checksums>
-					<checksumValue>SOME-SHA1</checksumValue>
-					<algorithm>checksumAlgorithm_sha1</algorithm>
-				</checksums>
-                <licenseDeclared>NOASSERTION</licenseDeclared>
-                <licenseConcluded>NOASSERTION</licenseConcluded>
-                <files>
-					<File>
-						<name>./some/path/tofile</name>
-						<SPDXID>SPDXRef-File</SPDXID>
-						<checksums>
-							<checksumValue>SOME-SHA1</checksumValue>
-							<algorithm>checksumAlgorithm_sha1</algorithm>
-						</checksums>
-                        <licenseConcluded>NOASSERTION</licenseConcluded>
-                        <copyrightText>NOASSERTION</copyrightText>
-						<licenseInfoFromFiles>LGPL-2.1-or-later</licenseInfoFromFiles>
-						<sha1>SOME-SHA1</sha1>
-					</File>
-				</files>
-                <licenseInfoFromFiles>LGPL-2.1-or-later</licenseInfoFromFiles>
-                <sha1>SOME-SHA1</sha1>
-            </Package>
-        </documentDescribes>
-    </Document>
-</SpdxDocument>
+<Document>
+	<spdxVersion>SPDX-2.1</spdxVersion>
+	<dataLicense>CC0-1.0</dataLicense>
+	<name>Sample_Document-V2.1</name>
+	<SPDXID>SPDXRef-DOCUMENT</SPDXID>
+	<documentNamespace>https://spdx.org/spdxdocs/spdx-example-444504E0-4F89-41D3-9A0C-0305E82C3301</documentNamespace>
+	<documentDescribes>
+		<Package>
+			<SPDXID>SPDXRef-Package</SPDXID>
+			<name>some/path</name>
+			<downloadLocation>NOASSERTION</downloadLocation>
+			<copyrightText>Some copyrught</copyrightText>
+			<packageVerificationCode>
+				<packageVerificationCodeValue>SOME code</packageVerificationCodeValue>
+			</packageVerificationCode>
+			<checksums>
+				<checksumValue>SOME-SHA1</checksumValue>
+				<algorithm>checksumAlgorithm_sha1</algorithm>
+			</checksums>
+			<licenseDeclared>NOASSERTION</licenseDeclared>
+			<licenseConcluded>NOASSERTION</licenseConcluded>
+			<files>
+				<File>
+					<name>./some/path/tofile</name>
+					<SPDXID>SPDXRef-File</SPDXID>
+					<checksums>
+						<checksumValue>SOME-SHA1</checksumValue>
+						<algorithm>checksumAlgorithm_sha1</algorithm>
+					</checksums>
+					<licenseConcluded>NOASSERTION</licenseConcluded>
+					<copyrightText>NOASSERTION</copyrightText>
+					<licenseInfoFromFiles>LGPL-2.1-or-later</licenseInfoFromFiles>
+					<sha1>SOME-SHA1</sha1>
+				</File>
+			</files>
+			<licenseInfoFromFiles>LGPL-2.1-or-later</licenseInfoFromFiles>
+			<sha1>SOME-SHA1</sha1>
+		</Package>
+	</documentDescribes>
+</Document>

--- a/tests/data/doc_write/xml-simple.xml
+++ b/tests/data/doc_write/xml-simple.xml
@@ -1,43 +1,41 @@
 <?xml version="1.0" encoding="utf-8"?>
-<SpdxDocument>
-	<Document>
-        <spdxVersion>SPDX-2.1</spdxVersion>
-        <dataLicense>CC0-1.0</dataLicense>
-		<name>Sample_Document-V2.1</name>
-		<SPDXID>SPDXRef-DOCUMENT</SPDXID>
-		<documentNamespace>https://spdx.org/spdxdocs/spdx-example-444504E0-4F89-41D3-9A0C-0305E82C3301</documentNamespace>
-        <documentDescribes>
-            <Package>
-				<SPDXID>SPDXRef-Package</SPDXID>
-                <name>some/path</name>
-                <downloadLocation>NOASSERTION</downloadLocation>
-                <copyrightText>Some copyrught</copyrightText>
-                <packageVerificationCode>
-					<packageVerificationCodeValue>SOME code</packageVerificationCodeValue>
-				</packageVerificationCode>
-                <checksums>
-					<checksumValue>SOME-SHA1</checksumValue>
-					<algorithm>checksumAlgorithm_sha1</algorithm>
-				</checksums>
-                <licenseDeclared>NOASSERTION</licenseDeclared>
-                <licenseConcluded>NOASSERTION</licenseConcluded>
-                <files>
-					<File>
-						<name>./some/path/tofile</name>
-						<SPDXID>SPDXRef-File</SPDXID>
-						<checksums>
-							<checksumValue>SOME-SHA1</checksumValue>
-							<algorithm>checksumAlgorithm_sha1</algorithm>
-						</checksums>
-                        <licenseConcluded>NOASSERTION</licenseConcluded>
-                        <copyrightText>NOASSERTION</copyrightText>
-						<licenseInfoFromFiles>LGPL-2.1-only</licenseInfoFromFiles>
-						<sha1>SOME-SHA1</sha1>
-					</File>
-				</files>
-                <licenseInfoFromFiles>LGPL-2.1-only</licenseInfoFromFiles>
-                <sha1>SOME-SHA1</sha1>
-            </Package>
-        </documentDescribes>
-    </Document>
-</SpdxDocument>
+<Document>
+	<spdxVersion>SPDX-2.1</spdxVersion>
+	<dataLicense>CC0-1.0</dataLicense>
+	<name>Sample_Document-V2.1</name>
+	<SPDXID>SPDXRef-DOCUMENT</SPDXID>
+	<documentNamespace>https://spdx.org/spdxdocs/spdx-example-444504E0-4F89-41D3-9A0C-0305E82C3301</documentNamespace>
+	<documentDescribes>
+		<Package>
+			<SPDXID>SPDXRef-Package</SPDXID>
+			<name>some/path</name>
+			<downloadLocation>NOASSERTION</downloadLocation>
+			<copyrightText>Some copyrught</copyrightText>
+			<packageVerificationCode>
+				<packageVerificationCodeValue>SOME code</packageVerificationCodeValue>
+			</packageVerificationCode>
+			<checksums>
+				<checksumValue>SOME-SHA1</checksumValue>
+				<algorithm>checksumAlgorithm_sha1</algorithm>
+			</checksums>
+			<licenseDeclared>NOASSERTION</licenseDeclared>
+			<licenseConcluded>NOASSERTION</licenseConcluded>
+			<files>
+				<File>
+					<name>./some/path/tofile</name>
+					<SPDXID>SPDXRef-File</SPDXID>
+					<checksums>
+						<checksumValue>SOME-SHA1</checksumValue>
+						<algorithm>checksumAlgorithm_sha1</algorithm>
+					</checksums>
+					<licenseConcluded>NOASSERTION</licenseConcluded>
+					<copyrightText>NOASSERTION</copyrightText>
+					<licenseInfoFromFiles>LGPL-2.1-only</licenseInfoFromFiles>
+					<sha1>SOME-SHA1</sha1>
+				</File>
+			</files>
+			<licenseInfoFromFiles>LGPL-2.1-only</licenseInfoFromFiles>
+			<sha1>SOME-SHA1</sha1>
+		</Package>
+	</documentDescribes>
+</Document>

--- a/tests/data/doc_write/yaml-simple-multi-package.yaml
+++ b/tests/data/doc_write/yaml-simple-multi-package.yaml
@@ -39,6 +39,27 @@ Document:
       name: some/path2
       packageVerificationCode:
         packageVerificationCodeValue: SOME code
+  - Package:
+      SPDXID: SPDXRef-Package3
+      copyrightText: Some copyright
+      downloadLocation: NOASSERTION
+      files:
+      - File:
+          SPDXID: SPDXRef-File
+          checksums:
+          - algorithm: checksumAlgorithm_sha1
+            checksumValue: SOME-SHA1
+          copyrightText: NOASSERTION
+          licenseConcluded: NOASSERTION
+          licenseInfoFromFiles:
+          - LGPL-2.1-or-later
+          name: ./some/path/tofile
+          sha1: SOME-SHA1
+      licenseConcluded: NOASSERTION
+      licenseDeclared: NOASSERTION
+      licenseInfoFromFiles:
+      - LGPL-2.1-or-later
+      name: some/path3
   documentNamespace: https://spdx.org/spdxdocs/spdx-example-444504E0-4F89-41D3-9A0C-0305E82C3301
   name: Sample_Document-V2.1
   spdxVersion: SPDX-2.1

--- a/tests/data/doc_write/yaml-simple-multi-package.yaml
+++ b/tests/data/doc_write/yaml-simple-multi-package.yaml
@@ -1,0 +1,44 @@
+---
+Document:
+  SPDXID: SPDXRef-DOCUMENT
+  creationInfo:
+    created: '2021-10-21T16:46:56Z'
+    creators:
+    - 'Tool: ScanCode'
+    licenseListVersion: '3.6'
+  dataLicense: CC0-1.0
+  documentDescribes:
+  - Package:
+      SPDXID: SPDXRef-Package1
+      copyrightText: Some copyright
+      downloadLocation: NOASSERTION
+      filesAnalyzed: false
+      licenseConcluded: NOASSERTION
+      licenseDeclared: NOASSERTION
+      name: some/path1
+  - Package:
+      SPDXID: SPDXRef-Package2
+      copyrightText: Some copyright
+      downloadLocation: NOASSERTION
+      files:
+      - File:
+          SPDXID: SPDXRef-File
+          checksums:
+          - algorithm: checksumAlgorithm_sha1
+            checksumValue: SOME-SHA1
+          copyrightText: NOASSERTION
+          licenseConcluded: NOASSERTION
+          licenseInfoFromFiles:
+          - LGPL-2.1-or-later
+          name: ./some/path/tofile
+          sha1: SOME-SHA1
+      licenseConcluded: NOASSERTION
+      licenseDeclared: NOASSERTION
+      licenseInfoFromFiles:
+      - LGPL-2.1-or-later
+      name: some/path2
+      packageVerificationCode:
+        packageVerificationCodeValue: SOME code
+  documentNamespace: https://spdx.org/spdxdocs/spdx-example-444504E0-4F89-41D3-9A0C-0305E82C3301
+  name: Sample_Document-V2.1
+  spdxVersion: SPDX-2.1

--- a/tests/data/formats/SPDXJsonExample.json
+++ b/tests/data/formats/SPDXJsonExample.json
@@ -1,158 +1,273 @@
 {
-    "Document": {
-        "comment": "This is a sample spreadsheet", 
-        "name": "Sample_Document-V2.1", 
-        "documentDescribes": [
-            {
-                "Package": {
-                    "SPDXID": "SPDXRef-Package", 
-                    "originator": "Organization: SPDX", 
-                    "files": [
-                        {
-                            "File": {
-                                "comment": "This file belongs to Jena", 
-                                "licenseInfoFromFiles": [
-                                    "LicenseRef-1"
-                                ], 
-                                "sha1": "3ab4e1c67a2d28fced849ee1bb76e7391b93f125", 
-                                "name": "Jenna-2.6.3/jena-2.6.3-sources.jar", 
-                                "copyrightText": "(c) Copyright 2000, 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009 Hewlett-Packard Development Company, LP", 
-                                "artifactOf" : [ 
-                                    {
-                                        "name" : "Jena",
-                                        "homePage" : "http://www.openjena.org/",
-                                        "projectUri" : "http://subversion.apache.org/doap.rdf"
-                                    } 
-                                ],
-                                "licenseConcluded": "LicenseRef-1", 
-                                "licenseComments": "This license is used by Jena", 
-                                "checksums": [
-                                    {
-                                        "checksumValue": "3ab4e1c67a2d28fced849ee1bb76e7391b93f125", 
-                                        "algorithm": "checksumAlgorithm_sha1"
-                                    }
-                                ], 
-                                "fileTypes": [
-                                    "fileType_archive"
-                                ], 
-                                "SPDXID": "SPDXRef-File1"
-                            }
-                        }, 
-                        {
-                            "File": {
-                                "licenseInfoFromFiles": [
-                                    "Apache-2.0"
-                                ], 
-                                "sha1": "2fd4e1c67a2d28fced849ee1bb76e7391b93eb12", 
-                                "name": "src/org/spdx/parser/DOAPProject.java", 
-                                "copyrightText": "Copyright 2010, 2011 Source Auditor Inc.", 
-                                "licenseConcluded": "Apache-2.0", 
-                                "checksums": [
-                                    {
-                                        "checksumValue": "2fd4e1c67a2d28fced849ee1bb76e7391b93eb12", 
-                                        "algorithm": "checksumAlgorithm_sha1"
-                                    }
-                                ], 
-                                "fileTypes": [
-                                    "fileType_source"
-                                ], 
-                                "SPDXID": "SPDXRef-File2"
-                            }
-                        }
-                    ], 
-                    "licenseInfoFromFiles": [
-                        "Apache-1.0", 
-                        "LicenseRef-3", 
-                        "MPL-1.1", 
-                        "LicenseRef-2", 
-                        "LicenseRef-4", 
-                        "Apache-2.0", 
-                        "LicenseRef-1"
-                    ], 
-                    "sha1": "2fd4e1c67a2d28fced849ee1bb76e7391b93eb12", 
-                    "name": "SPDX Translator", 
-                    "packageFileName": "spdxtranslator-1.0.zip", 
-                    "licenseComments": "The declared license information can be found in the NOTICE file at the root of the archive file", 
-                    "summary": "SPDX Translator utility", 
-                    "sourceInfo": "Version 1.0 of the SPDX Translator application", 
-                    "copyrightText": " Copyright 2010, 2011 Source Auditor Inc.", 
-                    "packageVerificationCode": {
-                        "packageVerificationCodeValue": "4e3211c67a2d28fced849ee1bb76e7391b93feba", 
-                        "packageVerificationCodeExcludedFiles": [
-                            "SpdxTranslatorSpdx.rdf", 
-                            "SpdxTranslatorSpdx.txt"
-                        ]
-                    }, 
-                    "licenseConcluded": "(Apache-1.0 AND LicenseRef-2 AND MPL-1.1 AND LicenseRef-3 AND LicenseRef-4 AND Apache-2.0 AND LicenseRef-1)", 
-                    "supplier": "Organization: Linux Foundation", 
-                    "attributionTexts" : [ "The GNU C Library is free software.  See the file COPYING.LIB for copying conditions, and LICENSES for notices about a few contributions that require these additional notices to be distributed.  License copyright years may be listed using range notation, e.g., 1996-2015, indicating that every year in the range, inclusive, is a copyrightable year that would otherwise be listed individually." ],
-                    "checksums": [
-                        {
-                            "checksumValue": "2fd4e1c67a2d28fced849ee1bb76e7391b93eb12", 
-                            "algorithm": "checksumAlgorithm_sha1"
-                        }
-                    ], 
-                    "versionInfo": "Version 0.9.2", 
-                    "licenseDeclared": "(LicenseRef-4 AND LicenseRef-3 AND Apache-2.0 AND LicenseRef-2 AND MPL-1.1 AND LicenseRef-1)", 
-                    "downloadLocation": "http://www.spdx.org/tools", 
-                    "description": "This utility translates and SPDX RDF XML document to a spreadsheet, translates a spreadsheet to an SPDX RDF XML document and translates an SPDX RDFa document to an SPDX RDF XML document."
-                }
-            }
-        ], 
-        "creationInfo": {
-            "comment": "This is an example of an SPDX spreadsheet format", 
-            "creators": [
-                "Tool: SourceAuditor-V1.2", 
-                "Person: Gary O'Neall", 
-                "Organization: Source Auditor Inc."
-            ], 
-            "licenseListVersion": "3.6", 
-            "created": "2010-02-03T00:00:00Z"
-        }, 
-        "externalDocumentRefs": [
-            {
-                "checksum": {
-                    "checksumValue": "d6a770ba38583ed4bb4525bd96e50461655d2759", 
-                    "algorithm": "checksumAlgorithm_sha1"
-                }, 
-                "spdxDocument": "https://spdx.org/spdxdocs/spdx-tools-v2.1-3F2504E0-4F89-41D3-9A0C-0305E82C3301", 
-                "externalDocumentId": "DocumentRef-spdx-tool-2.1"
-            }
-        ], 
-        "documentNamespace": "https://spdx.org/spdxdocs/spdx-example-444504E0-4F89-41D3-9A0C-0305E82C3301", 
-        "annotations": [
-            {
-                "comment": "This is just an example. Some of the non-standard licenses look like they are actually BSD 3 clause licenses", 
-                "annotationType": "REVIEW", 
-                "SPDXID": "SPDXRef-45", 
-                "annotationDate": "2012-06-13T00:00:00Z", 
-                "annotator": "Person: Jim Reviewer"
-            }
-        ],
-        "relationships" : [ {
+  "SPDXID" : "SPDXRef-DOCUMENT",
+  "spdxVersion" : "SPDX-2.2",
+  "creationInfo" : {
+    "comment" : "This package has been shipped in source and binary form.\nThe binaries were created with gcc 4.5.1 and expect to link to\ncompatible system run time libraries.",
+    "created" : "2010-01-29T18:30:22Z",
+    "creators" : [ "Tool: LicenseFind-1.0", "Organization: ExampleCodeInspect ()", "Person: Jane Doe ()" ],
+    "licenseListVersion" : "3.9"
+  },
+  "name" : "SPDX-Tools-v2.0",
+  "dataLicense" : "CC0-1.0",
+  "comment" : "This document was created using SPDX 2.0 using licenses from the web site.",
+  "externalDocumentRefs" : [ {
+    "externalDocumentId" : "DocumentRef-spdx-tool-1.2",
+    "checksum" : {
+      "algorithm" : "SHA1",
+      "checksumValue" : "d6a770ba38583ed4bb4525bd96e50461655d2759"
+    },
+    "spdxDocument" : "http://spdx.org/spdxdocs/spdx-tools-v1.2-3F2504E0-4F89-41D3-9A0C-0305E82C3301"
+  } ],
+  "hasExtractedLicensingInfos" : [ {
+    "licenseId" : "LicenseRef-1",
+    "extractedText" : "/*\n * (c) Copyright 2000, 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009 Hewlett-Packard Development Company, LP\n * All rights reserved.\n *\n * Redistribution and use in source and binary forms, with or without\n * modification, are permitted provided that the following conditions\n * are met:\n * 1. Redistributions of source code must retain the above copyright\n *    notice, this list of conditions and the following disclaimer.\n * 2. Redistributions in binary form must reproduce the above copyright\n *    notice, this list of conditions and the following disclaimer in the\n *    documentation and/or other materials provided with the distribution.\n * 3. The name of the author may not be used to endorse or promote products\n *    derived from this software without specific prior written permission.\n *\n * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR\n * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES\n * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.\n * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,\n * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT\n * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,\n * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY\n * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT\n * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF\n * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.\n*/"
+  }, {
+    "licenseId" : "LicenseRef-2",
+    "extractedText" : "This package includes the GRDDL parser developed by Hewlett Packard under the following license:\n� Copyright 2007 Hewlett-Packard Development Company, LP\n\nRedistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met: \n\nRedistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer. \nRedistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution. \nThe name of the author may not be used to endorse or promote products derived from this software without specific prior written permission. \nTHIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE."
+  }, {
+    "licenseId" : "LicenseRef-4",
+    "extractedText" : "/*\n * (c) Copyright 2009 University of Bristol\n * All rights reserved.\n *\n * Redistribution and use in source and binary forms, with or without\n * modification, are permitted provided that the following conditions\n * are met:\n * 1. Redistributions of source code must retain the above copyright\n *    notice, this list of conditions and the following disclaimer.\n * 2. Redistributions in binary form must reproduce the above copyright\n *    notice, this list of conditions and the following disclaimer in the\n *    documentation and/or other materials provided with the distribution.\n * 3. The name of the author may not be used to endorse or promote products\n *    derived from this software without specific prior written permission.\n *\n * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR\n * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES\n * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.\n * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,\n * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT\n * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,\n * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY\n * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT\n * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF\n * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.\n*/"
+  }, {
+    "licenseId" : "LicenseRef-Beerware-4.2",
+    "comment" : "The beerware license has a couple of other standard variants.",
+    "extractedText" : "\"THE BEER-WARE LICENSE\" (Revision 42):\nphk@FreeBSD.ORG wrote this file. As long as you retain this notice you\ncan do whatever you want with this stuff. If we meet some day, and you think this stuff is worth it, you can buy me a beer in return Poul-Henning Kamp",
+    "name" : "Beer-Ware License (Version 42)",
+    "seeAlsos" : [ "http://people.freebsd.org/~phk/" ]
+  }, {
+    "licenseId" : "LicenseRef-3",
+    "comment" : "This is tye CyperNeko License",
+    "extractedText" : "The CyberNeko Software License, Version 1.0\n\n \n(C) Copyright 2002-2005, Andy Clark.  All rights reserved.\n \nRedistribution and use in source and binary forms, with or without\nmodification, are permitted provided that the following conditions\nare met:\n\n1. Redistributions of source code must retain the above copyright\n   notice, this list of conditions and the following disclaimer. \n\n2. Redistributions in binary form must reproduce the above copyright\n   notice, this list of conditions and the following disclaimer in\n   the documentation and/or other materials provided with the\n   distribution.\n\n3. The end-user documentation included with the redistribution,\n   if any, must include the following acknowledgment:  \n     \"This product includes software developed by Andy Clark.\"\n   Alternately, this acknowledgment may appear in the software itself,\n   if and wherever such third-party acknowledgments normally appear.\n\n4. The names \"CyberNeko\" and \"NekoHTML\" must not be used to endorse\n   or promote products derived from this software without prior \n   written permission. For written permission, please contact \n   andyc@cyberneko.net.\n\n5. Products derived from this software may not be called \"CyberNeko\",\n   nor may \"CyberNeko\" appear in their name, without prior written\n   permission of the author.\n\nTHIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESSED OR IMPLIED\nWARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES\nOF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE\nDISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR OTHER CONTRIBUTORS\nBE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, \nOR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT \nOF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR \nBUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, \nWHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE \nOR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, \nEVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.",
+    "name" : "CyberNeko License",
+    "seeAlsos" : [ "http://people.apache.org/~andyc/neko/LICENSE", "http://justasample.url.com" ]
+  } ],
+  "annotations" : [ {
+    "annotationDate" : "2010-01-29T18:30:22Z",
+    "annotationType" : "OTHER",
+    "annotator" : "Person: Jane Doe ()",
+    "comment" : "Document level annotation"
+  }, {
+    "annotationDate" : "2010-02-10T00:00:00Z",
+    "annotationType" : "REVIEW",
+    "annotator" : "Person: Joe Reviewer",
+    "comment" : "This is just an example.  Some of the non-standard licenses look like they are actually BSD 3 clause licenses"
+  }, {
+    "annotationDate" : "2011-03-13T00:00:00Z",
+    "annotationType" : "REVIEW",
+    "annotator" : "Person: Suzanne Reviewer",
+    "comment" : "Another example reviewer."
+  } ],
+  "documentNamespace" : "http://spdx.org/spdxdocs/spdx-example-444504E0-4F89-41D3-9A0C-0305E82C3301",
+  "documentDescribes" : [ "SPDXRef-File", "SPDXRef-Package" ],
+  "packages" : [ {
+    "SPDXID" : "SPDXRef-Package",
+    "annotations" : [ {
+      "annotationDate" : "2011-01-29T18:30:22Z",
+      "annotationType" : "OTHER",
+      "annotator" : "Person: Package Commenter",
+      "comment" : "Package level annotation"
+    } ],
+    "attributionTexts" : [ "The GNU C Library is free software.  See the file COPYING.LIB for copying conditions, and LICENSES for notices about a few contributions that require these additional notices to be distributed.  License copyright years may be listed using range notation, e.g., 1996-2015, indicating that every year in the range, inclusive, is a copyrightable year that would otherwise be listed individually." ],
+    "checksums" : [ {
+      "algorithm" : "MD5",
+      "checksumValue" : "624c1abb3664f4b35547e7c73864ad24"
+    }, {
+      "algorithm" : "SHA1",
+      "checksumValue" : "85ed0817af83a24ad8da68c2b5094de69833983c"
+    }, {
+      "algorithm" : "SHA256",
+      "checksumValue" : "11b6d3ee554eedf79299905a98f9b9a04e498210b59f15094c916c91d150efcd"
+    } ],
+    "copyrightText" : "Copyright 2008-2010 John Smith",
+    "description" : "The GNU C Library defines functions that are specified by the ISO C standard, as well as additional features specific to POSIX and other derivatives of the Unix operating system, and extensions specific to GNU systems.",
+    "downloadLocation" : "http://ftp.gnu.org/gnu/glibc/glibc-ports-2.15.tar.gz",
+    "externalRefs" : [ {
+      "referenceCategory" : "SECURITY",
+      "referenceLocator" : "cpe:2.3:a:pivotal_software:spring_framework:4.1.0:*:*:*:*:*:*:*",
+      "referenceType" : "cpe23Type"
+    }, {
+      "comment" : "This is the external ref for Acme",
+      "referenceCategory" : "OTHER",
+      "referenceLocator" : "acmecorp/acmenator/4.1.3-alpha",
+      "referenceType" : "http://spdx.org/spdxdocs/spdx-example-444504E0-4F89-41D3-9A0C-0305E82C3301#LocationRef-acmeforge"
+    } ],
+    "filesAnalyzed" : true,
+    "hasFiles" : [ "SPDXRef-CommonsLangSrc", "SPDXRef-JenaLib", "SPDXRef-DoapSource" ],
+    "homepage" : "http://ftp.gnu.org/gnu/glibc",
+    "licenseComments" : "The license for this project changed with the release of version x.y.  The version of the project included here post-dates the license change.",
+    "licenseConcluded" : "(LGPL-2.0-only OR LicenseRef-3)",
+    "licenseDeclared" : "(LGPL-2.0-only AND LicenseRef-3)",
+    "licenseInfoFromFiles" : [ "GPL-2.0-only", "LicenseRef-2", "LicenseRef-1" ],
+    "name" : "glibc",
+    "originator" : "Organization: ExampleCodeInspect (contact@example.com)",
+    "packageFileName" : "glibc-2.11.1.tar.gz",
+    "packageVerificationCode" : {
+      "packageVerificationCodeExcludedFiles" : [ "./package.spdx" ],
+      "packageVerificationCodeValue" : "d6a770ba38583ed4bb4525bd96e50461655d2758"
+    },
+    "sourceInfo" : "uses glibc-2_11-branch from git://sourceware.org/git/glibc.git.",
+    "summary" : "GNU C library.",
+    "supplier" : "Person: Jane Doe (jane.doe@example.com)",
+    "versionInfo" : "2.11.1"
+  }, {
+    "SPDXID" : "SPDXRef-fromDoap-1",
+    "copyrightText" : "NOASSERTION",
+    "downloadLocation" : "NOASSERTION",
+    "filesAnalyzed" : false,
+    "homepage" : "http://commons.apache.org/proper/commons-lang/",
+    "licenseConcluded" : "NOASSERTION",
+    "licenseDeclared" : "NOASSERTION",
+    "name" : "Apache Commons Lang"
+  }, {
+    "SPDXID" : "SPDXRef-fromDoap-0",
+    "copyrightText" : "NOASSERTION",
+    "downloadLocation" : "https://search.maven.org/remotecontent?filepath=org/apache/jena/apache-jena/3.12.0/apache-jena-3.12.0.tar.gz",
+    "externalRefs" : [ {
+      "referenceCategory" : "PACKAGE_MANAGER",
+      "referenceLocator" : "pkg:maven/org.apache.jena/apache-jena@3.12.0",
+      "referenceType" : "purl"
+    } ],
+    "filesAnalyzed" : false,
+    "homepage" : "http://www.openjena.org/",
+    "licenseConcluded" : "NOASSERTION",
+    "licenseDeclared" : "NOASSERTION",
+    "name" : "Jena",
+    "versionInfo" : "3.12.0"
+  }, {
+    "SPDXID" : "SPDXRef-Saxon",
+    "checksums" : [ {
+      "algorithm" : "SHA1",
+      "checksumValue" : "85ed0817af83a24ad8da68c2b5094de69833983c"
+    } ],
+    "copyrightText" : "Copyright Saxonica Ltd",
+    "description" : "The Saxon package is a collection of tools for processing XML documents.",
+    "downloadLocation" : "https://sourceforge.net/projects/saxon/files/Saxon-B/8.8.0.7/saxonb8-8-0-7j.zip/download",
+    "filesAnalyzed" : false,
+    "homepage" : "http://saxon.sourceforge.net/",
+    "licenseComments" : "Other versions available for a commercial license",
+    "licenseConcluded" : "MPL-1.0",
+    "licenseDeclared" : "MPL-1.0",
+    "name" : "Saxon",
+    "packageFileName" : "saxonB-8.8.zip",
+    "versionInfo" : "8.8"
+  } ],
+  "files" : [ {
+    "SPDXID" : "SPDXRef-DoapSource",
+    "checksums" : [ {
+      "algorithm" : "SHA1",
+      "checksumValue" : "2fd4e1c67a2d28fced849ee1bb76e7391b93eb12"
+    } ],
+    "copyrightText" : "Copyright 2010, 2011 Source Auditor Inc.",
+    "fileContributors" : [ "Protecode Inc.", "SPDX Technical Team Members", "Open Logic Inc.", "Source Auditor Inc.", "Black Duck Software In.c" ],
+    "fileName" : "./src/org/spdx/parser/DOAPProject.java",
+    "fileTypes" : [ "SOURCE" ],
+    "licenseConcluded" : "Apache-2.0",
+    "licenseInfoInFiles" : [ "Apache-2.0" ]
+  }, {
+    "SPDXID" : "SPDXRef-CommonsLangSrc",
+    "checksums" : [ {
+      "algorithm" : "SHA1",
+      "checksumValue" : "c2b4e1c67a2d28fced849ee1bb76e7391b93f125"
+    } ],
+    "comment" : "This file is used by Jena",
+    "copyrightText" : "Copyright 2001-2011 The Apache Software Foundation",
+    "fileContributors" : [ "Apache Software Foundation" ],
+    "fileName" : "./lib-source/commons-lang3-3.1-sources.jar",
+    "fileTypes" : [ "ARCHIVE" ],
+    "licenseConcluded" : "Apache-2.0",
+    "licenseInfoInFiles" : [ "Apache-2.0" ],
+    "noticeText" : "Apache Commons Lang\nCopyright 2001-2011 The Apache Software Foundation\n\nThis product includes software developed by\nThe Apache Software Foundation (http://www.apache.org/).\n\nThis product includes software from the Spring Framework,\nunder the Apache License 2.0 (see: StringUtils.containsWhitespace())"
+  }, {
+    "SPDXID" : "SPDXRef-JenaLib",
+    "checksums" : [ {
+      "algorithm" : "SHA1",
+      "checksumValue" : "3ab4e1c67a2d28fced849ee1bb76e7391b93f125"
+    } ],
+    "comment" : "This file belongs to Jena",
+    "copyrightText" : "(c) Copyright 2000, 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009 Hewlett-Packard Development Company, LP",
+    "fileContributors" : [ "Apache Software Foundation", "Hewlett Packard Inc." ],
+    "fileName" : "./lib-source/jena-2.6.3-sources.jar",
+    "fileTypes" : [ "ARCHIVE" ],
+    "licenseComments" : "This license is used by Jena",
+    "licenseConcluded" : "LicenseRef-1",
+    "licenseInfoInFiles" : [ "LicenseRef-1" ]
+  }, {
+    "SPDXID" : "SPDXRef-File",
+    "annotations" : [ {
+      "annotationDate" : "2011-01-29T18:30:22Z",
+      "annotationType" : "OTHER",
+      "annotator" : "Person: File Commenter",
+      "comment" : "File level annotation"
+    } ],
+    "checksums" : [ {
+      "algorithm" : "SHA1",
+      "checksumValue" : "d6a770ba38583ed4bb4525bd96e50461655d2758"
+    }, {
+      "algorithm" : "MD5",
+      "checksumValue" : "624c1abb3664f4b35547e7c73864ad24"
+    } ],
+    "comment" : "The concluded license was taken from the package level that the file was included in.\nThis information was found in the COPYING.txt file in the xyz directory.",
+    "copyrightText" : "Copyright 2008-2010 John Smith",
+    "fileContributors" : [ "The Regents of the University of California", "Modified by Paul Mundt lethal@linux-sh.org", "IBM Corporation" ],
+    "fileName" : "./package/foo.c",
+    "fileTypes" : [ "SOURCE" ],
+    "licenseComments" : "The concluded license was taken from the package level that the file was included in.",
+    "licenseConcluded" : "(LGPL-2.0-only OR LicenseRef-2)",
+    "licenseInfoInFiles" : [ "GPL-2.0-only", "LicenseRef-2" ],
+    "noticeText" : "Copyright (c) 2001 Aaron Lehmann aaroni@vitelus.com\n\nPermission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the �Software�), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions: \nThe above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.\n\nTHE SOFTWARE IS PROVIDED �AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE."
+  } ],
+  "snippets" : [ {
+    "SPDXID" : "SPDXRef-Snippet",
+    "comment" : "This snippet was identified as significant and highlighted in this Apache-2.0 file, when a commercial scanner identified it as being derived from file foo.c in package xyz which is licensed under GPL-2.0.",
+    "copyrightText" : "Copyright 2008-2010 John Smith",
+    "licenseComments" : "The concluded license was taken from package xyz, from which the snippet was copied into the current file. The concluded license information was found in the COPYING.txt file in package xyz.",
+    "licenseConcluded" : "GPL-2.0-only",
+    "licenseInfoInSnippets" : [ "GPL-2.0-only" ],
+    "name" : "from linux kernel",
+    "ranges" : [ {
+      "endPointer" : {
+        "offset" : 420,
+        "reference" : "SPDXRef-DoapSource"
+      },
+      "startPointer" : {
+        "offset" : 310,
+        "reference" : "SPDXRef-DoapSource"
+      }
+    }, {
+      "endPointer" : {
+        "lineNumber" : 23,
+        "reference" : "SPDXRef-DoapSource"
+      },
+      "startPointer" : {
+        "lineNumber" : 5,
+        "reference" : "SPDXRef-DoapSource"
+      }
+    } ],
+    "snippetFromFile" : "SPDXRef-DoapSource"
+  } ],
+  "relationships" : [ {
     "spdxElementId" : "SPDXRef-DOCUMENT",
     "relatedSpdxElement" : "SPDXRef-Package",
     "relationshipType" : "CONTAINS"
-  }, {
-    "spdxElementId" : "SPDXRef-DOCUMENT",
-    "relatedSpdxElement" : "SPDXRef-File",
-    "relationshipType" : "DESCRIBES"
   }, {
     "spdxElementId" : "SPDXRef-DOCUMENT",
     "relatedSpdxElement" : "DocumentRef-spdx-tool-1.2:SPDXRef-ToolsElement",
     "relationshipType" : "COPY_OF"
   }, {
     "spdxElementId" : "SPDXRef-DOCUMENT",
+    "relatedSpdxElement" : "SPDXRef-File",
+    "relationshipType" : "DESCRIBES"
+  }, {
+    "spdxElementId" : "SPDXRef-DOCUMENT",
     "relatedSpdxElement" : "SPDXRef-Package",
     "relationshipType" : "DESCRIBES"
   }, {
     "spdxElementId" : "SPDXRef-Package",
-    "relatedSpdxElement" : "SPDXRef-Saxon",
-    "relationshipType" : "DYNAMIC_LINK"
-  }, {
-    "spdxElementId" : "SPDXRef-Package",
     "relatedSpdxElement" : "SPDXRef-JenaLib",
     "relationshipType" : "CONTAINS"
+  }, {
+    "spdxElementId" : "SPDXRef-Package",
+    "relatedSpdxElement" : "SPDXRef-Saxon",
+    "relationshipType" : "DYNAMIC_LINK"
   }, {
     "spdxElementId" : "SPDXRef-CommonsLangSrc",
     "relatedSpdxElement" : "NOASSERTION",
@@ -165,59 +280,5 @@
     "spdxElementId" : "SPDXRef-File",
     "relatedSpdxElement" : "SPDXRef-fromDoap-0",
     "relationshipType" : "GENERATED_FROM"
-  } ], 
-        "dataLicense": "CC0-1.0", 
-        "reviewers": [
-            {
-                "comment": "This is just an example.  Some of the non-standard licenses look like they are actually BSD 3 clause licenses", 
-                "reviewer": "Person: Joe Reviewer", 
-                "reviewDate": "2010-02-10T00:00:00Z"
-            }, 
-            {
-                "comment": "Another example reviewer.", 
-                "reviewer": "Person: Suzanne Reviewer", 
-                "reviewDate": "2011-03-13T00:00:00Z"
-            }
-        ], 
-        "hasExtractedLicensingInfos": [
-            {
-                "extractedText": "This package includes the GRDDL parser developed by Hewlett Packard under the following license:\n\u00a9 Copyright 2007 Hewlett-Packard Development Company, LP\n\nRedistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met: \n\nRedistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer. \nRedistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution. \nThe name of the author may not be used to endorse or promote products derived from this software without specific prior written permission. \nTHIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. ", 
-                "licenseId": "LicenseRef-2"
-            }, 
-            {
-                "extractedText": "The CyberNeko Software License, Version 1.0\n\n \n(C) Copyright 2002-2005, Andy Clark.  All rights reserved.\n \nRedistribution and use in source and binary forms, with or without\nmodification, are permitted provided that the following conditions\nare met:\n\n1. Redistributions of source code must retain the above copyright\n   notice, this list of conditions and the following disclaimer. \n\n2. Redistributions in binary form must reproduce the above copyright\n   notice, this list of conditions and the following disclaimer in\n   the documentation and/or other materials provided with the\n   distribution.\n\n3. The end-user documentation included with the redistribution,\n   if any, must include the following acknowledgment:  \n     \"This product includes software developed by Andy Clark.\"\n   Alternately, this acknowledgment may appear in the software itself,\n   if and wherever such third-party acknowledgments normally appear.\n\n4. The names \"CyberNeko\" and \"NekoHTML\" must not be used to endorse\n   or promote products derived from this software without prior \n   written permission. For written permission, please contact \n   andyc@cyberneko.net.\n\n5. Products derived from this software may not be called \"CyberNeko\",\n   nor may \"CyberNeko\" appear in their name, without prior written\n   permission of the author.\n\nTHIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESSED OR IMPLIED\nWARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES\nOF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE\nDISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR OTHER CONTRIBUTORS\nBE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, \nOR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT \nOF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR \nBUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, \nWHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE \nOR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, \nEVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.", 
-                "comment": "This is tye CyperNeko License", 
-                "licenseId": "LicenseRef-3", 
-                "name": "CyberNeko License", 
-                "seeAlso": [
-                    "http://justasample.url.com", 
-                    "http://people.apache.org/~andyc/neko/LICENSE"
-                ]
-            }, 
-            {
-                "extractedText": "/*\n * (c) Copyright 2009 University of Bristol\n * All rights reserved.\n *\n * Redistribution and use in source and binary forms, with or without\n * modification, are permitted provided that the following conditions\n * are met:\n * 1. Redistributions of source code must retain the above copyright\n *    notice, this list of conditions and the following disclaimer.\n * 2. Redistributions in binary form must reproduce the above copyright\n *    notice, this list of conditions and the following disclaimer in the\n *    documentation and/or other materials provided with the distribution.\n * 3. The name of the author may not be used to endorse or promote products\n *    derived from this software without specific prior written permission.\n *\n * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR\n * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES\n * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.\n * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,\n * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT\n * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,\n * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY\n * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT\n * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF\n * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.\n */  ", 
-                "licenseId": "LicenseRef-4"
-            }, 
-            {
-                "extractedText": "/*\n * (c) Copyright 2000, 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009 Hewlett-Packard Development Company, LP\n * All rights reserved.\n *\n * Redistribution and use in source and binary forms, with or without\n * modification, are permitted provided that the following conditions\n * are met:\n * 1. Redistributions of source code must retain the above copyright\n *    notice, this list of conditions and the following disclaimer.\n * 2. Redistributions in binary form must reproduce the above copyright\n *    notice, this list of conditions and the following disclaimer in the\n *    documentation and/or other materials provided with the distribution.\n * 3. The name of the author may not be used to endorse or promote products\n *    derived from this software without specific prior written permission.\n *\n * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR\n * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES\n * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.\n * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,\n * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT\n * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,\n * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY\n * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT\n * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF\n * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.\n */", 
-                "licenseId": "LicenseRef-1"
-            }
-        ], 
-        "spdxVersion": "SPDX-2.1", 
-        "SPDXID": "SPDXRef-DOCUMENT", 
-        "snippets": [
-            {
-                "comment": "This snippet was identified as significant and highlighted in this Apache-2.0 file, when a commercial scanner identified it as being derived from file foo.c in package xyz which is licensed under GPL-2.0-or-later.", 
-                "name": "from linux kernel", 
-                "copyrightText": "Copyright 2008-2010 John Smith", 
-                "licenseConcluded": "Apache-2.0", 
-                "licenseInfoFromSnippet": [
-                    "Apache-2.0"
-                ], 
-                "licenseComments": "The concluded license was taken from package xyz, from which the snippet was copied into the current file. The concluded license information was found in the COPYING.txt file in package xyz.", 
-                "SPDXID": "SPDXRef-Snippet", 
-                "fileId": "SPDXRef-DoapSource"
-            }
-        ]
-    }
+  } ]
 }

--- a/tests/data/formats/SPDXXmlExample.xml
+++ b/tests/data/formats/SPDXXmlExample.xml
@@ -8,6 +8,7 @@
 				<SPDXID>SPDXRef-Package</SPDXID>
                 <originator>Organization: SPDX</originator>
                                  <attributionTexts>The GNU C Library is free software.  See the file COPYING.LIB for copying conditions, and LICENSES for notices about a few contributions that require these additional notices to be distributed.  License copyright years may be listed using range notation, e.g., 1996-2015, indicating that every year in the range, inclusive, is a copyrightable year that would otherwise be listed individually.</attributionTexts>
+				<filesAnalyzed>true</filesAnalyzed>
 				<files>
 					<File>
 						<licenseInfoFromFiles>Apache-2.0</licenseInfoFromFiles>

--- a/tests/data/formats/SPDXXmlExample.xml
+++ b/tests/data/formats/SPDXXmlExample.xml
@@ -1,120 +1,31 @@
-<?xml version="1.0" encoding="utf-8"?>
-<SpdxDocument>
-	<Document>
-		<comment>This is a sample spreadsheet</comment>
-		<name>Sample_Document-V2.1</name>
-		<documentDescribes>
-			<Package>
-				<SPDXID>SPDXRef-Package</SPDXID>
-                <originator>Organization: SPDX</originator>
-                                 <attributionTexts>The GNU C Library is free software.  See the file COPYING.LIB for copying conditions, and LICENSES for notices about a few contributions that require these additional notices to be distributed.  License copyright years may be listed using range notation, e.g., 1996-2015, indicating that every year in the range, inclusive, is a copyrightable year that would otherwise be listed individually.</attributionTexts>
-				<filesAnalyzed>true</filesAnalyzed>
-				<files>
-					<File>
-						<licenseInfoFromFiles>Apache-2.0</licenseInfoFromFiles>
-						<sha1>2fd4e1c67a2d28fced849ee1bb76e7391b93eb12</sha1>
-						<name>src/org/spdx/parser/DOAPProject.java</name>
-						<copyrightText>Copyright 2010, 2011 Source Auditor Inc.</copyrightText>
-						<licenseConcluded>Apache-2.0</licenseConcluded>
-						<licenseComments></licenseComments>
-						<checksums>
-							<checksumValue>2fd4e1c67a2d28fced849ee1bb76e7391b93eb12</checksumValue>
-							<algorithm>checksumAlgorithm_sha1</algorithm>
-						</checksums>
-						<fileTypes>fileType_source</fileTypes>
-						<SPDXID>SPDXRef-File2</SPDXID>
-					</File>
-				</files>
-				<files>
-					<File>
-						<comment>This file belongs to Jena</comment>
-						<licenseInfoFromFiles>LicenseRef-1</licenseInfoFromFiles>
-						<sha1>3ab4e1c67a2d28fced849ee1bb76e7391b93f125</sha1>
-						<name>Jenna-2.6.3/jena-2.6.3-sources.jar</name>
-						<copyrightText>(c) Copyright 2000, 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009 Hewlett-Packard Development Company, LP</copyrightText>
-						<artifactOf>
-							<name>Jena</name>
-							<homePage>http://www.openjena.org/</homePage>
-							<projectUri>http://subversion.apache.org/doap.rdf</projectUri>
-						</artifactOf>
-						<licenseConcluded>LicenseRef-1</licenseConcluded>
-						<licenseComments>This license is used by Jena</licenseComments>
-						<checksums>
-							<checksumValue>3ab4e1c67a2d28fced849ee1bb76e7391b93f125</checksumValue>
-							<algorithm>checksumAlgorithm_sha1</algorithm>
-						</checksums>
-						<fileTypes>fileType_archive</fileTypes>
-						<SPDXID>SPDXRef-File1</SPDXID>
-					</File>
-				</files>
-				<licenseInfoFromFiles>LicenseRef-3</licenseInfoFromFiles>
-				<licenseInfoFromFiles>LicenseRef-1</licenseInfoFromFiles>
-				<licenseInfoFromFiles>Apache-1.0</licenseInfoFromFiles>
-				<licenseInfoFromFiles>LicenseRef-4</licenseInfoFromFiles>
-				<licenseInfoFromFiles>Apache-2.0</licenseInfoFromFiles>
-				<licenseInfoFromFiles>LicenseRef-2</licenseInfoFromFiles>
-				<licenseInfoFromFiles>MPL-1.1</licenseInfoFromFiles>
-				<sha1>2fd4e1c67a2d28fced849ee1bb76e7391b93eb12</sha1>
-				<name>SPDX Translator</name>
-				<packageFileName>spdxtranslator-1.0.zip</packageFileName>
-				<licenseComments>The declared license information can be found in the NOTICE file at the root of the archive file</licenseComments>
-				<summary>SPDX Translator utility</summary>
-				<sourceInfo>Version 1.0 of the SPDX Translator application</sourceInfo>
-				<copyrightText> Copyright 2010, 2011 Source Auditor Inc.</copyrightText>
-				<packageVerificationCode>
-					<packageVerificationCodeValue>4e3211c67a2d28fced849ee1bb76e7391b93feba</packageVerificationCodeValue>
-					<packageVerificationCodeExcludedFiles>SpdxTranslatorSpdx.rdf</packageVerificationCodeExcludedFiles>
-					<packageVerificationCodeExcludedFiles>SpdxTranslatorSpdx.txt</packageVerificationCodeExcludedFiles>
-				</packageVerificationCode>
-				<licenseConcluded>(LicenseRef-1 AND MPL-1.1 AND LicenseRef-2 AND LicenseRef-3 AND Apache-2.0 AND LicenseRef-4 AND Apache-1.0)</licenseConcluded>
-				<supplier>Organization: Linux Foundation</supplier>
-				<checksums>
-					<checksumValue>2fd4e1c67a2d28fced849ee1bb76e7391b93eb12</checksumValue>
-					<algorithm>checksumAlgorithm_sha1</algorithm>
-				</checksums>
-				<versionInfo>Version 0.9.2</versionInfo>
-				<licenseDeclared>(LicenseRef-3 AND LicenseRef-2 AND Apache-2.0 AND MPL-1.1 AND LicenseRef-1 AND LicenseRef-4)</licenseDeclared>
-				<downloadLocation>http://www.spdx.org/tools</downloadLocation>
-				<description>This utility translates and SPDX RDF XML document to a spreadsheet, translates a spreadsheet to an SPDX RDF XML document and translates an SPDX RDFa document to an SPDX RDF XML document.</description>
-			</Package>
-		</documentDescribes>
-		<creationInfo>
-			<comment>This is an example of an SPDX spreadsheet format</comment>
-			<creators>Tool: SourceAuditor-V1.2</creators>
-			<creators>Person: Gary O'Neall</creators>
-			<creators>Organization: Source Auditor Inc.</creators>
-			<licenseListVersion>3.6</licenseListVersion>
-			<created>2010-02-03T00:00:00Z</created>
-		</creationInfo>
-		<externalDocumentRefs>
-			<checksum>
-				<checksumValue>d6a770ba38583ed4bb4525bd96e50461655d2759</checksumValue>
-				<algorithm>checksumAlgorithm_sha1</algorithm>
-			</checksum>
-			<spdxDocument>https://spdx.org/spdxdocs/spdx-tools-v2.1-3F2504E0-4F89-41D3-9A0C-0305E82C3301</spdxDocument>
-			<externalDocumentId>DocumentRef-spdx-tool-2.1</externalDocumentId>
-		</externalDocumentRefs>
-		<documentNamespace>https://spdx.org/spdxdocs/spdx-example-444504E0-4F89-41D3-9A0C-0305E82C3301</documentNamespace>
-		<annotations>
-			<comment>This is just an example. Some of the non-standard licenses look like they are actually BSD 3 clause licenses</comment>
-			<annotationType>REVIEW</annotationType>
-			<SPDXID>SPDXRef-45</SPDXID>
-			<annotationDate>2012-06-13T00:00:00Z</annotationDate>
-			<annotator>Person: Jim Reviewer</annotator>
-		</annotations>
-		<dataLicense>CC0-1.0</dataLicense>
-		<reviewers>
-			<comment>This is just an example.  Some of the non-standard licenses look like they are actually BSD 3 clause licenses</comment>
-			<reviewer>Person: Joe Reviewer</reviewer>
-			<reviewDate>2010-02-10T00:00:00Z</reviewDate>
-		</reviewers>
-		<reviewers>
-			<comment>Another example reviewer.</comment>
-			<reviewer>Person: Suzanne Reviewer</reviewer>
-			<reviewDate>2011-03-13T00:00:00Z</reviewDate>
-		</reviewers>
-		<hasExtractedLicensingInfos>
-			<extractedText>/*
+<?xml version='1.0' encoding='UTF-8'?>
+<Document>
+  <SPDXID>SPDXRef-DOCUMENT</SPDXID>
+  <spdxVersion>SPDX-2.2</spdxVersion>
+  <creationInfo>
+    <comment>This package has been shipped in source and binary form.
+The binaries were created with gcc 4.5.1 and expect to link to
+compatible system run time libraries.</comment>
+    <created>2010-01-29T18:30:22Z</created>
+    <creators>Tool: LicenseFind-1.0</creators>
+    <creators>Organization: ExampleCodeInspect ()</creators>
+    <creators>Person: Jane Doe ()</creators>
+    <licenseListVersion>3.9</licenseListVersion>
+  </creationInfo>
+  <name>SPDX-Tools-v2.0</name>
+  <dataLicense>CC0-1.0</dataLicense>
+  <comment>This document was created using SPDX 2.0 using licenses from the web site.</comment>
+  <externalDocumentRefs>
+    <externalDocumentId>DocumentRef-spdx-tool-1.2</externalDocumentId>
+    <checksum>
+      <algorithm>SHA1</algorithm>
+      <checksumValue>d6a770ba38583ed4bb4525bd96e50461655d2759</checksumValue>
+    </checksum>
+    <spdxDocument>http://spdx.org/spdxdocs/spdx-tools-v1.2-3F2504E0-4F89-41D3-9A0C-0305E82C3301</spdxDocument>
+  </externalDocumentRefs>
+  <hasExtractedLicensingInfos>
+    <licenseId>LicenseRef-1</licenseId>
+    <extractedText>/*
  * (c) Copyright 2000, 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009 Hewlett-Packard Development Company, LP
  * All rights reserved.
  *
@@ -139,23 +50,62 @@
  * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
  * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */</extractedText>
-			<licenseId>LicenseRef-1</licenseId>
-		</hasExtractedLicensingInfos>
-		<hasExtractedLicensingInfos>
-			<extractedText>This package includes the GRDDL parser developed by Hewlett Packard under the following license:
-© Copyright 2007 Hewlett-Packard Development Company, LP
+*/</extractedText>
+  </hasExtractedLicensingInfos>
+  <hasExtractedLicensingInfos>
+    <licenseId>LicenseRef-2</licenseId>
+    <extractedText>This package includes the GRDDL parser developed by Hewlett Packard under the following license:
+� Copyright 2007 Hewlett-Packard Development Company, LP
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met: 
 
 Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer. 
 Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution. 
 The name of the author may not be used to endorse or promote products derived from this software without specific prior written permission. 
-THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. </extractedText>
-			<licenseId>LicenseRef-2</licenseId>
-		</hasExtractedLicensingInfos>
-		<hasExtractedLicensingInfos>
-			<extractedText>The CyberNeko Software License, Version 1.0
+THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.</extractedText>
+  </hasExtractedLicensingInfos>
+  <hasExtractedLicensingInfos>
+    <licenseId>LicenseRef-4</licenseId>
+    <extractedText>/*
+ * (c) Copyright 2009 University of Bristol
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. The name of the author may not be used to endorse or promote products
+ *    derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/</extractedText>
+  </hasExtractedLicensingInfos>
+  <hasExtractedLicensingInfos>
+    <licenseId>LicenseRef-Beerware-4.2</licenseId>
+    <comment>The beerware license has a couple of other standard variants.</comment>
+    <extractedText>"THE BEER-WARE LICENSE" (Revision 42):
+phk@FreeBSD.ORG wrote this file. As long as you retain this notice you
+can do whatever you want with this stuff. If we meet some day, and you think this stuff is worth it, you can buy me a beer in return Poul-Henning Kamp</extractedText>
+    <name>Beer-Ware License (Version 42)</name>
+    <seeAlsos>http://people.freebsd.org/~phk/</seeAlsos>
+  </hasExtractedLicensingInfos>
+  <hasExtractedLicensingInfos>
+    <licenseId>LicenseRef-3</licenseId>
+    <comment>This is tye CyperNeko License</comment>
+    <extractedText>The CyberNeko Software License, Version 1.0
 
  
 (C) Copyright 2002-2005, Andy Clark.  All rights reserved.
@@ -198,67 +148,296 @@ BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
 WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE 
 OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, 
 EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.</extractedText>
-			<comment>This is tye CyperNeko License</comment>
-			<licenseId>LicenseRef-3</licenseId>
-			<name>CyberNeko License</name>
-			<seeAlso>http://justasample.url.com</seeAlso>
-			<seeAlso>http://people.apache.org/~andyc/neko/LICENSE</seeAlso>
-		</hasExtractedLicensingInfos>
-		<hasExtractedLicensingInfos>
-			<extractedText>/*
- * (c) Copyright 2009 University of Bristol
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in the
- *    documentation and/or other materials provided with the distribution.
- * 3. The name of the author may not be used to endorse or promote products
- *    derived from this software without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
- * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
- * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
- * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
- * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
- * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
- * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
- * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */  </extractedText>
-			<licenseId>LicenseRef-4</licenseId>
-		</hasExtractedLicensingInfos>
-		<spdxVersion>SPDX-2.1</spdxVersion>
-		<SPDXID>SPDXRef-DOCUMENT</SPDXID>
-		<snippets>
-			<comment>This snippet was identified as significant and highlighted in this Apache-2.0 file, when a commercial scanner identified it as being derived from file foo.c in package xyz which is licensed under GPL-2.0-or-later.</comment>
-			<name>from linux kernel</name>
-			<copyrightText>Copyright 2008-2010 John Smith</copyrightText>
-			<licenseConcluded>Apache-2.0</licenseConcluded>
-			<licenseInfoFromSnippet>Apache-2.0</licenseInfoFromSnippet>
-			<licenseComments>The concluded license was taken from package xyz, from which the snippet was copied into the current file. The concluded license information was found in the COPYING.txt file in package xyz.</licenseComments>
-			<SPDXID>SPDXRef-Snippet</SPDXID>
-			<fileId>SPDXRef-DoapSource</fileId>
-		</snippets>
-        <relationships>
-            <spdxElementId>SPDXRef-DOCUMENT</spdxElementId>
-            <relatedSpdxElement>SPDXRef-File</relatedSpdxElement>
-            <relationshipType>DESCRIBES</relationshipType>
-        </relationships>
-        <relationships>
-            <spdxElementId>SPDXRef-DOCUMENT</spdxElementId>
-            <relatedSpdxElement>SPDXRef-Package</relatedSpdxElement>
-            <relationshipType>DESCRIBES</relationshipType>
-        </relationships>
-        <relationships>
-            <spdxElementId>SPDXRef-DOCUMENT</spdxElementId>
-            <relatedSpdxElement>SPDXRef-Package</relatedSpdxElement>
-            <relationshipType>CONTAINS</relationshipType>
-        </relationships>
-	</Document>
-</SpdxDocument>
+    <name>CyberNeko License</name>
+    <seeAlsos>http://people.apache.org/~andyc/neko/LICENSE</seeAlsos>
+    <seeAlsos>http://justasample.url.com</seeAlsos>
+  </hasExtractedLicensingInfos>
+  <annotations>
+    <annotationDate>2010-01-29T18:30:22Z</annotationDate>
+    <annotationType>OTHER</annotationType>
+    <annotator>Person: Jane Doe ()</annotator>
+    <comment>Document level annotation</comment>
+  </annotations>
+  <annotations>
+    <annotationDate>2010-02-10T00:00:00Z</annotationDate>
+    <annotationType>REVIEW</annotationType>
+    <annotator>Person: Joe Reviewer</annotator>
+    <comment>This is just an example.  Some of the non-standard licenses look like they are actually BSD 3 clause licenses</comment>
+  </annotations>
+  <annotations>
+    <annotationDate>2011-03-13T00:00:00Z</annotationDate>
+    <annotationType>REVIEW</annotationType>
+    <annotator>Person: Suzanne Reviewer</annotator>
+    <comment>Another example reviewer.</comment>
+  </annotations>
+  <documentNamespace>http://spdx.org/spdxdocs/spdx-example-444504E0-4F89-41D3-9A0C-0305E82C3301</documentNamespace>
+  <documentDescribes>SPDXRef-File</documentDescribes>
+  <documentDescribes>SPDXRef-Package</documentDescribes>
+  <packages>
+    <SPDXID>SPDXRef-Package</SPDXID>
+    <annotations>
+      <annotationDate>2011-01-29T18:30:22Z</annotationDate>
+      <annotationType>OTHER</annotationType>
+      <annotator>Person: Package Commenter</annotator>
+      <comment>Package level annotation</comment>
+    </annotations>
+    <attributionTexts>The GNU C Library is free software.  See the file COPYING.LIB for copying conditions, and LICENSES for notices about a few contributions that require these additional notices to be distributed.  License copyright years may be listed using range notation, e.g., 1996-2015, indicating that every year in the range, inclusive, is a copyrightable year that would otherwise be listed individually.</attributionTexts>
+    <checksums>
+      <algorithm>MD5</algorithm>
+      <checksumValue>624c1abb3664f4b35547e7c73864ad24</checksumValue>
+    </checksums>
+    <checksums>
+      <algorithm>SHA1</algorithm>
+      <checksumValue>85ed0817af83a24ad8da68c2b5094de69833983c</checksumValue>
+    </checksums>
+    <checksums>
+      <algorithm>SHA256</algorithm>
+      <checksumValue>11b6d3ee554eedf79299905a98f9b9a04e498210b59f15094c916c91d150efcd</checksumValue>
+    </checksums>
+    <copyrightText>Copyright 2008-2010 John Smith</copyrightText>
+    <description>The GNU C Library defines functions that are specified by the ISO C standard, as well as additional features specific to POSIX and other derivatives of the Unix operating system, and extensions specific to GNU systems.</description>
+    <downloadLocation>http://ftp.gnu.org/gnu/glibc/glibc-ports-2.15.tar.gz</downloadLocation>
+    <externalRefs>
+      <referenceCategory>SECURITY</referenceCategory>
+      <referenceLocator>cpe:2.3:a:pivotal_software:spring_framework:4.1.0:*:*:*:*:*:*:*</referenceLocator>
+      <referenceType>cpe23Type</referenceType>
+    </externalRefs>
+    <externalRefs>
+      <comment>This is the external ref for Acme</comment>
+      <referenceCategory>OTHER</referenceCategory>
+      <referenceLocator>acmecorp/acmenator/4.1.3-alpha</referenceLocator>
+      <referenceType>http://spdx.org/spdxdocs/spdx-example-444504E0-4F89-41D3-9A0C-0305E82C3301#LocationRef-acmeforge</referenceType>
+    </externalRefs>
+    <filesAnalyzed>true</filesAnalyzed>
+    <hasFiles>SPDXRef-CommonsLangSrc</hasFiles>
+    <hasFiles>SPDXRef-JenaLib</hasFiles>
+    <hasFiles>SPDXRef-DoapSource</hasFiles>
+    <homepage>http://ftp.gnu.org/gnu/glibc</homepage>
+    <licenseComments>The license for this project changed with the release of version x.y.  The version of the project included here post-dates the license change.</licenseComments>
+    <licenseConcluded>(LGPL-2.0-only OR LicenseRef-3)</licenseConcluded>
+    <licenseDeclared>(LGPL-2.0-only AND LicenseRef-3)</licenseDeclared>
+    <licenseInfoFromFiles>GPL-2.0-only</licenseInfoFromFiles>
+    <licenseInfoFromFiles>LicenseRef-2</licenseInfoFromFiles>
+    <licenseInfoFromFiles>LicenseRef-1</licenseInfoFromFiles>
+    <name>glibc</name>
+    <originator>Organization: ExampleCodeInspect (contact@example.com)</originator>
+    <packageFileName>glibc-2.11.1.tar.gz</packageFileName>
+    <packageVerificationCode>
+      <packageVerificationCodeExcludedFiles>./package.spdx</packageVerificationCodeExcludedFiles>
+      <packageVerificationCodeValue>d6a770ba38583ed4bb4525bd96e50461655d2758</packageVerificationCodeValue>
+    </packageVerificationCode>
+    <sourceInfo>uses glibc-2_11-branch from git://sourceware.org/git/glibc.git.</sourceInfo>
+    <summary>GNU C library.</summary>
+    <supplier>Person: Jane Doe (jane.doe@example.com)</supplier>
+    <versionInfo>2.11.1</versionInfo>
+  </packages>
+  <packages>
+    <SPDXID>SPDXRef-fromDoap-1</SPDXID>
+    <copyrightText>NOASSERTION</copyrightText>
+    <downloadLocation>NOASSERTION</downloadLocation>
+    <filesAnalyzed>false</filesAnalyzed>
+    <homepage>http://commons.apache.org/proper/commons-lang/</homepage>
+    <licenseConcluded>NOASSERTION</licenseConcluded>
+    <licenseDeclared>NOASSERTION</licenseDeclared>
+    <name>Apache Commons Lang</name>
+  </packages>
+  <packages>
+    <SPDXID>SPDXRef-fromDoap-0</SPDXID>
+    <copyrightText>NOASSERTION</copyrightText>
+    <downloadLocation>https://search.maven.org/remotecontent?filepath=org/apache/jena/apache-jena/3.12.0/apache-jena-3.12.0.tar.gz</downloadLocation>
+    <externalRefs>
+      <referenceCategory>PACKAGE_MANAGER</referenceCategory>
+      <referenceLocator>pkg:maven/org.apache.jena/apache-jena@3.12.0</referenceLocator>
+      <referenceType>purl</referenceType>
+    </externalRefs>
+    <filesAnalyzed>false</filesAnalyzed>
+    <homepage>http://www.openjena.org/</homepage>
+    <licenseConcluded>NOASSERTION</licenseConcluded>
+    <licenseDeclared>NOASSERTION</licenseDeclared>
+    <name>Jena</name>
+    <versionInfo>3.12.0</versionInfo>
+  </packages>
+  <packages>
+    <SPDXID>SPDXRef-Saxon</SPDXID>
+    <checksums>
+      <algorithm>SHA1</algorithm>
+      <checksumValue>85ed0817af83a24ad8da68c2b5094de69833983c</checksumValue>
+    </checksums>
+    <copyrightText>Copyright Saxonica Ltd</copyrightText>
+    <description>The Saxon package is a collection of tools for processing XML documents.</description>
+    <downloadLocation>https://sourceforge.net/projects/saxon/files/Saxon-B/8.8.0.7/saxonb8-8-0-7j.zip/download</downloadLocation>
+    <filesAnalyzed>false</filesAnalyzed>
+    <homepage>http://saxon.sourceforge.net/</homepage>
+    <licenseComments>Other versions available for a commercial license</licenseComments>
+    <licenseConcluded>MPL-1.0</licenseConcluded>
+    <licenseDeclared>MPL-1.0</licenseDeclared>
+    <name>Saxon</name>
+    <packageFileName>saxonB-8.8.zip</packageFileName>
+    <versionInfo>8.8</versionInfo>
+  </packages>
+  <files>
+    <SPDXID>SPDXRef-DoapSource</SPDXID>
+    <checksums>
+      <algorithm>SHA1</algorithm>
+      <checksumValue>2fd4e1c67a2d28fced849ee1bb76e7391b93eb12</checksumValue>
+    </checksums>
+    <copyrightText>Copyright 2010, 2011 Source Auditor Inc.</copyrightText>
+    <fileContributors>Protecode Inc.</fileContributors>
+    <fileContributors>SPDX Technical Team Members</fileContributors>
+    <fileContributors>Open Logic Inc.</fileContributors>
+    <fileContributors>Source Auditor Inc.</fileContributors>
+    <fileContributors>Black Duck Software In.c</fileContributors>
+    <fileName>./src/org/spdx/parser/DOAPProject.java</fileName>
+    <fileTypes>SOURCE</fileTypes>
+    <licenseConcluded>Apache-2.0</licenseConcluded>
+    <licenseInfoInFiles>Apache-2.0</licenseInfoInFiles>
+  </files>
+  <files>
+    <SPDXID>SPDXRef-CommonsLangSrc</SPDXID>
+    <checksums>
+      <algorithm>SHA1</algorithm>
+      <checksumValue>c2b4e1c67a2d28fced849ee1bb76e7391b93f125</checksumValue>
+    </checksums>
+    <comment>This file is used by Jena</comment>
+    <copyrightText>Copyright 2001-2011 The Apache Software Foundation</copyrightText>
+    <fileContributors>Apache Software Foundation</fileContributors>
+    <fileName>./lib-source/commons-lang3-3.1-sources.jar</fileName>
+    <fileTypes>ARCHIVE</fileTypes>
+    <licenseConcluded>Apache-2.0</licenseConcluded>
+    <licenseInfoInFiles>Apache-2.0</licenseInfoInFiles>
+    <noticeText>Apache Commons Lang
+Copyright 2001-2011 The Apache Software Foundation
+
+This product includes software developed by
+The Apache Software Foundation (http://www.apache.org/).
+
+This product includes software from the Spring Framework,
+under the Apache License 2.0 (see: StringUtils.containsWhitespace())</noticeText>
+  </files>
+  <files>
+    <SPDXID>SPDXRef-JenaLib</SPDXID>
+    <checksums>
+      <algorithm>SHA1</algorithm>
+      <checksumValue>3ab4e1c67a2d28fced849ee1bb76e7391b93f125</checksumValue>
+    </checksums>
+    <comment>This file belongs to Jena</comment>
+    <copyrightText>(c) Copyright 2000, 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009 Hewlett-Packard Development Company, LP</copyrightText>
+    <fileContributors>Apache Software Foundation</fileContributors>
+    <fileContributors>Hewlett Packard Inc.</fileContributors>
+    <fileName>./lib-source/jena-2.6.3-sources.jar</fileName>
+    <fileTypes>ARCHIVE</fileTypes>
+    <licenseComments>This license is used by Jena</licenseComments>
+    <licenseConcluded>LicenseRef-1</licenseConcluded>
+    <licenseInfoInFiles>LicenseRef-1</licenseInfoInFiles>
+  </files>
+  <files>
+    <SPDXID>SPDXRef-File</SPDXID>
+    <annotations>
+      <annotationDate>2011-01-29T18:30:22Z</annotationDate>
+      <annotationType>OTHER</annotationType>
+      <annotator>Person: File Commenter</annotator>
+      <comment>File level annotation</comment>
+    </annotations>
+    <checksums>
+      <algorithm>SHA1</algorithm>
+      <checksumValue>d6a770ba38583ed4bb4525bd96e50461655d2758</checksumValue>
+    </checksums>
+    <checksums>
+      <algorithm>MD5</algorithm>
+      <checksumValue>624c1abb3664f4b35547e7c73864ad24</checksumValue>
+    </checksums>
+    <comment>The concluded license was taken from the package level that the file was included in.
+This information was found in the COPYING.txt file in the xyz directory.</comment>
+    <copyrightText>Copyright 2008-2010 John Smith</copyrightText>
+    <fileContributors>The Regents of the University of California</fileContributors>
+    <fileContributors>Modified by Paul Mundt lethal@linux-sh.org</fileContributors>
+    <fileContributors>IBM Corporation</fileContributors>
+    <fileName>./package/foo.c</fileName>
+    <fileTypes>SOURCE</fileTypes>
+    <licenseComments>The concluded license was taken from the package level that the file was included in.</licenseComments>
+    <licenseConcluded>(LGPL-2.0-only OR LicenseRef-2)</licenseConcluded>
+    <licenseInfoInFiles>GPL-2.0-only</licenseInfoInFiles>
+    <licenseInfoInFiles>LicenseRef-2</licenseInfoInFiles>
+    <noticeText>Copyright (c) 2001 Aaron Lehmann aaroni@vitelus.com
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the �Software�), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions: 
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED �AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.</noticeText>
+  </files>
+  <snippets>
+    <SPDXID>SPDXRef-Snippet</SPDXID>
+    <comment>This snippet was identified as significant and highlighted in this Apache-2.0 file, when a commercial scanner identified it as being derived from file foo.c in package xyz which is licensed under GPL-2.0.</comment>
+    <copyrightText>Copyright 2008-2010 John Smith</copyrightText>
+    <licenseComments>The concluded license was taken from package xyz, from which the snippet was copied into the current file. The concluded license information was found in the COPYING.txt file in package xyz.</licenseComments>
+    <licenseConcluded>GPL-2.0-only</licenseConcluded>
+    <licenseInfoInSnippets>GPL-2.0-only</licenseInfoInSnippets>
+    <name>from linux kernel</name>
+    <ranges>
+      <endPointer>
+        <offset>420</offset>
+        <reference>SPDXRef-DoapSource</reference>
+      </endPointer>
+      <startPointer>
+        <offset>310</offset>
+        <reference>SPDXRef-DoapSource</reference>
+      </startPointer>
+    </ranges>
+    <ranges>
+      <endPointer>
+        <lineNumber>23</lineNumber>
+        <reference>SPDXRef-DoapSource</reference>
+      </endPointer>
+      <startPointer>
+        <lineNumber>5</lineNumber>
+        <reference>SPDXRef-DoapSource</reference>
+      </startPointer>
+    </ranges>
+    <snippetFromFile>SPDXRef-DoapSource</snippetFromFile>
+  </snippets>
+  <relationships>
+    <spdxElementId>SPDXRef-DOCUMENT</spdxElementId>
+    <relatedSpdxElement>SPDXRef-Package</relatedSpdxElement>
+    <relationshipType>CONTAINS</relationshipType>
+  </relationships>
+  <relationships>
+    <spdxElementId>SPDXRef-DOCUMENT</spdxElementId>
+    <relatedSpdxElement>DocumentRef-spdx-tool-1.2:SPDXRef-ToolsElement</relatedSpdxElement>
+    <relationshipType>COPY_OF</relationshipType>
+  </relationships>
+  <relationships>
+    <spdxElementId>SPDXRef-DOCUMENT</spdxElementId>
+    <relatedSpdxElement>SPDXRef-File</relatedSpdxElement>
+    <relationshipType>DESCRIBES</relationshipType>
+  </relationships>
+  <relationships>
+    <spdxElementId>SPDXRef-DOCUMENT</spdxElementId>
+    <relatedSpdxElement>SPDXRef-Package</relatedSpdxElement>
+    <relationshipType>DESCRIBES</relationshipType>
+  </relationships>
+  <relationships>
+    <spdxElementId>SPDXRef-Package</spdxElementId>
+    <relatedSpdxElement>SPDXRef-JenaLib</relatedSpdxElement>
+    <relationshipType>CONTAINS</relationshipType>
+  </relationships>
+  <relationships>
+    <spdxElementId>SPDXRef-Package</spdxElementId>
+    <relatedSpdxElement>SPDXRef-Saxon</relatedSpdxElement>
+    <relationshipType>DYNAMIC_LINK</relationshipType>
+  </relationships>
+  <relationships>
+    <spdxElementId>SPDXRef-CommonsLangSrc</spdxElementId>
+    <relatedSpdxElement>NOASSERTION</relatedSpdxElement>
+    <relationshipType>GENERATED_FROM</relationshipType>
+  </relationships>
+  <relationships>
+    <spdxElementId>SPDXRef-JenaLib</spdxElementId>
+    <relatedSpdxElement>SPDXRef-Package</relatedSpdxElement>
+    <relationshipType>CONTAINS</relationshipType>
+  </relationships>
+  <relationships>
+    <spdxElementId>SPDXRef-File</spdxElementId>
+    <relatedSpdxElement>SPDXRef-fromDoap-0</relatedSpdxElement>
+    <relationshipType>GENERATED_FROM</relationshipType>
+  </relationships>
+</Document>

--- a/tests/data/formats/SPDXYamlExample.yaml
+++ b/tests/data/formats/SPDXYamlExample.yaml
@@ -1,237 +1,390 @@
 ---
-Document:
+SPDXID: "SPDXRef-DOCUMENT"
+spdxVersion: "SPDX-2.2"
+creationInfo:
+  comment: "This package has been shipped in source and binary form.\nThe binaries\
+    \ were created with gcc 4.5.1 and expect to link to\ncompatible system run time\
+    \ libraries."
+  created: "2010-01-29T18:30:22Z"
+  creators:
+  - "Tool: LicenseFind-1.0"
+  - "Organization: ExampleCodeInspect ()"
+  - "Person: Jane Doe ()"
+  licenseListVersion: "3.9"
+name: "SPDX-Tools-v2.0"
+dataLicense: "CC0-1.0"
+comment: "This document was created using SPDX 2.0 using licenses from the web site."
+externalDocumentRefs:
+- externalDocumentId: "DocumentRef-spdx-tool-1.2"
+  checksum:
+    algorithm: "SHA1"
+    checksumValue: "d6a770ba38583ed4bb4525bd96e50461655d2759"
+  spdxDocument: "http://spdx.org/spdxdocs/spdx-tools-v1.2-3F2504E0-4F89-41D3-9A0C-0305E82C3301"
+hasExtractedLicensingInfos:
+- licenseId: "LicenseRef-1"
+  extractedText: "/*\n * (c) Copyright 2000, 2001, 2002, 2003, 2004, 2005, 2006, 2007,\
+    \ 2008, 2009 Hewlett-Packard Development Company, LP\n * All rights reserved.\n\
+    \ *\n * Redistribution and use in source and binary forms, with or without\n *\
+    \ modification, are permitted provided that the following conditions\n * are met:\n\
+    \ * 1. Redistributions of source code must retain the above copyright\n *    notice,\
+    \ this list of conditions and the following disclaimer.\n * 2. Redistributions\
+    \ in binary form must reproduce the above copyright\n *    notice, this list of\
+    \ conditions and the following disclaimer in the\n *    documentation and/or other\
+    \ materials provided with the distribution.\n * 3. The name of the author may\
+    \ not be used to endorse or promote products\n *    derived from this software\
+    \ without specific prior written permission.\n *\n * THIS SOFTWARE IS PROVIDED\
+    \ BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR\n * IMPLIED WARRANTIES, INCLUDING,\
+    \ BUT NOT LIMITED TO, THE IMPLIED WARRANTIES\n * OF MERCHANTABILITY AND FITNESS\
+    \ FOR A PARTICULAR PURPOSE ARE DISCLAIMED.\n * IN NO EVENT SHALL THE AUTHOR BE\
+    \ LIABLE FOR ANY DIRECT, INDIRECT,\n * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL\
+    \ DAMAGES (INCLUDING, BUT\n * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS\
+    \ OR SERVICES; LOSS OF USE,\n * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER\
+    \ CAUSED AND ON ANY\n * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,\
+    \ OR TORT\n * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE\
+    \ USE OF\n * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.\n\
+    */"
+- licenseId: "LicenseRef-2"
+  extractedText: "This package includes the GRDDL parser developed by Hewlett Packard\
+    \ under the following license:\n� Copyright 2007 Hewlett-Packard Development Company,\
+    \ LP\n\nRedistribution and use in source and binary forms, with or without modification,\
+    \ are permitted provided that the following conditions are met: \n\nRedistributions\
+    \ of source code must retain the above copyright notice, this list of conditions\
+    \ and the following disclaimer. \nRedistributions in binary form must reproduce\
+    \ the above copyright notice, this list of conditions and the following disclaimer\
+    \ in the documentation and/or other materials provided with the distribution.\
+    \ \nThe name of the author may not be used to endorse or promote products derived\
+    \ from this software without specific prior written permission. \nTHIS SOFTWARE\
+    \ IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,\
+    \ BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR\
+    \ A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHOR BE LIABLE\
+    \ FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES\
+    \ (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;\
+    \ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND\
+    \ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING\
+    \ NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,\
+    \ EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE."
+- licenseId: "LicenseRef-4"
+  extractedText: "/*\n * (c) Copyright 2009 University of Bristol\n * All rights reserved.\n\
+    \ *\n * Redistribution and use in source and binary forms, with or without\n *\
+    \ modification, are permitted provided that the following conditions\n * are met:\n\
+    \ * 1. Redistributions of source code must retain the above copyright\n *    notice,\
+    \ this list of conditions and the following disclaimer.\n * 2. Redistributions\
+    \ in binary form must reproduce the above copyright\n *    notice, this list of\
+    \ conditions and the following disclaimer in the\n *    documentation and/or other\
+    \ materials provided with the distribution.\n * 3. The name of the author may\
+    \ not be used to endorse or promote products\n *    derived from this software\
+    \ without specific prior written permission.\n *\n * THIS SOFTWARE IS PROVIDED\
+    \ BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR\n * IMPLIED WARRANTIES, INCLUDING,\
+    \ BUT NOT LIMITED TO, THE IMPLIED WARRANTIES\n * OF MERCHANTABILITY AND FITNESS\
+    \ FOR A PARTICULAR PURPOSE ARE DISCLAIMED.\n * IN NO EVENT SHALL THE AUTHOR BE\
+    \ LIABLE FOR ANY DIRECT, INDIRECT,\n * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL\
+    \ DAMAGES (INCLUDING, BUT\n * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS\
+    \ OR SERVICES; LOSS OF USE,\n * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER\
+    \ CAUSED AND ON ANY\n * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,\
+    \ OR TORT\n * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE\
+    \ USE OF\n * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.\n\
+    */"
+- licenseId: "LicenseRef-Beerware-4.2"
+  comment: "The beerware license has a couple of other standard variants."
+  extractedText: "\"THE BEER-WARE LICENSE\" (Revision 42):\nphk@FreeBSD.ORG wrote\
+    \ this file. As long as you retain this notice you\ncan do whatever you want with\
+    \ this stuff. If we meet some day, and you think this stuff is worth it, you can\
+    \ buy me a beer in return Poul-Henning Kamp"
+  name: "Beer-Ware License (Version 42)"
+  seeAlsos:
+  - "http://people.freebsd.org/~phk/"
+- licenseId: "LicenseRef-3"
+  comment: "This is tye CyperNeko License"
+  extractedText: "The CyberNeko Software License, Version 1.0\n\n \n(C) Copyright\
+    \ 2002-2005, Andy Clark.  All rights reserved.\n \nRedistribution and use in source\
+    \ and binary forms, with or without\nmodification, are permitted provided that\
+    \ the following conditions\nare met:\n\n1. Redistributions of source code must\
+    \ retain the above copyright\n   notice, this list of conditions and the following\
+    \ disclaimer. \n\n2. Redistributions in binary form must reproduce the above copyright\n\
+    \   notice, this list of conditions and the following disclaimer in\n   the documentation\
+    \ and/or other materials provided with the\n   distribution.\n\n3. The end-user\
+    \ documentation included with the redistribution,\n   if any, must include the\
+    \ following acknowledgment:  \n     \"This product includes software developed\
+    \ by Andy Clark.\"\n   Alternately, this acknowledgment may appear in the software\
+    \ itself,\n   if and wherever such third-party acknowledgments normally appear.\n\
+    \n4. The names \"CyberNeko\" and \"NekoHTML\" must not be used to endorse\n  \
+    \ or promote products derived from this software without prior \n   written permission.\
+    \ For written permission, please contact \n   andyc@cyberneko.net.\n\n5. Products\
+    \ derived from this software may not be called \"CyberNeko\",\n   nor may \"CyberNeko\"\
+    \ appear in their name, without prior written\n   permission of the author.\n\n\
+    THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESSED OR IMPLIED\nWARRANTIES,\
+    \ INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES\nOF MERCHANTABILITY AND\
+    \ FITNESS FOR A PARTICULAR PURPOSE ARE\nDISCLAIMED.  IN NO EVENT SHALL THE AUTHOR\
+    \ OR OTHER CONTRIBUTORS\nBE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,\
+    \ EXEMPLARY, \nOR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT\
+    \ \nOF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR \nBUSINESS\
+    \ INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, \nWHETHER IN CONTRACT,\
+    \ STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE \nOR OTHERWISE) ARISING IN ANY\
+    \ WAY OUT OF THE USE OF THIS SOFTWARE, \nEVEN IF ADVISED OF THE POSSIBILITY OF\
+    \ SUCH DAMAGE."
+  name: "CyberNeko License"
+  seeAlsos:
+  - "http://people.apache.org/~andyc/neko/LICENSE"
+  - "http://justasample.url.com"
+annotations:
+- annotationDate: "2010-01-29T18:30:22Z"
+  annotationType: "OTHER"
+  annotator: "Person: Jane Doe ()"
+  comment: "Document level annotation"
+- annotationDate: "2010-02-10T00:00:00Z"
+  annotationType: "REVIEW"
+  annotator: "Person: Joe Reviewer"
+  comment: "This is just an example.  Some of the non-standard licenses look like\
+    \ they are actually BSD 3 clause licenses"
+- annotationDate: "2011-03-13T00:00:00Z"
+  annotationType: "REVIEW"
+  annotator: "Person: Suzanne Reviewer"
+  comment: "Another example reviewer."
+documentNamespace: "http://spdx.org/spdxdocs/spdx-example-444504E0-4F89-41D3-9A0C-0305E82C3301"
+documentDescribes:
+- "SPDXRef-File"
+- "SPDXRef-Package"
+packages:
+- SPDXID: "SPDXRef-Package"
   annotations:
-  - annotationDate: '2012-06-13T00:00:00Z'
-    annotationType: REVIEW
-    annotator: 'Person: Jim Reviewer'
-    comment: This is just an example. Some of the non-standard licenses look like
-      they are actually BSD 3 clause licenses
-    SPDXID: SPDXRef-45
-  comment: This is a sample spreadsheet
-  creationInfo:
-    comment: This is an example of an SPDX spreadsheet format
-    created: '2010-02-03T00:00:00Z'
-    creators:
-    - 'Tool: SourceAuditor-V1.2'
-    - 'Organization: Source Auditor Inc.'
-    - 'Person: Gary O''Neall'
-    licenseListVersion: '3.6'
-  dataLicense: CC0-1.0
-  documentDescribes:
-  - Package:
-      SPDXID: SPDXRef-Package
-      checksums:
-      - algorithm: checksumAlgorithm_sha1
-        checksumValue: 2fd4e1c67a2d28fced849ee1bb76e7391b93eb12
-      copyrightText: ' Copyright 2010, 2011 Source Auditor Inc.'
-      description: This utility translates and SPDX RDF XML document to a spreadsheet,
-        translates a spreadsheet to an SPDX RDF XML document and translates an SPDX
-        RDFa document to an SPDX RDF XML document.
-      downloadLocation: http://www.spdx.org/tools
-      attributionTexts:
-      - "The GNU C Library is free software.  See the file COPYING.LIB for copying conditions,\
-        \ and LICENSES for notices about a few contributions that require these additional\
-        \ notices to be distributed.  License copyright years may be listed using range\
-        \ notation, e.g., 1996-2015, indicating that every year in the range, inclusive,\
-        \ is a copyrightable year that would otherwise be listed individually."
-      files:
-      - File:
-          checksums:
-          - algorithm: checksumAlgorithm_sha1
-            checksumValue: 3ab4e1c67a2d28fced849ee1bb76e7391b93f125
-          comment: This file belongs to Jena
-          copyrightText: (c) Copyright 2000, 2001, 2002, 2003, 2004, 2005, 2006, 2007,
-            2008, 2009 Hewlett-Packard Development Company, LP
-          artifactOf:
-            - name: "Jena"
-              homePage: "http://www.openjena.org/"
-              projectUri: "http://subversion.apache.org/doap.rdf"
-          fileTypes:
-          - fileType_archive
-          SPDXID: SPDXRef-File1
-          licenseComments: This license is used by Jena
-          licenseConcluded: LicenseRef-1
-          licenseInfoFromFiles:
-          - LicenseRef-1
-          name: Jenna-2.6.3/jena-2.6.3-sources.jar
-          sha1: 3ab4e1c67a2d28fced849ee1bb76e7391b93f125
-      - File:
-          checksums:
-          - algorithm: checksumAlgorithm_sha1
-            checksumValue: 2fd4e1c67a2d28fced849ee1bb76e7391b93eb12
-          copyrightText: Copyright 2010, 2011 Source Auditor Inc.
-          fileTypes:
-          - fileType_source
-          SPDXID: SPDXRef-File2
-          licenseConcluded: Apache-2.0
-          licenseInfoFromFiles:
-          - Apache-2.0
-          name: src/org/spdx/parser/DOAPProject.java
-          sha1: 2fd4e1c67a2d28fced849ee1bb76e7391b93eb12
-      licenseComments: The declared license information can be found in the NOTICE
-        file at the root of the archive file
-      licenseConcluded: (LicenseRef-3 AND LicenseRef-1 AND MPL-1.1 AND Apache-2.0
-        AND LicenseRef-2 AND Apache-1.0 AND LicenseRef-4)
-      licenseDeclared: (MPL-1.1 AND LicenseRef-4 AND LicenseRef-2 AND LicenseRef-1
-        AND Apache-2.0 AND LicenseRef-3)
-      licenseInfoFromFiles:
-      - Apache-2.0
-      - MPL-1.1
-      - LicenseRef-3
-      - LicenseRef-1
-      - LicenseRef-4
-      - Apache-1.0
-      - LicenseRef-2
-      name: SPDX Translator
-      originator: 'Organization: SPDX'
-      packageFileName: spdxtranslator-1.0.zip
-      packageVerificationCode:
-        packageVerificationCodeExcludedFiles:
-        - SpdxTranslatorSpdx.txt
-        - SpdxTranslatorSpdx.rdf
-        packageVerificationCodeValue: 4e3211c67a2d28fced849ee1bb76e7391b93feba
-      sha1: 2fd4e1c67a2d28fced849ee1bb76e7391b93eb12
-      sourceInfo: Version 1.0 of the SPDX Translator application
-      summary: SPDX Translator utility
-      supplier: 'Organization: Linux Foundation'
-      versionInfo: Version 0.9.2
-  externalDocumentRefs:
-  - checksum:
-      algorithm: checksumAlgorithm_sha1
-      checksumValue: d6a770ba38583ed4bb4525bd96e50461655d2759
-    externalDocumentId: DocumentRef-spdx-tool-2.1
-    spdxDocument: https://spdx.org/spdxdocs/spdx-tools-v2.1-3F2504E0-4F89-41D3-9A0C-0305E82C3301
-  hasExtractedLicensingInfos:
-  - comment: This is tye CyperNeko License
-    extractedText: "The CyberNeko Software License, Version 1.0\n\n \n(C) Copyright\
-      \ 2002-2005, Andy Clark.  All rights reserved.\n \nRedistribution and use in\
-      \ source and binary forms, with or without\nmodification, are permitted provided\
-      \ that the following conditions\nare met:\n\n1. Redistributions of source code\
-      \ must retain the above copyright\n   notice, this list of conditions and the\
-      \ following disclaimer. \n\n2. Redistributions in binary form must reproduce\
-      \ the above copyright\n   notice, this list of conditions and the following\
-      \ disclaimer in\n   the documentation and/or other materials provided with the\n\
-      \   distribution.\n\n3. The end-user documentation included with the redistribution,\n\
-      \   if any, must include the following acknowledgment:  \n     \"This product\
-      \ includes software developed by Andy Clark.\"\n   Alternately, this acknowledgment\
-      \ may appear in the software itself,\n   if and wherever such third-party acknowledgments\
-      \ normally appear.\n\n4. The names \"CyberNeko\" and \"NekoHTML\" must not be\
-      \ used to endorse\n   or promote products derived from this software without\
-      \ prior \n   written permission. For written permission, please contact \n \
-      \  andyc@cyberneko.net.\n\n5. Products derived from this software may not be\
-      \ called \"CyberNeko\",\n   nor may \"CyberNeko\" appear in their name, without\
-      \ prior written\n   permission of the author.\n\nTHIS SOFTWARE IS PROVIDED ``AS\
-      \ IS'' AND ANY EXPRESSED OR IMPLIED\nWARRANTIES, INCLUDING, BUT NOT LIMITED\
-      \ TO, THE IMPLIED WARRANTIES\nOF MERCHANTABILITY AND FITNESS FOR A PARTICULAR\
-      \ PURPOSE ARE\nDISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR OTHER CONTRIBUTORS\n\
-      BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, \nOR CONSEQUENTIAL\
-      \ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT \nOF SUBSTITUTE GOODS\
-      \ OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR \nBUSINESS INTERRUPTION) HOWEVER\
-      \ CAUSED AND ON ANY THEORY OF LIABILITY, \nWHETHER IN CONTRACT, STRICT LIABILITY,\
-      \ OR TORT (INCLUDING NEGLIGENCE \nOR OTHERWISE) ARISING IN ANY WAY OUT OF THE\
-      \ USE OF THIS SOFTWARE, \nEVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE."
-    licenseId: LicenseRef-3
-    name: CyberNeko License
-    seeAlso:
-    - http://justasample.url.com
-    - http://people.apache.org/~andyc/neko/LICENSE
-  - extractedText: "/*\n * (c) Copyright 2000, 2001, 2002, 2003, 2004, 2005, 2006,\
-      \ 2007, 2008, 2009 Hewlett-Packard Development Company, LP\n * All rights reserved.\n\
-      \ *\n * Redistribution and use in source and binary forms, with or without\n\
-      \ * modification, are permitted provided that the following conditions\n * are\
-      \ met:\n * 1. Redistributions of source code must retain the above copyright\n\
-      \ *    notice, this list of conditions and the following disclaimer.\n * 2.\
-      \ Redistributions in binary form must reproduce the above copyright\n *    notice,\
-      \ this list of conditions and the following disclaimer in the\n *    documentation\
-      \ and/or other materials provided with the distribution.\n * 3. The name of\
-      \ the author may not be used to endorse or promote products\n *    derived from\
-      \ this software without specific prior written permission.\n *\n * THIS SOFTWARE\
-      \ IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR\n * IMPLIED WARRANTIES,\
-      \ INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES\n * OF MERCHANTABILITY\
-      \ AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.\n * IN NO EVENT SHALL\
-      \ THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,\n * INCIDENTAL, SPECIAL, EXEMPLARY,\
-      \ OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT\n * NOT LIMITED TO, PROCUREMENT OF\
-      \ SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,\n * DATA, OR PROFITS; OR BUSINESS\
-      \ INTERRUPTION) HOWEVER CAUSED AND ON ANY\n * THEORY OF LIABILITY, WHETHER IN\
-      \ CONTRACT, STRICT LIABILITY, OR TORT\n * (INCLUDING NEGLIGENCE OR OTHERWISE)\
-      \ ARISING IN ANY WAY OUT OF THE USE OF\n * THIS SOFTWARE, EVEN IF ADVISED OF\
-      \ THE POSSIBILITY OF SUCH DAMAGE.\n */"
-    licenseId: LicenseRef-1
-  - extractedText: "This package includes the GRDDL parser developed by Hewlett Packard\
-      \ under the following license:\n\xA9 Copyright 2007 Hewlett-Packard Development\
-      \ Company, LP\n\nRedistribution and use in source and binary forms, with or\
-      \ without modification, are permitted provided that the following conditions\
-      \ are met: \n\nRedistributions of source code must retain the above copyright\
-      \ notice, this list of conditions and the following disclaimer. \nRedistributions\
-      \ in binary form must reproduce the above copyright notice, this list of conditions\
-      \ and the following disclaimer in the documentation and/or other materials provided\
-      \ with the distribution. \nThe name of the author may not be used to endorse\
-      \ or promote products derived from this software without specific prior written\
-      \ permission. \nTHIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS\
-      \ OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES\
-      \ OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN\
-      \ NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,\
-      \ SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,\
-      \ PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;\
-      \ OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER\
-      \ IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)\
-      \ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE\
-      \ POSSIBILITY OF SUCH DAMAGE. "
-    licenseId: LicenseRef-2
-  - extractedText: "/*\n * (c) Copyright 2009 University of Bristol\n * All rights\
-      \ reserved.\n *\n * Redistribution and use in source and binary forms, with\
-      \ or without\n * modification, are permitted provided that the following conditions\n\
-      \ * are met:\n * 1. Redistributions of source code must retain the above copyright\n\
-      \ *    notice, this list of conditions and the following disclaimer.\n * 2.\
-      \ Redistributions in binary form must reproduce the above copyright\n *    notice,\
-      \ this list of conditions and the following disclaimer in the\n *    documentation\
-      \ and/or other materials provided with the distribution.\n * 3. The name of\
-      \ the author may not be used to endorse or promote products\n *    derived from\
-      \ this software without specific prior written permission.\n *\n * THIS SOFTWARE\
-      \ IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR\n * IMPLIED WARRANTIES,\
-      \ INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES\n * OF MERCHANTABILITY\
-      \ AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.\n * IN NO EVENT SHALL\
-      \ THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,\n * INCIDENTAL, SPECIAL, EXEMPLARY,\
-      \ OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT\n * NOT LIMITED TO, PROCUREMENT OF\
-      \ SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,\n * DATA, OR PROFITS; OR BUSINESS\
-      \ INTERRUPTION) HOWEVER CAUSED AND ON ANY\n * THEORY OF LIABILITY, WHETHER IN\
-      \ CONTRACT, STRICT LIABILITY, OR TORT\n * (INCLUDING NEGLIGENCE OR OTHERWISE)\
-      \ ARISING IN ANY WAY OUT OF THE USE OF\n * THIS SOFTWARE, EVEN IF ADVISED OF\
-      \ THE POSSIBILITY OF SUCH DAMAGE.\n */  "
-    licenseId: LicenseRef-4
-  SPDXID: SPDXRef-DOCUMENT
-  name: Sample_Document-V2.1
-  documentNamespace: https://spdx.org/spdxdocs/spdx-example-444504E0-4F89-41D3-9A0C-0305E82C3301
-  relationships:
-  - spdxElementId: "SPDXRef-DOCUMENT"
-    relatedSpdxElement: "SPDXRef-Package"
-    relationshipType: "DESCRIBES"
-  - spdxElementId: "SPDXRef-DOCUMENT"
-    relatedSpdxElement: "SPDXRef-Package"
-    relationshipType: "CONTAINS"
-  - spdxElementId: "SPDXRef-DOCUMENT"
-    relatedSpdxElement: "SPDXRef-File"
-    relationshipType: "DESCRIBES"
-  reviewers:
-  - comment: Another example reviewer.
-    reviewDate: '2011-03-13T00:00:00Z'
-    reviewer: 'Person: Suzanne Reviewer'
-  - comment: This is just an example.  Some of the non-standard licenses look like
-      they are actually BSD 3 clause licenses
-    reviewDate: '2010-02-10T00:00:00Z'
-    reviewer: 'Person: Joe Reviewer'
-  snippets:
-  - comment: This snippet was identified as significant and highlighted in this Apache-2.0
-      file, when a commercial scanner identified it as being derived from file foo.c
-      in package xyz which is licensed under GPL-2.0-or-later.
-    copyrightText: Copyright 2008-2010 John Smith
-    fileId: SPDXRef-DoapSource
-    SPDXID: SPDXRef-Snippet
-    licenseComments: The concluded license was taken from package xyz, from which
-      the snippet was copied into the current file. The concluded license information
-      was found in the COPYING.txt file in package xyz.
-    licenseConcluded: Apache-2.0
-    licenseInfoFromSnippet:
-    - Apache-2.0
-    name: from linux kernel
-  spdxVersion: SPDX-2.1
+  - annotationDate: "2011-01-29T18:30:22Z"
+    annotationType: "OTHER"
+    annotator: "Person: Package Commenter"
+    comment: "Package level annotation"
+  attributionTexts:
+  - "The GNU C Library is free software.  See the file COPYING.LIB for copying conditions,\
+    \ and LICENSES for notices about a few contributions that require these additional\
+    \ notices to be distributed.  License copyright years may be listed using range\
+    \ notation, e.g., 1996-2015, indicating that every year in the range, inclusive,\
+    \ is a copyrightable year that would otherwise be listed individually."
+  checksums:
+  - algorithm: "MD5"
+    checksumValue: "624c1abb3664f4b35547e7c73864ad24"
+  - algorithm: "SHA1"
+    checksumValue: "85ed0817af83a24ad8da68c2b5094de69833983c"
+  - algorithm: "SHA256"
+    checksumValue: "11b6d3ee554eedf79299905a98f9b9a04e498210b59f15094c916c91d150efcd"
+  copyrightText: "Copyright 2008-2010 John Smith"
+  description: "The GNU C Library defines functions that are specified by the ISO\
+    \ C standard, as well as additional features specific to POSIX and other derivatives\
+    \ of the Unix operating system, and extensions specific to GNU systems."
+  downloadLocation: "http://ftp.gnu.org/gnu/glibc/glibc-ports-2.15.tar.gz"
+  externalRefs:
+  - referenceCategory: "SECURITY"
+    referenceLocator: "cpe:2.3:a:pivotal_software:spring_framework:4.1.0:*:*:*:*:*:*:*"
+    referenceType: "cpe23Type"
+  - comment: "This is the external ref for Acme"
+    referenceCategory: "OTHER"
+    referenceLocator: "acmecorp/acmenator/4.1.3-alpha"
+    referenceType: "http://spdx.org/spdxdocs/spdx-example-444504E0-4F89-41D3-9A0C-0305E82C3301#LocationRef-acmeforge"
+  filesAnalyzed: true
+  hasFiles:
+  - "SPDXRef-CommonsLangSrc"
+  - "SPDXRef-JenaLib"
+  - "SPDXRef-DoapSource"
+  homepage: "http://ftp.gnu.org/gnu/glibc"
+  licenseComments: "The license for this project changed with the release of version\
+    \ x.y.  The version of the project included here post-dates the license change."
+  licenseConcluded: "(LGPL-2.0-only OR LicenseRef-3)"
+  licenseDeclared: "(LGPL-2.0-only AND LicenseRef-3)"
+  licenseInfoFromFiles:
+  - "GPL-2.0-only"
+  - "LicenseRef-2"
+  - "LicenseRef-1"
+  name: "glibc"
+  originator: "Organization: ExampleCodeInspect (contact@example.com)"
+  packageFileName: "glibc-2.11.1.tar.gz"
+  packageVerificationCode:
+    packageVerificationCodeExcludedFiles:
+    - "./package.spdx"
+    packageVerificationCodeValue: "d6a770ba38583ed4bb4525bd96e50461655d2758"
+  sourceInfo: "uses glibc-2_11-branch from git://sourceware.org/git/glibc.git."
+  summary: "GNU C library."
+  supplier: "Person: Jane Doe (jane.doe@example.com)"
+  versionInfo: "2.11.1"
+- SPDXID: "SPDXRef-fromDoap-1"
+  copyrightText: "NOASSERTION"
+  downloadLocation: "NOASSERTION"
+  filesAnalyzed: false
+  homepage: "http://commons.apache.org/proper/commons-lang/"
+  licenseConcluded: "NOASSERTION"
+  licenseDeclared: "NOASSERTION"
+  name: "Apache Commons Lang"
+- SPDXID: "SPDXRef-fromDoap-0"
+  copyrightText: "NOASSERTION"
+  downloadLocation: "https://search.maven.org/remotecontent?filepath=org/apache/jena/apache-jena/3.12.0/apache-jena-3.12.0.tar.gz"
+  externalRefs:
+  - referenceCategory: "PACKAGE_MANAGER"
+    referenceLocator: "pkg:maven/org.apache.jena/apache-jena@3.12.0"
+    referenceType: "purl"
+  filesAnalyzed: false
+  homepage: "http://www.openjena.org/"
+  licenseConcluded: "NOASSERTION"
+  licenseDeclared: "NOASSERTION"
+  name: "Jena"
+  versionInfo: "3.12.0"
+- SPDXID: "SPDXRef-Saxon"
+  checksums:
+  - algorithm: "SHA1"
+    checksumValue: "85ed0817af83a24ad8da68c2b5094de69833983c"
+  copyrightText: "Copyright Saxonica Ltd"
+  description: "The Saxon package is a collection of tools for processing XML documents."
+  downloadLocation: "https://sourceforge.net/projects/saxon/files/Saxon-B/8.8.0.7/saxonb8-8-0-7j.zip/download"
+  filesAnalyzed: false
+  homepage: "http://saxon.sourceforge.net/"
+  licenseComments: "Other versions available for a commercial license"
+  licenseConcluded: "MPL-1.0"
+  licenseDeclared: "MPL-1.0"
+  name: "Saxon"
+  packageFileName: "saxonB-8.8.zip"
+  versionInfo: "8.8"
+files:
+- SPDXID: "SPDXRef-DoapSource"
+  checksums:
+  - algorithm: "SHA1"
+    checksumValue: "2fd4e1c67a2d28fced849ee1bb76e7391b93eb12"
+  copyrightText: "Copyright 2010, 2011 Source Auditor Inc."
+  fileContributors:
+  - "Protecode Inc."
+  - "SPDX Technical Team Members"
+  - "Open Logic Inc."
+  - "Source Auditor Inc."
+  - "Black Duck Software In.c"
+  fileName: "./src/org/spdx/parser/DOAPProject.java"
+  fileTypes:
+  - "SOURCE"
+  licenseConcluded: "Apache-2.0"
+  licenseInfoInFiles:
+  - "Apache-2.0"
+- SPDXID: "SPDXRef-CommonsLangSrc"
+  checksums:
+  - algorithm: "SHA1"
+    checksumValue: "c2b4e1c67a2d28fced849ee1bb76e7391b93f125"
+  comment: "This file is used by Jena"
+  copyrightText: "Copyright 2001-2011 The Apache Software Foundation"
+  fileContributors:
+  - "Apache Software Foundation"
+  fileName: "./lib-source/commons-lang3-3.1-sources.jar"
+  fileTypes:
+  - "ARCHIVE"
+  licenseConcluded: "Apache-2.0"
+  licenseInfoInFiles:
+  - "Apache-2.0"
+  noticeText: "Apache Commons Lang\nCopyright 2001-2011 The Apache Software Foundation\n\
+    \nThis product includes software developed by\nThe Apache Software Foundation\
+    \ (http://www.apache.org/).\n\nThis product includes software from the Spring\
+    \ Framework,\nunder the Apache License 2.0 (see: StringUtils.containsWhitespace())"
+- SPDXID: "SPDXRef-JenaLib"
+  checksums:
+  - algorithm: "SHA1"
+    checksumValue: "3ab4e1c67a2d28fced849ee1bb76e7391b93f125"
+  comment: "This file belongs to Jena"
+  copyrightText: "(c) Copyright 2000, 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008,\
+    \ 2009 Hewlett-Packard Development Company, LP"
+  fileContributors:
+  - "Apache Software Foundation"
+  - "Hewlett Packard Inc."
+  fileName: "./lib-source/jena-2.6.3-sources.jar"
+  fileTypes:
+  - "ARCHIVE"
+  licenseComments: "This license is used by Jena"
+  licenseConcluded: "LicenseRef-1"
+  licenseInfoInFiles:
+  - "LicenseRef-1"
+- SPDXID: "SPDXRef-File"
+  annotations:
+  - annotationDate: "2011-01-29T18:30:22Z"
+    annotationType: "OTHER"
+    annotator: "Person: File Commenter"
+    comment: "File level annotation"
+  checksums:
+  - algorithm: "SHA1"
+    checksumValue: "d6a770ba38583ed4bb4525bd96e50461655d2758"
+  - algorithm: "MD5"
+    checksumValue: "624c1abb3664f4b35547e7c73864ad24"
+  comment: "The concluded license was taken from the package level that the file was\
+    \ included in.\nThis information was found in the COPYING.txt file in the xyz\
+    \ directory."
+  copyrightText: "Copyright 2008-2010 John Smith"
+  fileContributors:
+  - "The Regents of the University of California"
+  - "Modified by Paul Mundt lethal@linux-sh.org"
+  - "IBM Corporation"
+  fileName: "./package/foo.c"
+  fileTypes:
+  - "SOURCE"
+  licenseComments: "The concluded license was taken from the package level that the\
+    \ file was included in."
+  licenseConcluded: "(LGPL-2.0-only OR LicenseRef-2)"
+  licenseInfoInFiles:
+  - "GPL-2.0-only"
+  - "LicenseRef-2"
+  noticeText: "Copyright (c) 2001 Aaron Lehmann aaroni@vitelus.com\n\nPermission is\
+    \ hereby granted, free of charge, to any person obtaining a copy of this software\
+    \ and associated documentation files (the �Software�), to deal in the Software\
+    \ without restriction, including without limitation the rights to use, copy, modify,\
+    \ merge, publish, distribute, sublicense, and/or sell copies of the Software,\
+    \ and to permit persons to whom the Software is furnished to do so, subject to\
+    \ the following conditions: \nThe above copyright notice and this permission notice\
+    \ shall be included in all copies or substantial portions of the Software.\n\n\
+    THE SOFTWARE IS PROVIDED �AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,\
+    \ INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR\
+    \ A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE AUTHORS OR\
+    \ COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER\
+    \ IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION\
+    \ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE."
+snippets:
+- SPDXID: "SPDXRef-Snippet"
+  comment: "This snippet was identified as significant and highlighted in this Apache-2.0\
+    \ file, when a commercial scanner identified it as being derived from file foo.c\
+    \ in package xyz which is licensed under GPL-2.0."
+  copyrightText: "Copyright 2008-2010 John Smith"
+  licenseComments: "The concluded license was taken from package xyz, from which the\
+    \ snippet was copied into the current file. The concluded license information\
+    \ was found in the COPYING.txt file in package xyz."
+  licenseConcluded: "GPL-2.0-only"
+  licenseInfoInSnippets:
+  - "GPL-2.0-only"
+  name: "from linux kernel"
+  ranges:
+  - endPointer:
+      offset: 420
+      reference: "SPDXRef-DoapSource"
+    startPointer:
+      offset: 310
+      reference: "SPDXRef-DoapSource"
+  - endPointer:
+      lineNumber: 23
+      reference: "SPDXRef-DoapSource"
+    startPointer:
+      lineNumber: 5
+      reference: "SPDXRef-DoapSource"
+  snippetFromFile: "SPDXRef-DoapSource"
+relationships:
+- spdxElementId: "SPDXRef-DOCUMENT"
+  relatedSpdxElement: "SPDXRef-Package"
+  relationshipType: "CONTAINS"
+- spdxElementId: "SPDXRef-DOCUMENT"
+  relatedSpdxElement: "DocumentRef-spdx-tool-1.2:SPDXRef-ToolsElement"
+  relationshipType: "COPY_OF"
+- spdxElementId: "SPDXRef-DOCUMENT"
+  relatedSpdxElement: "SPDXRef-File"
+  relationshipType: "DESCRIBES"
+- spdxElementId: "SPDXRef-DOCUMENT"
+  relatedSpdxElement: "SPDXRef-Package"
+  relationshipType: "DESCRIBES"
+- spdxElementId: "SPDXRef-Package"
+  relatedSpdxElement: "SPDXRef-JenaLib"
+  relationshipType: "CONTAINS"
+- spdxElementId: "SPDXRef-Package"
+  relatedSpdxElement: "SPDXRef-Saxon"
+  relationshipType: "DYNAMIC_LINK"
+- spdxElementId: "SPDXRef-CommonsLangSrc"
+  relatedSpdxElement: "NOASSERTION"
+  relationshipType: "GENERATED_FROM"
+- spdxElementId: "SPDXRef-JenaLib"
+  relatedSpdxElement: "SPDXRef-Package"
+  relationshipType: "CONTAINS"
+- spdxElementId: "SPDXRef-File"
+  relatedSpdxElement: "SPDXRef-fromDoap-0"
+  relationshipType: "GENERATED_FROM"

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -99,7 +99,6 @@ class TestDocument(TestCase):
             'of spdx.utils.SPDXNone or spdx.utils.NoAssert or spdx.document.License',
             'Sample_Document-V2.1: some/path: Package download_location can not be None.',
             'Sample_Document-V2.1: some/path: Package must have at least one file.',
-            'Sample_Document-V2.1: some/path: Package verif_code can not be None.'
         ]
         assert sorted(expected) == sorted(messages)
 
@@ -218,6 +217,14 @@ class TestWriters(TestCase):
         package2.conc_lics = NoAssert()
         package2.verif_code = 'SOME code'
 
+        # This one does, but per recommendation, we choose to make the
+        # verification code optional in this library
+        package3 = Package(name='some/path3', download_location=NoAssert())
+        package3.spdx_id = 'SPDXRef-Package3'
+        package3.cr_text = 'Some copyright'
+        package3.license_declared = NoAssert()
+        package3.conc_lics = NoAssert()
+
         file1 = File('./some/path/tofile')
         file1.name = './some/path/tofile'
         file1.spdx_id = 'SPDXRef-File'
@@ -233,8 +240,11 @@ class TestWriters(TestCase):
 
         package2.add_lics_from_file(lic1)
         package2.add_file(file1)
+        package3.add_lics_from_file(lic1)
+        package3.add_file(file1)
 
         doc.add_package(package2)
+        doc.add_package(package3)
 
         return doc
 

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -98,7 +98,6 @@ class TestDocument(TestCase):
             'Sample_Document-V2.1: some/path: Package declared license must be instance '
             'of spdx.utils.SPDXNone or spdx.utils.NoAssert or spdx.document.License',
             'Sample_Document-V2.1: some/path: Package download_location can not be None.',
-            'Sample_Document-V2.1: some/path: Package must have at least one file.',
         ]
         assert sorted(expected) == sorted(messages)
 

--- a/tests/test_parse_anything.py
+++ b/tests/test_parse_anything.py
@@ -26,5 +26,5 @@ def test_parse_anything(test_file):
     assert not error
 
     # test a few fields, the core of the tests are per parser
-    assert doc.name in ('Sample_Document-V2.1', 'xyz-0.1.0')
-    assert doc.comment in (None, 'This is a sample spreadsheet', 'Sample Comment')
+    assert doc.name in ('Sample_Document-V2.0', 'Sample_Document-V2.1', 'SPDX-Tools-v2.0', 'xyz-0.1.0')
+    assert doc.comment in (None, 'This is a sample spreadsheet', 'Sample Comment', 'This document was created using SPDX 2.0 using licenses from the web site.')

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -106,7 +106,10 @@ def sort_nested(data):
         new_data = {}
         for k, v in data.items():
             if isinstance(v, list):
-                v = sorted(v)
+                try:
+                    v = sort_nested(v)
+                except TypeError:
+                    pass
             if isinstance(v, dict):
                 v = sort_nested(v)
             new_data[k] = v

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -21,6 +21,7 @@ import re
 
 import xmltodict
 import yaml
+from spdx.utils import NoAssert
 
 import spdx
 from spdx import utils
@@ -237,9 +238,8 @@ def load_and_clean_xml(location):
     with io.open(location, encoding='utf-8') as l:
         content = l.read()
     data = xmltodict.parse(content, encoding='utf-8')
-
-    if 'creationInfo' in data['SpdxDocument']['Document']:
-        del(data['SpdxDocument']['Document']['creationInfo'])
+    if 'creationInfo' in data['Document']:
+        del(data['Document']['creationInfo'])
 
     return sort_nested(data)
 
@@ -276,7 +276,10 @@ class TestParserUtils(object):
             return None
         license_dict = OrderedDict()
 
-        if isinstance(license, spdx.document.LicenseConjunction):
+        if isinstance(license, NoAssert):
+            license_dict['type'] = NoAssert()
+            return license_dict
+        elif isinstance(license, spdx.document.LicenseConjunction):
             license_dict['type'] = 'Conjunction'
             sep_regex = CONJ_SEP
         elif isinstance(license, spdx.document.LicenseDisjunction):


### PR DESCRIPTION
Attempt to address https://github.com/spdx/tools-python/issues/196

TODO:

- Test validator for documentDescribes
- Add documentDescribes to writers

I took the SPDX Example files from [here](https://github.com/spdx/spdx-spec/tree/development/v2.2.2/examples) and tried to update the existing tests to work with them. 

This PR includes the commits from https://github.com/spdx/tools-python/pull/195

I think all the parser issues are fixed now, at least for XML, YAML, and JSON. TagValue, and RDF are harder for me because I'm not familiar with the syntax of those.

There are failing tests in test_conversion.py and test_write_anything.py. I'm almost ready to give up trying to fix the TagValue and RDF writers, because I can't figure out how to fix them, help appreciated!

I haven't look at test_conversion.py yet, but I'm thinking it will be similar. Possible for XML, YAML, and JSON, but harder for TagValue and RDF. 
