### PR TITLE
[issue-326] fix output for licenses that are SPDXNone or NoAssert-objects

### DIFF
--- a/spdx/cli_tools/parser.py
+++ b/spdx/cli_tools/parser.py
@@ -12,6 +12,8 @@
 # limitations under the License.
 
 import os
+
+from spdx import utils
 from spdx.parsers.parse_anything import parse_file
 import spdx.file as spdxfile
 
@@ -87,7 +89,9 @@ def main(file, force):
         print("\tFile license concluded: {0}".format(f.conc_lics))
         print(
             "\tFile license info in file: {0}".format(
-                ",".join(map(lambda l: l.identifier, f.licenses_in_file))
+                ",".join(
+                    map(lambda l: l.identifier if not isinstance(l, (utils.SPDXNone, utils.NoAssert)) else l.to_value(),
+                        f.licenses_in_file))
             )
         )
         print(
@@ -119,6 +123,7 @@ def main(file, force):
             print("\tRelationship: {0}".format(relation.comment))
         except:
             continue
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
fixes #326 

Signed-off-by: Meret Behrens <meret.behrens@tngtech.com>