### PR TITLE
[refactor] move comment to the end of extractedLicensingInfo constructor

### DIFF
--- a/src/model/extracted_licensing_info.py
+++ b/src/model/extracted_licensing_info.py
@@ -20,11 +20,11 @@ class ExtractedLicensingInfo:
     license_id: Optional[str] = None
     extracted_text: Optional[str] = None
     license_name: Optional[str] = None
-    comment: Optional[str] = None
     cross_references: List[str] = field(default_factory=list)
+    comment: Optional[str] = None
 
     def __init__(self, license_id: Optional[str] = None, extracted_text: Optional[str] = None,
-                 license_name: Optional[str] = None, comment: Optional[str] = None,
-                 cross_references: List[str] = None):
+                 license_name: Optional[str] = None, cross_references: List[str] = None,
+                 comment: Optional[str] = None):
         cross_references = [] if cross_references is None else cross_references
         check_types_and_set_values(self, locals())

--- a/tests/model/test_extracted_licensing_info.py
+++ b/tests/model/test_extracted_licensing_info.py
@@ -4,12 +4,12 @@ from src.model.extracted_licensing_info import ExtractedLicensingInfo
 
 
 def test_correct_initialization():
-    extracted_licensing_info = ExtractedLicensingInfo("id", "text", "name", "comment", ["reference"])
+    extracted_licensing_info = ExtractedLicensingInfo("id", "text", "name", ["reference"], "comment")
     assert extracted_licensing_info.license_id == "id"
     assert extracted_licensing_info.extracted_text == "text"
     assert extracted_licensing_info.license_name == "name"
-    assert extracted_licensing_info.comment == "comment"
     assert extracted_licensing_info.cross_references == ["reference"]
+    assert extracted_licensing_info.comment == "comment"
 
 
 def test_wrong_type_in_license_id():
@@ -27,11 +27,11 @@ def test_wrong_type_in_license_name():
         ExtractedLicensingInfo(license_name=42)
 
 
-def test_wrong_type_in_comment():
-    with pytest.raises(TypeError):
-        ExtractedLicensingInfo(comment=42)
-
-
 def test_wrong_type_in_cross_references():
     with pytest.raises(TypeError):
         ExtractedLicensingInfo(cross_references=["ref", 42])
+
+
+def test_wrong_type_in_comment():
+    with pytest.raises(TypeError):
+        ExtractedLicensingInfo(comment=42)


### PR DESCRIPTION
this makes sense as it is the only unconditionally optional parameter (also, it is the order as found in the specification)

Signed-off-by: Armin Tänzer <armin.taenzer@tngtech.com>