### PR TITLE
Rename snippet properties

### DIFF
--- a/spdx/parsers/jsonyamlxml.py
+++ b/spdx/parsers/jsonyamlxml.py
@@ -516,7 +516,7 @@ class SnippetParser(BaseParser):
                         self.parse_snippet_license_comment(
                             snippet.get("licenseComments")
                         )
-                        self.parse_snippet_file_spdxid(snippet.get("fileId"))
+                        self.parse_snippet_file_spdxid(snippet.get("snippetFromFile"))
                         self.parse_snippet_concluded_license(
                             snippet.get("licenseConcluded")
                         )
@@ -524,7 +524,7 @@ class SnippetParser(BaseParser):
                             snippet.get("attributionTexts")
                         )
                         self.parse_snippet_license_info_from_snippet(
-                            snippet.get("licenseInfoFromSnippet")
+                            snippet.get("licenseInfoInSnippets")
                         )
                         self.parse_annotations(snippet.get("annotations"), spdx_id=snippet.get("SPDXID"))
                         self.parse_snippet_ranges(snippet.get("ranges"))
@@ -669,7 +669,7 @@ class SnippetParser(BaseParser):
                         lic_parser.parse(lic_in_snippet)
                     )
                     try:
-                        return self.builder.set_snippet_lics_info(
+                        self.builder.set_snippet_lics_info(
                             self.document, license_object
                         )
                     except SPDXValueError:

--- a/spdx/parsers/xmlparser.py
+++ b/spdx/parsers/xmlparser.py
@@ -33,7 +33,6 @@ class Parser(jsonyamlxml.Parser):
             "annotations",
             "relationships",
             "snippets",
-            "licenseInfoFromSnippet",
             "reviewers",
             "fileTypes",
             "licenseInfoFromFiles",
@@ -41,14 +40,15 @@ class Parser(jsonyamlxml.Parser):
             "artifactOf",
             "fileContributors",
             "fileDependencies",
-            "excludedFilesNames",
             "files",
             "documentDescribes",
             "packages",
             "checksums",
             "hasFiles",
             "externalRefs",
-            "ranges"
+            "ranges",
+            "licenseInfoInSnippets",
+            "packageVerificationCodeExcludedFiles"
         }
 
     def parse(self, file):

--- a/spdx/writers/jsonyamlxml.py
+++ b/spdx/writers/jsonyamlxml.py
@@ -402,7 +402,7 @@ class SnippetWriter(BaseWriter):
             snippet_from_file_spdx_id = self.spdx_id(snippet.snip_from_file_spdxid)
             snippet_object = dict()
             snippet_object["SPDXID"] = self.spdx_id(snippet.spdx_id)
-            snippet_object["fileId"] = snippet_from_file_spdx_id
+            snippet_object["snippetFromFile"] = snippet_from_file_spdx_id
 
             if snippet.has_optional_field("copyright"):
                 snippet_object["copyrightText"] = snippet.copyright
@@ -411,7 +411,7 @@ class SnippetWriter(BaseWriter):
                 snippet_object["licenseConcluded"] = self.license(snippet.conc_lics)
 
             if snippet.has_optional_field("licenses_in_snippet"):
