### PR TITLE
Minor parsing/writing fixes

### DIFF
--- a/src/jsonschema/document_converter.py
+++ b/src/jsonschema/document_converter.py
@@ -79,7 +79,7 @@ class DocumentConverter(TypedConverter[Document]):
         elif document_property == DocumentProperty.EXTERNAL_DOCUMENT_REFS:
             return [self.external_document_ref_converter.convert(external_document_ref) for
                     external_document_ref in document.creation_info.external_document_refs] or None
-        elif document_property == DocumentProperty.HAS_EXTRACTED_LICENSING_INFO:
+        elif document_property == DocumentProperty.HAS_EXTRACTED_LICENSING_INFOS:
             return [self.extracted_licensing_info_converter.convert(licensing_info) for licensing_info in
                     document.extracted_licensing_info] or None
         elif document_property == DocumentProperty.NAME:

--- a/src/jsonschema/document_properties.py
+++ b/src/jsonschema/document_properties.py
@@ -20,7 +20,7 @@ class DocumentProperty(JsonProperty):
     CREATION_INFO = auto()
     DATA_LICENSE = auto()
     EXTERNAL_DOCUMENT_REFS = auto()
-    HAS_EXTRACTED_LICENSING_INFO = auto()
+    HAS_EXTRACTED_LICENSING_INFOS = auto()
     NAME = auto()
     SPDX_VERSION = auto()
     DOCUMENT_NAMESPACE = auto()

--- a/src/parser/jsonlikedict/package_parser.py
+++ b/src/parser/jsonlikedict/package_parser.py
@@ -60,10 +60,11 @@ class PackageParser:
         external_refs: List[ExternalPackageRef] = parse_field_or_log_error(logger, package_dict.get("externalRefs"),
                                                                            self.parse_external_refs)
 
-        files_analyzed: Optional[Union[bool, str]] = parse_field_or_log_error(logger, package_dict.get("filesAnalyzed"),
-                                                                  lambda x: x, True)
+        files_analyzed: Optional[Union[bool, str]] = package_dict.get("filesAnalyzed")
 
-        if isinstance(files_analyzed, str): # XML does not support boolean typed values
+        if files_analyzed is None: # default value is True
+            files_analyzed = True
+        elif isinstance(files_analyzed, str): # XML does not support boolean typed values
             if files_analyzed.lower() == "true":
                 files_analyzed = True
             elif files_analyzed.lower() == "false":

--- a/src/parser/xml/xml_parser.py
+++ b/src/parser/xml/xml_parser.py
@@ -20,7 +20,7 @@ from src.parser.jsonlikedict.json_like_dict_parser import JsonLikeDictParser
 LIST_LIKE_FIELDS = [
     "creators",
     "externalDocumentRefs",
-    "extractedLicenseInfos",
+    "hasExtractedLicensingInfos",
     "seeAlsos",
     "annotations",
     "relationships",

--- a/tests/jsonschema/test_document_converter.py
+++ b/tests/jsonschema/test_document_converter.py
@@ -63,7 +63,7 @@ def converter(relationship_converter_mock: MagicMock, snippet_converter_mock: Ma
                           (DocumentProperty.PACKAGES, "packages"), (DocumentProperty.FILES, "files"),
                           (DocumentProperty.SNIPPETS, "snippets"), (DocumentProperty.ANNOTATIONS, "annotations"),
                           (DocumentProperty.RELATIONSHIPS, "relationships"),
-                          (DocumentProperty.HAS_EXTRACTED_LICENSING_INFO, "hasExtractedLicensingInfo")])
+                          (DocumentProperty.HAS_EXTRACTED_LICENSING_INFOS, "hasExtractedLicensingInfos")])
 def test_json_property_names(converter: DocumentConverter, document_property: DocumentProperty,
                              expected: str):
     assert converter.json_property_name(document_property) == expected
@@ -99,7 +99,7 @@ def test_successful_conversion(converter: DocumentConverter):
         converter.json_property_name(DocumentProperty.CREATION_INFO): "mock_converted_creation_info",
         converter.json_property_name(DocumentProperty.DATA_LICENSE): "dataLicense",
         converter.json_property_name(DocumentProperty.EXTERNAL_DOCUMENT_REFS): ["mock_converted_external_ref"],
-        converter.json_property_name(DocumentProperty.HAS_EXTRACTED_LICENSING_INFO): [
+        converter.json_property_name(DocumentProperty.HAS_EXTRACTED_LICENSING_INFOS): [
             "mock_converted_extracted_licensing_info"],
         converter.json_property_name(DocumentProperty.NAME): "name",
         converter.json_property_name(DocumentProperty.SPDX_VERSION): "spdxVersion",
@@ -127,7 +127,7 @@ def test_null_values(converter: DocumentConverter):
 
     assert converter.json_property_name(DocumentProperty.ANNOTATIONS) not in converted_dict
     assert converter.json_property_name(DocumentProperty.EXTERNAL_DOCUMENT_REFS) not in converted_dict
-    assert converter.json_property_name(DocumentProperty.HAS_EXTRACTED_LICENSING_INFO) not in converted_dict
+    assert converter.json_property_name(DocumentProperty.HAS_EXTRACTED_LICENSING_INFOS) not in converted_dict
     assert converter.json_property_name(DocumentProperty.DOCUMENT_DESCRIBES) not in converted_dict
     assert converter.json_property_name(DocumentProperty.PACKAGES) not in converted_dict
     assert converter.json_property_name(DocumentProperty.FILES) not in converted_dict

--- a/tests/writer/json/expected_results/expected.json
+++ b/tests/writer/json/expected_results/expected.json
@@ -26,7 +26,7 @@
             }
         }
     ],
-    "hasExtractedLicensingInfo": [
+    "hasExtractedLicensingInfos": [
         {
             "extractedText": "licenseText",
             "licenseId": "licenseId"


### PR DESCRIPTION
While testing I came upon two bugs:
- `hasExtractedLicensingInfo` must be `hasExtractedLicensingInfos`
- parsing of `filesAnalyzed` failed because of its boolean nature the `if not value: return default` triggered for `filesAnalyzed=False`