### PR TITLE
[issue-243] delete duplicated license list version field

### DIFF
--- a/spdx/creationinfo.py
+++ b/spdx/creationinfo.py
@@ -14,6 +14,7 @@ from functools import total_ordering
 
 from spdx import config
 from spdx import utils
+from spdx.version import Version
 
 
 @total_ordering
@@ -155,6 +156,9 @@ class CreationInfo(object):
 
     def set_created_now(self):
         self.created = datetime.utcnow().replace(microsecond=0)
+
+    def set_license_list_version(self, license_list_version):
+        self.license_list_version = Version.from_str(license_list_version)
 
     @property
     def created_iso_format(self):

--- a/spdx/document.py
+++ b/spdx/document.py
@@ -120,7 +120,6 @@ class Document(object):
         self.version = version
         self.data_license = data_license
         self.name = name
-        self.license_list_version=license_list_version
         self.spdx_id = spdx_id
         self.ext_document_references = []
         self.comment = comment
@@ -135,6 +134,10 @@ class Document(object):
         self.annotations = []
         self.relationships: List[Relationship] = []
         self.snippet = []
+
+        # due to backwards compatibility write input argument for license list version to creation info
+        if license_list_version:
+            self.creation_info.set_license_list_version(license_list_version)
 
     def add_review(self, review):
         self.reviews.append(review)


### PR DESCRIPTION
I decided to keep the input argument for `license_list_version` for the `document` object for backwards compatibility and redirect the input to the `creation_info` field. The current parsers and writers only use the `license_list_version` field from the `creation_info` so nothing needs to be changed here.

Signed-off-by: Meret Behrens <meret.behrens@tngtech.com>