-                snippet_object["licenseInfoFromSnippet"] = list(
+                snippet_object["licenseInfoInSnippets"] = list(
                     map(self.license, snippet.licenses_in_snippet)
                 )
             byte_range = {"endPointer": {"offset": snippet.byte_range[1], "reference": snippet_from_file_spdx_id},

--- a/tests/data/doc_parse/expected.json
+++ b/tests/data/doc_parse/expected.json
@@ -302,13 +302,13 @@
       "comment": "This snippet was identified as significant and highlighted in this Apache-2.0 file, when a commercial scanner identified it as being derived from file foo.c in package xyz which is licensed under GPL-2.0-or-later.",
       "copyrightText": "Copyright 2008-2010 John Smith",
       "licenseComments": "The concluded license was taken from package xyz, from which the snippet was copied into the current file. The concluded license information was found in the COPYING.txt file in package xyz.",
-      "fileId": "SPDXRef-DoapSource",
+      "snippetFromFile": "SPDXRef-DoapSource",
       "licenseConcluded": {
         "type": "Single",
         "identifier": "Apache-2.0",
         "name": "Apache License 2.0"
       },
-      "licenseInfoFromSnippet": [
+      "licenseInfoInSnippets": [
         {
           "type": "Single",
           "identifier": "Apache-2.0",

--- a/tests/data/doc_parse/expected.json
+++ b/tests/data/doc_parse/expected.json
@@ -313,6 +313,11 @@
           "type": "Single",
           "identifier": "Apache-2.0",
           "name": "Apache License 2.0"
+        },
+        {
+          "type": "Single",
+          "identifier": "GPL-2.0-only",
+          "name": "GNU General Public License v2.0 only"
         }
       ]
     }

--- a/tests/data/doc_parse/spdx-expected.json
+++ b/tests/data/doc_parse/spdx-expected.json
@@ -296,13 +296,13 @@
       "comment": "This snippet was identified as significant and highlighted in this Apache-2.0 file, when a commercial scanner identified it as being derived from file foo.c in package xyz which is licensed under GPL-2.0-or-later.",
       "copyrightText": "Copyright 2008-2010 John Smith",
       "licenseComments": "The concluded license was taken from package xyz, from which the snippet was copied into the current file. The concluded license information was found in the COPYING.txt file in package xyz.",
-      "fileId": "SPDXRef-DoapSource",
+      "snippetFromFile": "SPDXRef-DoapSource",
       "licenseConcluded": {
         "type": "Single",
         "identifier": "Apache-2.0",
         "name": "Apache License 2.0"
       },
-      "licenseInfoFromSnippet": [
+      "licenseInfoInSnippets": [
         {
           "type": "Single",
           "identifier": "Apache-2.0",

--- a/tests/data/formats/SPDXJsonExample.json
+++ b/tests/data/formats/SPDXJsonExample.json
@@ -176,12 +176,12 @@
       "name": "from linux kernel",
       "copyrightText": "Copyright 2008-2010 John Smith",
       "licenseConcluded": "Apache-2.0",
-      "licenseInfoFromSnippet": [
+      "licenseInfoInSnippets": [
         "Apache-2.0"
       ],
       "licenseComments": "The concluded license was taken from package xyz, from which the snippet was copied into the current file. The concluded license information was found in the COPYING.txt file in package xyz.",
       "SPDXID": "SPDXRef-Snippet",
-      "fileId": "SPDXRef-DoapSource",
+      "snippetFromFile": "SPDXRef-DoapSource",
         "ranges": [
             {
                 "endPointer": {

--- a/tests/data/formats/SPDXJsonExample.json
+++ b/tests/data/formats/SPDXJsonExample.json
@@ -177,7 +177,8 @@
       "copyrightText": "Copyright 2008-2010 John Smith",
       "licenseConcluded": "Apache-2.0",
       "licenseInfoInSnippets": [
-        "Apache-2.0"
+        "Apache-2.0",
+        "GPL-2.0-only"
       ],
       "licenseComments": "The concluded license was taken from package xyz, from which the snippet was copied into the current file. The concluded license information was found in the COPYING.txt file in package xyz.",
       "SPDXID": "SPDXRef-Snippet",

--- a/tests/data/formats/SPDXXmlExample.xml
+++ b/tests/data/formats/SPDXXmlExample.xml
@@ -235,10 +235,10 @@ EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.</extractedText>
 			<name>from linux kernel</name>
 			<copyrightText>Copyright 2008-2010 John Smith</copyrightText>
 			<licenseConcluded>Apache-2.0</licenseConcluded>
-			<licenseInfoFromSnippet>Apache-2.0</licenseInfoFromSnippet>
+			<licenseInfoInSnippets>Apache-2.0</licenseInfoInSnippets>
 			<licenseComments>The concluded license was taken from package xyz, from which the snippet was copied into the current file. The concluded license information was found in the COPYING.txt file in package xyz.</licenseComments>
 			<SPDXID>SPDXRef-Snippet</SPDXID>
-			<fileId>SPDXRef-DoapSource</fileId>
+			<snippetFromFile>SPDXRef-DoapSource</snippetFromFile>
             <ranges>
                 <endPointer>
                     <offset>420</offset>

--- a/tests/data/formats/SPDXXmlExample.xml
+++ b/tests/data/formats/SPDXXmlExample.xml
@@ -236,6 +236,7 @@ EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.</extractedText>
 			<copyrightText>Copyright 2008-2010 John Smith</copyrightText>
 			<licenseConcluded>Apache-2.0</licenseConcluded>
 			<licenseInfoInSnippets>Apache-2.0</licenseInfoInSnippets>
+			<licenseInfoInSnippets>GPL-2.0-only</licenseInfoInSnippets>
 			<licenseComments>The concluded license was taken from package xyz, from which the snippet was copied into the current file. The concluded license information was found in the COPYING.txt file in package xyz.</licenseComments>
 			<SPDXID>SPDXRef-Snippet</SPDXID>
 			<snippetFromFile>SPDXRef-DoapSource</snippetFromFile>

--- a/tests/data/formats/SPDXYamlExample.yaml
+++ b/tests/data/formats/SPDXYamlExample.yaml
@@ -186,13 +186,13 @@ Document:
         file, when a commercial scanner identified it as being derived from file foo.c
         in package xyz which is licensed under GPL-2.0-or-later.
       copyrightText: Copyright 2008-2010 John Smith
-      fileId: SPDXRef-DoapSource
+      snippetFromFile: SPDXRef-DoapSource
       SPDXID: SPDXRef-Snippet
       licenseComments: The concluded license was taken from package xyz, from which
         the snippet was copied into the current file. The concluded license information
         was found in the COPYING.txt file in package xyz.
       licenseConcluded: Apache-2.0
-      licenseInfoFromSnippet:
+      licenseInfoInSnippets:
         - Apache-2.0
       name: from linux kernel
       ranges:

--- a/tests/data/formats/SPDXYamlExample.yaml
+++ b/tests/data/formats/SPDXYamlExample.yaml
@@ -194,6 +194,7 @@ Document:
       licenseConcluded: Apache-2.0
       licenseInfoInSnippets:
         - Apache-2.0
+        - GPL-2.0-only
       name: from linux kernel
       ranges:
         - endPointer:

--- a/tests/test_write_anything.py
+++ b/tests/test_write_anything.py
@@ -67,18 +67,24 @@ def test_write_anything_rdf(in_file, out_format, tmpdir):
 
 
 def write_anything_test(in_basename, in_file, out_format, tmpdir):
-    doc, error = parse_anything.parse_file(in_file)
-    assert not error
-    result = utils_test.TestParserUtils.to_dict(doc)
-    out_fn = os.path.join(tmpdir, "test." + out_format)
-    write_anything.write_file(doc, out_fn)
-    doc2, error2 = parse_anything.parse_file(out_fn)
-    result2 = utils_test.TestParserUtils.to_dict(doc2)
-    assert not error2
+    """This parses the in_file and writes it to the out_format,
+    then parses the written out_file again and checks if it is still the same as in_file."""
+    doc_in, error_in = parse_anything.parse_file(in_file)
+    assert not error_in
+    result_in = utils_test.TestParserUtils.to_dict(doc_in)
+
+    out_file_name = os.path.join(tmpdir, "test." + out_format)
+    write_anything.write_file(doc_in, out_file_name)
+
+    doc_out, error_out = parse_anything.parse_file(out_file_name)
+    assert not error_out
+    result_out = utils_test.TestParserUtils.to_dict(doc_out)
+
     test = in_basename + "-" + out_format
     if test not in UNSTABLE_CONVERSIONS:
-        assert result == result2
+        assert result_in == result_out
+
     else:
         # if this test fails, this means we are more stable \o/
         # in that case, please remove the test from UNSTABLE_CONVERSIONS list
-        assert result2 != result, test
+        assert result_out != result_in, test

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -503,9 +503,9 @@ class TestParserUtils(object):
                 ('comment', snippet.comment),
                 ('copyrightText', snippet.copyright),
                 ('licenseComments', snippet.license_comment),
-                ('fileId', snippet.snip_from_file_spdxid),
+                ('snippetFromFile', snippet.snip_from_file_spdxid),
                 ('licenseConcluded', cls.license_to_dict(snippet.conc_lics)),
-                ('licenseInfoFromSnippet', [cls.license_to_dict(lic) for lic in lics_from_snippet]),
+                ('licenseInfoInSnippets', [cls.license_to_dict(lic) for lic in lics_from_snippet]),
             ])
             snippets_list.append(snippet_dict)
 


### PR DESCRIPTION
fixes #287 

also adds an additional `licenseInfoInSnippet` for the tests