### PR TITLE
[tv-parser] fix parsing of annotation type

### DIFF
--- a/spdx/annotation.py
+++ b/spdx/annotation.py
@@ -85,6 +85,8 @@ class Annotation(object):
         self.validate_annotation_type(messages)
         self.validate_spdx_id(messages)
 
+        return messages
+
     def validate_annotator(self, messages):
         if self.annotator is None:
             messages.append("Annotation missing annotator.")

--- a/spdx/parsers/lexers/tagvalue.py
+++ b/spdx/parsers/lexers/tagvalue.py
@@ -103,6 +103,7 @@ class Lexer(object):
         "BINARY": "BINARY",
         "ARCHIVE": "ARCHIVE",
         "OTHER": "OTHER",
+        "REVIEW": "REVIEW"
     }
     states = (("text", "exclusive"),)
 

--- a/spdx/parsers/tagvalue.py
+++ b/spdx/parsers/tagvalue.py
@@ -642,6 +642,13 @@ class Parser(object):
                            | BINARY
         """
         p[0] = p[1]
+
+    def p_annotation_type_value(self, p):
+        """annotation_type_value : OTHER
+                           | REVIEW
+        """
+        p[0] = p[1]
+
     def p_pkg_desc_1(self, p):
         """pkg_desc : PKG_DESC TEXT"""
         try:

--- a/spdx/parsers/tagvalue.py
+++ b/spdx/parsers/tagvalue.py
@@ -1349,7 +1349,7 @@ class Parser(object):
         self.logger.log(msg)
 
     def p_annotation_type_1(self, p):
-        """annotation_type : ANNOTATION_TYPE LINE"""
+        """annotation_type : ANNOTATION_TYPE annotation_type_value"""
         try:
             value = p[2]
             self.builder.add_annotation_type(self.document, value)

--- a/tests/test_tag_value_parser.py
+++ b/tests/test_tag_value_parser.py
@@ -13,11 +13,98 @@ import sys
 from unittest import TestCase
 
 import spdx
+from spdx import utils
 from spdx.parsers.tagvalue import Parser
 from spdx.parsers.lexers.tagvalue import Lexer
 from spdx.parsers.tagvaluebuilders import Builder
 from spdx.parsers.loggers import StandardLogger
 from spdx.version import Version
+
+document_str = '\n'.join([
+        'SPDXVersion: SPDX-2.1',
+        'DataLicense: CC0-1.0',
+        'DocumentName: Sample_Document-V2.1',
+        'SPDXID: SPDXRef-DOCUMENT',
+        'DocumentComment: <text>Sample Comment</text>',
+        'DocumentNamespace: https://spdx.org/spdxdocs/spdx-example-444504E0-4F89-41D3-9A0C-0305E82C3301'
+    ])
+
+creation_str = '\n'.join([
+    'Creator: Person: Bob (bob@example.com)',
+    'Creator: Organization: Acme.',
+    'Created: 2010-02-03T00:00:00Z',
+    'CreatorComment: <text>Sample Comment</text>'
+])
+
+review_str = '\n'.join([
+    'Reviewer: Person: Bob the Reviewer',
+    'ReviewDate: 2010-02-10T00:00:00Z',
+    'ReviewComment: <text>Bob was Here.</text>',
+    'Reviewer: Person: Alice the Reviewer',
+    'ReviewDate: 2011-02-10T00:00:00Z',
+    'ReviewComment: <text>Alice was also here.</text>'
+])
+
+package_str = '\n'.join([
+    'PackageName: Test',
+    'SPDXID: SPDXRef-Package',
+    'PackageVersion: Version 0.9.2',
+    'PackageDownloadLocation: http://example.com/test',
+    'FilesAnalyzed: True',
+    'PackageSummary: <text>Test package</text>',
+    'PackageSourceInfo: <text>Version 1.0 of test</text>',
+    'PackageFileName: test-1.0.zip',
+    'PackageSupplier: Organization:ACME',
+    'PackageOriginator: Organization:ACME',
+    'PackageChecksum: SHA1: 2fd4e1c67a2d28fced849ee1bb76e7391b93eb12',
+    'PackageVerificationCode: 4e3211c67a2d28fced849ee1bb76e7391b93feba (something.rdf, something.txt)',
+    'PackageDescription: <text>A package.</text>',
+    'PackageComment: <text>Comment on the package.</text>',
+    'PackageCopyrightText: <text> Copyright 2014 Acme Inc.</text>',
+    'PackageLicenseDeclared: Apache-2.0',
+    'PackageLicenseConcluded: (LicenseRef-2.0 and Apache-2.0)',
+    'PackageLicenseInfoFromFiles: Apache-1.0',
+    'PackageLicenseInfoFromFiles: Apache-2.0',
+    'PackageLicenseComments: <text>License Comments</text>',
+    'ExternalRef: SECURITY cpe23Type cpe:2.3:a:pivotal_software:spring_framework:4.1.0:*:*:*:*:*:*:',
+    'ExternalRefComment: <text>Some comment about the package.</text>'
+])
+
+file_str = '\n'.join([
+    'FileName: testfile.java',
+    'SPDXID: SPDXRef-File',
+    'FileType: SOURCE',
+    'FileChecksum: SHA1: 2fd4e1c67a2d28fced849ee1bb76e7391b93eb12',
+    'LicenseConcluded: Apache-2.0',
+    'LicenseInfoInFile: Apache-2.0',
+    'FileCopyrightText: <text>Copyright 2014 Acme Inc.</text>',
+    'ArtifactOfProjectName: AcmeTest',
+    'ArtifactOfProjectHomePage: http://www.acme.org/',
+    'ArtifactOfProjectURI: http://www.acme.org/',
+    'FileComment: <text>Very long file</text>',
+    'FileAttributionText: <text>Acknowledgements that might be required to be communicated in some contexts.</text>'
+        ])
+
+unknown_tag_str = 'SomeUnknownTag: SomeUnknownValue'
+
+snippet_str = '\n'.join([
+    'SnippetSPDXID: SPDXRef-Snippet',
+    'SnippetLicenseComments: <text>Some lic comment.</text>',
+    'SnippetCopyrightText: <text> Copyright 2008-2010 John Smith </text>',
+    'SnippetComment: <text>Some snippet comment.</text>',
+    'SnippetName: from linux kernel',
+    'SnippetFromFileSPDXID: SPDXRef-DoapSource',
+    'SnippetLicenseConcluded: Apache-2.0',
+    'LicenseInfoInSnippet: Apache-2.0',
+])
+
+annotation_str = '\n'.join([
+    'Annotator: Person: Jane Doe()',
+    'AnnotationDate: 2010-01-29T18:30:22Z',
+    'AnnotationComment: <text>Document level annotation</text>',
+    'AnnotationType: OTHER',
+    'SPDXREF: SPDXRef-DOCUMENT'
+])
 
 
 class TestLexer(TestCase):
@@ -28,32 +115,24 @@ class TestLexer(TestCase):
         self.l.build()
 
     def test_document(self):
-        data = '''
-        SPDXVersion: SPDX-2.1
-        # Comment.
-        DataLicense: CC0-1.0
-        DocumentName: Sample_Document-V2.1
-        SPDXID: SPDXRef-DOCUMENT
-        DocumentNamespace: https://spdx.org/spdxdocs/spdx-example-444504E0-4F89-41D3-9A0C-0305E82C3301
-        DocumentComment: <text>This is a sample spreadsheet</text>
-        '''
+        data = document_str
         self.l.input(data)
-        self.token_assert_helper(self.l.token(), 'DOC_VERSION', 'SPDXVersion', 2)
-        self.token_assert_helper(self.l.token(), 'LINE', 'SPDX-2.1', 2)
-        self.token_assert_helper(self.l.token(), 'DOC_LICENSE', 'DataLicense', 4)
-        self.token_assert_helper(self.l.token(), 'LINE', 'CC0-1.0', 4)
-        self.token_assert_helper(self.l.token(), 'DOC_NAME', 'DocumentName', 5)
+        self.token_assert_helper(self.l.token(), 'DOC_VERSION', 'SPDXVersion', 1)
+        self.token_assert_helper(self.l.token(), 'LINE', 'SPDX-2.1', 1)
+        self.token_assert_helper(self.l.token(), 'DOC_LICENSE', 'DataLicense', 2)
+        self.token_assert_helper(self.l.token(), 'LINE', 'CC0-1.0', 2)
+        self.token_assert_helper(self.l.token(), 'DOC_NAME', 'DocumentName', 3)
         self.token_assert_helper(self.l.token(), 'LINE', 'Sample_Document-V2.1',
-                                 5)
-        self.token_assert_helper(self.l.token(), 'SPDX_ID', 'SPDXID', 6)
-        self.token_assert_helper(self.l.token(), 'LINE', 'SPDXRef-DOCUMENT', 6)
+                                 3)
+        self.token_assert_helper(self.l.token(), 'SPDX_ID', 'SPDXID', 4)
+        self.token_assert_helper(self.l.token(), 'LINE', 'SPDXRef-DOCUMENT', 4)
+        self.token_assert_helper(self.l.token(), 'DOC_COMMENT', 'DocumentComment', 5)
+        self.token_assert_helper(self.l.token(), 'TEXT', '<text>Sample Comment</text>', 5)
         self.token_assert_helper(self.l.token(), 'DOC_NAMESPACE',
-                                 'DocumentNamespace', 7)
+                                 'DocumentNamespace', 6)
         self.token_assert_helper(self.l.token(), 'LINE',
                                  'https://spdx.org/spdxdocs/spdx-example-444504E0-4F89-41D3-9A0C-0305E82C3301',
-                                 7)
-        self.token_assert_helper(self.l.token(), 'DOC_COMMENT', 'DocumentComment', 8)
-        self.token_assert_helper(self.l.token(), 'TEXT', '<text>This is a sample spreadsheet</text>', 8)
+                                 6)
 
     def test_external_document_references(self):
         data = '''
@@ -73,105 +152,123 @@ class TestLexer(TestCase):
 
 
     def test_creation_info(self):
-        data = '''
-        ## Creation Information
-        Creator: Person: Gary O'Neall
-        Creator: Organization: Source Auditor Inc.
-        Creator: Tool: SourceAuditor-V1.2
-        Created: 2010-02-03T00:00:00Z
-        CreatorComment: <text>This is an example of an SPDX
-        spreadsheet format</text>
-        '''
+        data = creation_str
         self.l.input(data)
-        self.token_assert_helper(self.l.token(), 'CREATOR', 'Creator', 3)
-        self.token_assert_helper(self.l.token(), 'PERSON_VALUE', "Person: Gary O'Neall", 3)
-        self.token_assert_helper(self.l.token(), 'CREATOR', 'Creator', 4)
-        self.token_assert_helper(self.l.token(), 'ORG_VALUE', 'Organization: Source Auditor Inc.', 4)
-        self.token_assert_helper(self.l.token(), 'CREATOR', 'Creator', 5)
-        self.token_assert_helper(self.l.token(), 'TOOL_VALUE', 'Tool: SourceAuditor-V1.2', 5)
-        self.token_assert_helper(self.l.token(), 'CREATED', 'Created', 6)
-        self.token_assert_helper(self.l.token(), 'DATE', '2010-02-03T00:00:00Z', 6)
+        self.token_assert_helper(self.l.token(), 'CREATOR', 'Creator', 1)
+        self.token_assert_helper(self.l.token(), 'PERSON_VALUE', "Person: Bob (bob@example.com)", 1)
+        self.token_assert_helper(self.l.token(), 'CREATOR', 'Creator', 2)
+        self.token_assert_helper(self.l.token(), 'ORG_VALUE', 'Organization: Acme.', 2)
+        self.token_assert_helper(self.l.token(), 'CREATED', 'Created', 3)
+        self.token_assert_helper(self.l.token(), 'DATE', '2010-02-03T00:00:00Z', 3)
+        self.token_assert_helper(self.l.token(), 'CREATOR_COMMENT', 'CreatorComment', 4)
+        self.token_assert_helper(self.l.token(), 'TEXT', '<text>Sample Comment</text>', 4)
 
     def test_review_info(self):
-        data = '''
-        Reviewer: Person: Joe Reviewer
-        ReviewDate: 2010-02-10T00:00:00Z
-        ReviewComment: <text>This is just an example.
-        Some of the non-standard licenses look like they are actually
-        BSD 3 clause licenses</text>
-        '''
+        data = review_str
         self.l.input(data)
-        self.token_assert_helper(self.l.token(), 'REVIEWER', 'Reviewer', 2)
-        self.token_assert_helper(self.l.token(), 'PERSON_VALUE', "Person: Joe Reviewer", 2)
-        self.token_assert_helper(self.l.token(), 'REVIEW_DATE', 'ReviewDate', 3)
-        self.token_assert_helper(self.l.token(), 'DATE', '2010-02-10T00:00:00Z', 3)
-        self.token_assert_helper(self.l.token(), 'REVIEW_COMMENT', 'ReviewComment', 4)
-        self.token_assert_helper(self.l.token(), 'TEXT', '''<text>This is just an example.
-        Some of the non-standard licenses look like they are actually
-        BSD 3 clause licenses</text>''', 4)
+        self.token_assert_helper(self.l.token(), 'REVIEWER', 'Reviewer', 1)
+        self.token_assert_helper(self.l.token(), 'PERSON_VALUE', "Person: Bob the Reviewer", 1)
+        self.token_assert_helper(self.l.token(), 'REVIEW_DATE', 'ReviewDate', 2)
+        self.token_assert_helper(self.l.token(), 'DATE', '2010-02-10T00:00:00Z', 2)
+        self.token_assert_helper(self.l.token(), 'REVIEW_COMMENT', 'ReviewComment', 3)
+        self.token_assert_helper(self.l.token(), 'TEXT', '<text>Bob was Here.</text>', 3)
+        self.token_assert_helper(self.l.token(), 'REVIEWER', 'Reviewer', 4)
+        self.token_assert_helper(self.l.token(), 'PERSON_VALUE', "Person: Alice the Reviewer", 4)
+        self.token_assert_helper(self.l.token(), 'REVIEW_DATE', 'ReviewDate', 5)
+        self.token_assert_helper(self.l.token(), 'DATE', '2011-02-10T00:00:00Z', 5)
+        self.token_assert_helper(self.l.token(), 'REVIEW_COMMENT', 'ReviewComment', 6)
+        self.token_assert_helper(self.l.token(), 'TEXT', '<text>Alice was also here.</text>', 6)
 
     def test_pacakage(self):
-        data = '''
-        SPDXID: SPDXRef-Package
-        FilesAnalyzed: False
-        PackageChecksum: SHA1: 2fd4e1c67a2d28fced849ee1bb76e7391b93eb12
-        PackageVerificationCode: 4e3211c67a2d28fced849ee1bb76e7391b93feba (SpdxTranslatorSpdx.rdf, SpdxTranslatorSpdx.txt)
-        ExternalRef: SECURITY cpe23Type cpe:2.3:a:pivotal_software:spring_framework:4.1.0:*:*:*:*:*:*:
-        ExternalRefComment: <text>Some comment about the package.</text>
-        '''
+        data = package_str
         self.l.input(data)
+        self.token_assert_helper(self.l.token(), 'PKG_NAME', 'PackageName', 1)
+        self.token_assert_helper(self.l.token(), 'LINE', 'Test', 1)
         self.token_assert_helper(self.l.token(), 'SPDX_ID', 'SPDXID', 2)
         self.token_assert_helper(self.l.token(), 'LINE', 'SPDXRef-Package', 2)
-        self.token_assert_helper(self.l.token(), 'PKG_FILES_ANALYZED', 'FilesAnalyzed', 3)
-        self.token_assert_helper(self.l.token(), 'LINE', 'False', 3)
-        self.token_assert_helper(self.l.token(), 'PKG_CHKSUM', 'PackageChecksum', 4)
-        self.token_assert_helper(self.l.token(), 'CHKSUM', 'SHA1: 2fd4e1c67a2d28fced849ee1bb76e7391b93eb12', 4)
-        self.token_assert_helper(self.l.token(), 'PKG_VERF_CODE', 'PackageVerificationCode', 5)
-        self.token_assert_helper(self.l.token(), 'LINE', '4e3211c67a2d28fced849ee1bb76e7391b93feba (SpdxTranslatorSpdx.rdf, SpdxTranslatorSpdx.txt)', 5)
-        self.token_assert_helper(self.l.token(), 'PKG_EXT_REF', 'ExternalRef', 6)
-        self.token_assert_helper(self.l.token(), 'LINE', 'SECURITY cpe23Type cpe:2.3:a:pivotal_software:spring_framework:4.1.0:*:*:*:*:*:*:', 6)
-        self.token_assert_helper(self.l.token(), 'PKG_EXT_REF_COMMENT', 'ExternalRefComment', 7)
-        self.token_assert_helper(self.l.token(), 'TEXT', '<text>Some comment about the package.</text>', 7)
+        self.token_assert_helper(self.l.token(), 'PKG_VERSION', 'PackageVersion', 3)
+        self.token_assert_helper(self.l.token(), 'LINE', 'Version 0.9.2', 3)
+        self.token_assert_helper(self.l.token(), 'PKG_DOWN', 'PackageDownloadLocation', 4)
+        self.token_assert_helper(self.l.token(), 'LINE', 'http://example.com/test', 4)
+        self.token_assert_helper(self.l.token(), 'PKG_FILES_ANALYZED', 'FilesAnalyzed', 5)
+        self.token_assert_helper(self.l.token(), 'LINE', 'True', 5)
+        self.token_assert_helper(self.l.token(), 'PKG_SUM', 'PackageSummary', 6)
+        self.token_assert_helper(self.l.token(), 'TEXT', '<text>Test package</text>', 6)
+        self.token_assert_helper(self.l.token(), 'PKG_SRC_INFO', 'PackageSourceInfo', 7)
+        self.token_assert_helper(self.l.token(), 'TEXT', '<text>Version 1.0 of test</text>', 7)
+        self.token_assert_helper(self.l.token(), 'PKG_FILE_NAME', 'PackageFileName', 8)
+        self.token_assert_helper(self.l.token(), 'LINE', 'test-1.0.zip', 8)
+        self.token_assert_helper(self.l.token(), 'PKG_SUPPL', 'PackageSupplier', 9)
+        self.token_assert_helper(self.l.token(), 'ORG_VALUE', 'Organization:ACME', 9)
+        self.token_assert_helper(self.l.token(), 'PKG_ORIG', 'PackageOriginator', 10)
+        self.token_assert_helper(self.l.token(), 'ORG_VALUE', 'Organization:ACME', 10)
+        self.token_assert_helper(self.l.token(), 'PKG_CHKSUM', 'PackageChecksum', 11)
+        self.token_assert_helper(self.l.token(), 'CHKSUM', 'SHA1: 2fd4e1c67a2d28fced849ee1bb76e7391b93eb12', 11)
+        self.token_assert_helper(self.l.token(), 'PKG_VERF_CODE', 'PackageVerificationCode', 12)
+        self.token_assert_helper(self.l.token(), 'LINE', '4e3211c67a2d28fced849ee1bb76e7391b93feba (something.rdf, something.txt)', 12)
+        self.token_assert_helper(self.l.token(), 'PKG_DESC', 'PackageDescription', 13)
+        self.token_assert_helper(self.l.token(), 'TEXT', '<text>A package.</text>', 13)
+        self.token_assert_helper(self.l.token(), 'PKG_COMMENT', 'PackageComment', 14)
+        self.token_assert_helper(self.l.token(), 'TEXT', '<text>Comment on the package.</text>', 14)
+        self.token_assert_helper(self.l.token(), 'PKG_CPY_TEXT', 'PackageCopyrightText', 15)
+        self.token_assert_helper(self.l.token(), 'TEXT', '<text> Copyright 2014 Acme Inc.</text>', 15)
+        self.token_assert_helper(self.l.token(), 'PKG_LICS_DECL', 'PackageLicenseDeclared', 16)
+        self.token_assert_helper(self.l.token(), 'LINE', 'Apache-2.0', 16)
+        self.token_assert_helper(self.l.token(), 'PKG_LICS_CONC', 'PackageLicenseConcluded', 17)
+        self.token_assert_helper(self.l.token(), 'LINE', '(LicenseRef-2.0 and Apache-2.0)', 17)
+        self.token_assert_helper(self.l.token(), 'PKG_LICS_FFILE', 'PackageLicenseInfoFromFiles', 18)
+        self.token_assert_helper(self.l.token(), 'LINE', 'Apache-1.0', 18)
+        self.token_assert_helper(self.l.token(), 'PKG_LICS_FFILE', 'PackageLicenseInfoFromFiles', 19)
+        self.token_assert_helper(self.l.token(), 'LINE', 'Apache-2.0', 19)
+        self.token_assert_helper(self.l.token(), 'PKG_LICS_COMMENT', 'PackageLicenseComments', 20)
+        self.token_assert_helper(self.l.token(), 'TEXT', '<text>License Comments</text>', 20)
+        self.token_assert_helper(self.l.token(), 'PKG_EXT_REF', 'ExternalRef', 21)
+        self.token_assert_helper(self.l.token(), 'LINE', 'SECURITY cpe23Type cpe:2.3:a:pivotal_software:spring_framework:4.1.0:*:*:*:*:*:*:', 21)
+        self.token_assert_helper(self.l.token(), 'PKG_EXT_REF_COMMENT', 'ExternalRefComment', 22)
+        self.token_assert_helper(self.l.token(), 'TEXT', '<text>Some comment about the package.</text>', 22)
 
     def test_unknown_tag(self):
-        data = '''
-        SomeUnknownTag: SomeUnknownValue
-        '''
+        data = unknown_tag_str
         self.l.input(data)
-        self.token_assert_helper(self.l.token(), 'UNKNOWN_TAG', 'SomeUnknownTag', 2)
-        self.token_assert_helper(self.l.token(), 'LINE', 'SomeUnknownValue', 2)
+        self.token_assert_helper(self.l.token(), 'UNKNOWN_TAG', 'SomeUnknownTag', 1)
+        self.token_assert_helper(self.l.token(), 'LINE', 'SomeUnknownValue', 1)
 
     def test_snippet(self):
-        data = '''
-        SnippetSPDXID: SPDXRef-Snippet
-        SnippetLicenseComments: <text>Some lic comment.</text>
-        SnippetCopyrightText: <text>Some cr text.</text>
-        SnippetComment: <text>Some snippet comment.</text>
-        SnippetName: from linux kernel
-        SnippetFromFileSPDXID: SPDXRef-DoapSource
-        SnippetLicenseConcluded: Apache-2.0
-        LicenseInfoInSnippet: Apache-2.0
-        '''
+        data = snippet_str
         self.l.input(data)
-        self.token_assert_helper(self.l.token(), 'SNIPPET_SPDX_ID', 'SnippetSPDXID', 2)
-        self.token_assert_helper(self.l.token(), 'LINE', 'SPDXRef-Snippet', 2)
-        self.token_assert_helper(self.l.token(), 'SNIPPET_LICS_COMMENT', 'SnippetLicenseComments', 3)
-        self.token_assert_helper(self.l.token(), 'TEXT', '<text>Some lic comment.</text>', 3)
-        self.token_assert_helper(self.l.token(), 'SNIPPET_CR_TEXT', 'SnippetCopyrightText', 4)
-        self.token_assert_helper(self.l.token(), 'TEXT', '<text>Some cr text.</text>', 4)
-        self.token_assert_helper(self.l.token(), 'SNIPPET_COMMENT', 'SnippetComment', 5)
-        self.token_assert_helper(self.l.token(), 'TEXT', '<text>Some snippet comment.</text>', 5)
-        self.token_assert_helper(self.l.token(), 'SNIPPET_NAME', 'SnippetName', 6)
-        self.token_assert_helper(self.l.token(), 'LINE', 'from linux kernel', 6)
+        self.token_assert_helper(self.l.token(), 'SNIPPET_SPDX_ID', 'SnippetSPDXID', 1)
+        self.token_assert_helper(self.l.token(), 'LINE', 'SPDXRef-Snippet', 1)
+        self.token_assert_helper(self.l.token(), 'SNIPPET_LICS_COMMENT', 'SnippetLicenseComments', 2)
+        self.token_assert_helper(self.l.token(), 'TEXT', '<text>Some lic comment.</text>', 2)
+        self.token_assert_helper(self.l.token(), 'SNIPPET_CR_TEXT', 'SnippetCopyrightText', 3)
+        self.token_assert_helper(self.l.token(), 'TEXT', '<text> Copyright 2008-2010 John Smith </text>', 3)
+        self.token_assert_helper(self.l.token(), 'SNIPPET_COMMENT', 'SnippetComment', 4)
+        self.token_assert_helper(self.l.token(), 'TEXT', '<text>Some snippet comment.</text>', 4)
+        self.token_assert_helper(self.l.token(), 'SNIPPET_NAME', 'SnippetName', 5)
+        self.token_assert_helper(self.l.token(), 'LINE', 'from linux kernel', 5)
         self.token_assert_helper(self.l.token(), 'SNIPPET_FILE_SPDXID',
-                                 'SnippetFromFileSPDXID', 7)
-        self.token_assert_helper(self.l.token(), 'LINE', 'SPDXRef-DoapSource', 7)
+                                 'SnippetFromFileSPDXID', 6)
+        self.token_assert_helper(self.l.token(), 'LINE', 'SPDXRef-DoapSource', 6)
         self.token_assert_helper(self.l.token(), 'SNIPPET_LICS_CONC',
-                                 'SnippetLicenseConcluded', 8)
-        self.token_assert_helper(self.l.token(), 'LINE', 'Apache-2.0', 8)
+                                 'SnippetLicenseConcluded', 7)
+        self.token_assert_helper(self.l.token(), 'LINE', 'Apache-2.0', 7)
         self.token_assert_helper(self.l.token(), 'SNIPPET_LICS_INFO',
-                                 'LicenseInfoInSnippet', 9)
-        self.token_assert_helper(self.l.token(), 'LINE', 'Apache-2.0', 9)
+                                 'LicenseInfoInSnippet', 8)
+        self.token_assert_helper(self.l.token(), 'LINE', 'Apache-2.0', 8)
+
+    def test_annotation(self):
+        data = annotation_str
+        self.l.input(data)
+        self.token_assert_helper(self.l.token(), 'ANNOTATOR', 'Annotator', 1)
+        self.token_assert_helper(self.l.token(), 'PERSON_VALUE', 'Person: Jane Doe()', 1)
+        self.token_assert_helper(self.l.token(), 'ANNOTATION_DATE', 'AnnotationDate', 2)
+        self.token_assert_helper(self.l.token(), 'DATE', '2010-01-29T18:30:22Z', 2)
+        self.token_assert_helper(self.l.token(), 'ANNOTATION_COMMENT', 'AnnotationComment', 3)
+        self.token_assert_helper(self.l.token(), 'TEXT', '<text>Document level annotation</text>', 3)
+        self.token_assert_helper(self.l.token(), 'ANNOTATION_TYPE', 'AnnotationType', 4)
+        self.token_assert_helper(self.l.token(), 'OTHER', 'OTHER', 4)
+        self.token_assert_helper(self.l.token(), 'ANNOTATION_SPDX_ID', 'SPDXREF', 5)
+        self.token_assert_helper(self.l.token(), 'LINE', 'SPDXRef-DOCUMENT', 5)
 
     def token_assert_helper(self, token, ttype, value, line):
         assert token.type == ttype
@@ -181,86 +278,8 @@ class TestLexer(TestCase):
 
 class TestParser(TestCase):
     maxDiff = None
-
-    document_str = '\n'.join([
-        'SPDXVersion: SPDX-2.1',
-        'DataLicense: CC0-1.0',
-        'DocumentName: Sample_Document-V2.1',
-        'SPDXID: SPDXRef-DOCUMENT',
-        'DocumentComment: <text>Sample Comment</text>',
-        'DocumentNamespace: https://spdx.org/spdxdocs/spdx-example-444504E0-4F89-41D3-9A0C-0305E82C3301'
-    ])
-
-    creation_str = '\n'.join([
-        'Creator: Person: Bob (bob@example.com)',
-        'Creator: Organization: Acme.',
-        'Created: 2010-02-03T00:00:00Z',
-        'CreatorComment: <text>Sample Comment</text>'
-    ])
-
-    review_str = '\n'.join([
-        'Reviewer: Person: Bob the Reviewer',
-        'ReviewDate: 2010-02-10T00:00:00Z',
-        'ReviewComment: <text>Bob was Here.</text>',
-        'Reviewer: Person: Alice the Reviewer',
-        'ReviewDate: 2011-02-10T00:00:00Z',
-        'ReviewComment: <text>Alice was also here.</text>'
-    ])
-
-    package_str = '\n'.join([
-        'PackageName: Test',
-        'SPDXID: SPDXRef-Package',
-        'PackageVersion: Version 0.9.2',
-        'PackageDownloadLocation: http://example.com/test',
-        'FilesAnalyzed: True',
-        'PackageSummary: <text>Test package</text>',
-        'PackageSourceInfo: <text>Version 1.0 of test</text>',
-        'PackageFileName: test-1.0.zip',
-        'PackageSupplier: Organization:ACME',
-        'PackageOriginator: Organization:ACME',
-        'PackageChecksum: SHA1: 2fd4e1c67a2d28fced849ee1bb76e7391b93eb12',
-        'PackageVerificationCode: 4e3211c67a2d28fced849ee1bb76e7391b93feba (something.rdf, something.txt)',
-        'PackageDescription: <text>A package.</text>',
-        'PackageComment: <text>Comment on the package.</text>',
-        'PackageCopyrightText: <text> Copyright 2014 Acme Inc.</text>',
-        'PackageLicenseDeclared: Apache-2.0',
-        'PackageLicenseConcluded: (LicenseRef-2.0 and Apache-2.0)',
-        'PackageLicenseInfoFromFiles: Apache-1.0',
-        'PackageLicenseInfoFromFiles: Apache-2.0',
-        'PackageLicenseComments: <text>License Comments</text>',
-        'ExternalRef: SECURITY cpe23Type cpe:2.3:a:pivotal_software:spring_framework:4.1.0:*:*:*:*:*:*:',
-        'ExternalRefComment: <text>Some comment about the package.</text>'
-    ])
-
-    file_str = '\n'.join([
-        'FileName: testfile.java',
-        'SPDXID: SPDXRef-File',
-        'FileType: SOURCE',
-        'FileChecksum: SHA1: 2fd4e1c67a2d28fced849ee1bb76e7391b93eb12',
-        'LicenseConcluded: Apache-2.0',
-        'LicenseInfoInFile: Apache-2.0',
-        'FileCopyrightText: <text>Copyright 2014 Acme Inc.</text>',
-        'ArtifactOfProjectName: AcmeTest',
-        'ArtifactOfProjectHomePage: http://www.acme.org/',
-        'ArtifactOfProjectURI: http://www.acme.org/',
-        'FileComment: <text>Very long file</text>',
-        'FileAttributionText: <text>Acknowledgements that might be required to be communicated in some contexts.</text>'
-        ])
-
-    unknown_tag_str = 'SomeUnknownTag: SomeUnknownValue'
-
-    snippet_str = '\n'.join([
-        'SnippetSPDXID: SPDXRef-Snippet',
-        'SnippetLicenseComments: <text>Some lic comment.</text>',
-        'SnippetCopyrightText: <text> Copyright 2008-2010 John Smith </text>',
-        'SnippetComment: <text>Some snippet comment.</text>',
-        'SnippetName: from linux kernel',
-        'SnippetFromFileSPDXID: SPDXRef-DoapSource',
-        'SnippetLicenseConcluded: Apache-2.0',
-        'LicenseInfoInSnippet: Apache-2.0',
-    ])
-
-    complete_str = '{0}\n{1}\n{2}\n{3}\n{4}\n{5}'.format(document_str, creation_str, review_str, package_str, file_str, snippet_str)
+    complete_str = '{0}\n{1}\n{2}\n{3}\n{4}\n{5}\n{6}'.format(document_str, creation_str, review_str, package_str,
+                                                              file_str, annotation_str, snippet_str)
 
     def setUp(self):
         self.p = Parser(Builder(), StandardLogger())
@@ -323,6 +342,18 @@ class TestParser(TestCase):
         assert spdx_file.attribution_text == 'Acknowledgements that might be required to be communicated in ' \
                                              'some contexts.'
 
+    def test_annotation(self):
+        document, error = self.p.parse(self.complete_str)
+        assert document is not None
+        assert not error
+        assert len(document.annotations) == 1
+        assert document.annotations[-1].annotator.name == 'Jane Doe'
+        assert spdx.utils.datetime_iso_format(document.annotations[-1].annotation_date) == '2010-01-29T18:30:22Z'
+        assert document.annotations[-1].comment == 'Document level annotation'
+        assert document.annotations[-1].annotation_type == 'OTHER'
+        assert document.annotations[-1].spdx_id == 'SPDXRef-DOCUMENT'
+
+
     def test_unknown_tag(self):
 
         try:
@@ -332,7 +363,7 @@ class TestParser(TestCase):
 
         saved_out = sys.stdout
         sys.stdout = StringIO()
-        document, error = self.p.parse(self.unknown_tag_str)
+        document, error = self.p.parse(unknown_tag_str)
         self.assertEqual(sys.stdout.getvalue(), 'Found unknown tag : SomeUnknownTag at line: 1\n')
         sys.stdout = saved_out
         assert error


### PR DESCRIPTION
Fixes the error described in #196 for parsing the annotation type in tv-files.
I also added two tests to verify that annotations are parsed correctly.