### PR TITLE
[issue-397] use fixtures in writer tests

### DIFF
--- a/src/spdx/parser/jsonlikedict/json_like_dict_parser.py
+++ b/src/spdx/parser/jsonlikedict/json_like_dict_parser.py
@@ -8,7 +8,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import json
 from typing import Dict
 
 from spdx.model.document import Document

--- a/src/spdx/validation/creation_info_validator.py
+++ b/src/spdx/validation/creation_info_validator.py
@@ -9,7 +9,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import re
 from typing import List
 
 from spdx.model.document import CreationInfo

--- a/tests/parser/jsonlikedict/test_dict_parsing_functions.py
+++ b/tests/parser/jsonlikedict/test_dict_parsing_functions.py
@@ -8,7 +8,6 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-from datetime import datetime
 from unittest import TestCase
 
 import pytest
@@ -18,7 +17,6 @@ from spdx.model.spdx_none import SpdxNone
 from spdx.parser.error import SPDXParsingError
 from spdx.parser.jsonlikedict.dict_parsing_functions import json_str_to_enum_name, \
     parse_field_or_no_assertion, parse_field_or_no_assertion_or_none
-from spdx.datetime_conversions import datetime_from_str
 
 
 def test_json_str_to_enum():

--- a/tests/writer/json/expected_results/expected.json
+++ b/tests/writer/json/expected_results/expected.json
@@ -1,101 +1,175 @@
 {
-    "SPDXID": "documentId",
-    "annotations": [
-        {
-            "annotationDate": "2022-12-02T00:00:00Z",
-            "annotationType": "REVIEW",
-            "annotator": "Person: reviewerName",
-            "comment": "reviewComment"
-        }
-    ],
-    "comment": "comment",
+    "SPDXID": "SPDXRef-DOCUMENT",
+    "comment": "documentComment",
     "creationInfo": {
+        "comment": "creatorComment",
         "created": "2022-12-01T00:00:00Z",
         "creators": [
-            "Tool: tools-python (tools-python@github.com)"
-        ]
+            "Person: creatorName (some@mail.com)"
+        ],
+        "licenseListVersion": "3.19"
     },
-    "dataLicense": "dataLicense",
+    "dataLicense": "CC0-1.0",
+    "documentDescribes": [
+        "SPDXRef-File"
+    ],
+    "documentNamespace": "https://some.namespace",
     "externalDocumentRefs": [
         {
-            "externalDocumentId": "docRefId",
-            "spdxDocument": "externalDocumentUri",
             "checksum": {
                 "algorithm": "SHA1",
-                "checksumValue": "externalRefSha1"
-            }
-        }
-    ],
-    "hasExtractedLicensingInfos": [
-        {
-            "extractedText": "licenseText",
-            "licenseId": "licenseId"
-        }
-    ],
-    "name": "documentName",
-    "spdxVersion": "spdxVersion",
-    "documentNamespace": "documentNamespace",
-    "documentDescribes": [
-        "packageId",
-        "fileId"
-    ],
-    "packages": [
-        {
-            "SPDXID": "packageId",
-            "downloadLocation": "NONE",
-            "filesAnalyzed": true,
-            "name": "packageName"
+                "checksumValue": "71c4025dd9897b364f3ebbb42c484ff43d00791c"
+            },
+            "externalDocumentId": "DocumentRef-external",
+            "spdxDocument": "https://namespace.com"
         }
     ],
     "files": [
         {
-            "SPDXID": "fileId",
+            "SPDXID": "SPDXRef-File",
             "annotations": [
                 {
-                    "annotationDate": "2022-12-03T00:00:00Z",
-                    "annotationType": "OTHER",
-                    "annotator": "Tool: toolName",
-                    "comment": "otherComment"
+                    "annotationDate": "2022-12-01T00:00:00Z",
+                    "annotationType": "REVIEW",
+                    "annotator": "Person: annotatorName (some@mail.com)",
+                    "comment": "annotationComment"
                 }
+            ],
+            "attributionTexts": [
+                "fileAttributionText"
             ],
             "checksums": [
                 {
                     "algorithm": "SHA1",
-                    "checksumValue": "fileSha1"
+                    "checksumValue": "71c4025dd9897b364f3ebbb42c484ff43d00791c"
                 }
             ],
-            "fileName": "fileName"
+            "comment": "fileComment",
+            "copyrightText": "copyrightText",
+            "fileContributors": [
+                "fileContributor"
+            ],
+            "fileName": "./fileName.py",
+            "fileTypes": [
+                "TEXT"
+            ],
+            "licenseComments": "licenseComment",
+            "licenseConcluded": "concludedLicenseExpression",
+            "licenseInfoInFiles": [
+                "licenseInfoInFileExpression"
+            ],
+            "noticeText": "fileNotice"
         }
     ],
-    "snippets": [
+    "hasExtractedLicensingInfos": [
         {
-            "SPDXID": "snippetId",
-            "ranges": [
+            "comment": "licenseComment",
+            "extractedText": "extractedText",
+            "licenseId": "LicenseRef-1",
+            "name": "licenseName",
+            "seeAlsos": [
+                "https://see.also"
+            ]
+        }
+    ],
+    "name": "documentName",
+    "packages": [
+        {
+            "SPDXID": "SPDXRef-Package",
+            "attributionTexts": [
+                "packageAttributionText"
+            ],
+            "builtDate": "2022-12-02T00:00:00Z",
+            "checksums": [
                 {
-                    "startPointer": {
-                        "reference": "snippetFileId",
-                        "offset": 1
-                    },
-                    "endPointer": {
-                        "reference": "snippetFileId",
-                        "offset": 2
-                    }
+                    "algorithm": "SHA1",
+                    "checksumValue": "71c4025dd9897b364f3ebbb42c484ff43d00791c"
                 }
             ],
-            "snippetFromFile": "snippetFileId"
+            "comment": "packageComment",
+            "copyrightText": "packageCopyrightText",
+            "description": "packageDescription",
+            "downloadLocation": "https://download.com",
+            "externalRefs": [
+                {
+                    "comment": "externalPackageRefComment",
+                    "referenceCategory": "PACKAGE_MANAGER",
+                    "referenceLocator": "org.apache.tomcat:tomcat:9.0.0.M4",
+                    "referenceType": "maven-central"
+                }
+            ],
+            "filesAnalyzed": true,
+            "homepage": "https://homepage.com",
+            "licenseComments": "packageLicenseComment",
+            "licenseConcluded": "packageLicenseConcluded",
+            "licenseDeclared": "packageLicenseDeclared",
+            "licenseInfoFromFiles": [
+                "licenseInfoFromFile"
+            ],
+            "name": "packageName",
+            "originator": "Person: originatorName (some@mail.com)",
+            "packageFileName": "./packageFileName",
+            "packageVerificationCode": {
+                "packageVerificationCodeExcludedFiles": [
+                    "./exclude.py"
+                ],
+                "packageVerificationCodeValue": "85ed0817af83a24ad8da68c2b5094de69833983c"
+            },
+            "primaryPackagePurpose": "SOURCE",
+            "releaseDate": "2022-12-01T00:00:00Z",
+            "sourceInfo": "sourceInfo",
+            "summary": "packageSummary",
+            "supplier": "Person: supplierName (some@mail.com)",
+            "validUntilDate": "2022-12-03T00:00:00Z",
+            "versionInfo": "12.2"
         }
     ],
     "relationships": [
         {
-            "spdxElementId": "documentId",
             "comment": "relationshipComment",
-            "relatedSpdxElement": "fileId",
-            "relationshipType": "DESCRIBES"
-        },
-        {
-            "spdxElementId": "relationshipOriginId",
-            "relatedSpdxElement": "relationShipTargetId",
-            "relationshipType": "AMENDS"
+            "relatedSpdxElement": "SPDXRef-File",
+            "relationshipType": "DESCRIBES",
+            "spdxElementId": "SPDXRef-DOCUMENT"
         }
-    ]
+    ],
+    "snippets": [
+        {
+            "SPDXID": "SPDXRef-Snippet",
+            "attributionTexts": [
+                "snippetAttributionText"
+            ],
+            "comment": "snippetComment",
+            "copyrightText": "licenseCopyrightText",
+            "licenseComments": "snippetLicenseComment",
+            "licenseConcluded": "snippetLicenseConcluded",
+            "licenseInfoInSnippets": [
+                "licenseInfoInSnippet"
+            ],
+            "name": "snippetName",
+            "ranges": [
+                {
+                    "endPointer": {
+                        "offset": 2,
+                        "reference": "SPDXRef-File"
+                    },
+                    "startPointer": {
+                        "offset": 1,
+                        "reference": "SPDXRef-File"
+                    }
+                },
+                {
+                    "endPointer": {
+                        "lineNumber": 4,
+                        "reference": "SPDXRef-File"
+                    },
+                    "startPointer": {
+                        "lineNumber": 3,
+                        "reference": "SPDXRef-File"
+                    }
+                }
+            ],
+            "snippetFromFile": "SPDXRef-File"
+        }
+    ],
+    "spdxVersion": "SPDX-2.3"
 }

--- a/tests/writer/json/test_json_writer.py
+++ b/tests/writer/json/test_json_writer.py
@@ -10,21 +10,9 @@
 # limitations under the License.
 import json
 import os
-from datetime import datetime
 
 import pytest
 
-from spdx.model.actor import Actor, ActorType
-from spdx.model.annotation import Annotation, AnnotationType
-from spdx.model.checksum import ChecksumAlgorithm, Checksum
-from spdx.model.document import CreationInfo, Document
-from spdx.model.external_document_ref import ExternalDocumentRef
-from spdx.model.extracted_licensing_info import ExtractedLicensingInfo
-from spdx.model.file import File
-from spdx.model.package import Package
-from spdx.model.relationship import RelationshipType, Relationship
-from spdx.model.snippet import Snippet
-from spdx.model.spdx_none import SpdxNone
 from spdx.writer.json.json_writer import write_document
 from tests.fixtures import document_fixture
 
@@ -37,29 +25,8 @@ def temporary_file_path() -> str:
 
 
 def test_write_json(temporary_file_path: str):
-    creation_info = CreationInfo("spdxVersion", "documentId", "documentName", "documentNamespace",
-                                 [Actor(ActorType.TOOL, "tools-python", "tools-python@github.com")],
-                                 datetime(2022, 12, 1), document_comment="comment", data_license="dataLicense",
-                                 external_document_refs=[ExternalDocumentRef("docRefId", "externalDocumentUri",
-                                                                             Checksum(ChecksumAlgorithm.SHA1,
-                                                                                      "externalRefSha1"))])
-    package = Package("packageId", "packageName", SpdxNone())
-    file = File("fileName", "fileId", [Checksum(ChecksumAlgorithm.SHA1, "fileSha1")])
-    snippet = Snippet("snippetId", "snippetFileId", (1, 2))
-    relationships = [
-        Relationship(creation_info.spdx_id, RelationshipType.DESCRIBES, "packageId"),
-        Relationship(creation_info.spdx_id, RelationshipType.DESCRIBES, "fileId", "relationshipComment"),
-        Relationship("relationshipOriginId", RelationshipType.AMENDS, "relationShipTargetId")]
-    annotations = [
-        Annotation("documentId", AnnotationType.REVIEW, Actor(ActorType.PERSON, "reviewerName"),
-                   datetime(2022, 12, 2), "reviewComment"),
-        Annotation("fileId", AnnotationType.OTHER, Actor(ActorType.TOOL, "toolName"), datetime(2022, 12, 3),
-                   "otherComment")]
-    extracted_licensing_info = [ExtractedLicensingInfo("licenseId", "licenseText")]
-    document = Document(creation_info, annotations=annotations, extracted_licensing_info=extracted_licensing_info,
-                        relationships=relationships, packages=[package], files=[file], snippets=[snippet])
-    # TODO: Enable validation once test data is valid, https://github.com/spdx/tools-python/issues/397
-    write_document(document, temporary_file_path, validate=False)
+    document = document_fixture()
+    write_document(document, temporary_file_path, validate=True)
 
     with open(temporary_file_path) as written_file:
         written_json = json.load(written_file)

--- a/tests/writer/tagvalue/test_package_writer.py
+++ b/tests/writer/tagvalue/test_package_writer.py
@@ -8,30 +8,14 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-from datetime import datetime
 from unittest.mock import patch, mock_open, call
 
-from spdx.model.actor import ActorType, Actor
-from spdx.model.checksum import Checksum, ChecksumAlgorithm
-from spdx.model.license_expression import LicenseExpression
-from spdx.model.package import PackagePurpose, Package, PackageVerificationCode, ExternalPackageRef, \
-    ExternalPackageRefCategory
-from spdx.model.spdx_no_assertion import SpdxNoAssertion
-from spdx.model.spdx_none import SpdxNone
+from tests.fixtures import package_fixture
 from spdx.writer.tagvalue.package_writer import write_package
 
 
 def test_package_writer():
-    package = Package("SPDXRef-Package", "package name", "www.download.com", "version", "file_name", SpdxNoAssertion(),
-                      Actor(ActorType.PERSON, "person name", "email@mail.com"), True,
-                      PackageVerificationCode("85ed0817af83a24ad8da68c2b5094de69833983c"),
-                      [Checksum(ChecksumAlgorithm.SHA1, "85ed0817af83a24ad8da68c2b5094de69833983c")],
-                      "https://homepage.com", "source_info", None, [LicenseExpression("expression")],
-                      SpdxNone(), "comment on license", "copyright", "summary", "description", "comment",
-                      [ExternalPackageRef(ExternalPackageRefCategory.SECURITY, "cpe22Type",
-                                          "cpe:/o:canonical:ubuntu_linux:10.04:-:lts",
-                                          "external package ref comment")],
-                      ["text"], PackagePurpose.OTHER, datetime(2022, 1, 1), None, None)
+    package = package_fixture()
 
     m = mock_open()
     with patch('{}.open'.format(__name__), m, create=True):
@@ -42,27 +26,30 @@ def test_package_writer():
     handle = m()
     handle.write.assert_has_calls(
         [call('## Package Information\n'),
-         call('PackageName: package name\n'),
+         call('PackageName: packageName\n'),
          call('SPDXID: SPDXRef-Package\n'),
-         call('PackageVersion: version\n'),
-         call('PackageFileName: file_name\n'),
-         call('PackageSupplier: NOASSERTION\n'),
-         call('PackageOriginator: Person: person name (email@mail.com)\n'),
-         call('PackageDownloadLocation: www.download.com\n'),
+         call('PackageVersion: 12.2\n'),
+         call('PackageFileName: ./packageFileName\n'),
+         call('PackageSupplier: Person: supplierName (some@mail.com)\n'),
+         call('PackageOriginator: Person: originatorName (some@mail.com)\n'),
+         call('PackageDownloadLocation: https://download.com\n'),
          call('FilesAnalyzed: True\n'),
-         call('PackageVerificationCode: 85ed0817af83a24ad8da68c2b5094de69833983c\n'),
-         call('PackageChecksum: SHA1: 85ed0817af83a24ad8da68c2b5094de69833983c\n'),
+         call('PackageVerificationCode: 85ed0817af83a24ad8da68c2b5094de69833983c (excludes: ./exclude.py)\n'),
+         call('PackageChecksum: SHA1: 71c4025dd9897b364f3ebbb42c484ff43d00791c\n'),
          call('PackageHomePage: https://homepage.com\n'),
-         call('PackageSourceInfo: source_info\n'),
-         call('PackageLicenseInfoFromFiles: expression\n'),
-         call('PackageLicenseDeclared: NONE\n'),
-         call('PackageLicenseComments: comment on license\n'),
-         call('PackageCopyrightText: copyright\n'),
-         call('PackageSummary: summary\n'),
-         call('PackageDescription: description\n'),
-         call('PackageComment: comment\n'),
-         call('ExternalRef: SECURITY cpe22Type cpe:/o:canonical:ubuntu_linux:10.04:-:lts\n'),
-         call('ExternalRefComment: external package ref comment\n'),
-         call('PackageAttributionText: text\n'),
-         call('PrimaryPackagePurpose: OTHER\n'),
-         call('ReleaseDate: 2022-01-01T00:00:00Z\n')])
+         call('PackageSourceInfo: sourceInfo\n'),
+         call('PackageLicenseConcluded: packageLicenseConcluded\n'),
+         call('PackageLicenseInfoFromFiles: licenseInfoFromFile\n'),
+         call('PackageLicenseDeclared: packageLicenseDeclared\n'),
+         call('PackageLicenseComments: packageLicenseComment\n'),
+         call('PackageCopyrightText: packageCopyrightText\n'),
+         call('PackageSummary: packageSummary\n'),
+         call('PackageDescription: packageDescription\n'),
+         call('PackageComment: packageComment\n'),
+         call('ExternalRef: PACKAGE-MANAGER maven-central org.apache.tomcat:tomcat:9.0.0.M4\n'),
+         call('ExternalRefComment: externalPackageRefComment\n'),
+         call('PackageAttributionText: packageAttributionText\n'),
+         call('PrimaryPackagePurpose: SOURCE\n'),
+         call('ReleaseDate: 2022-12-01T00:00:00Z\n'),
+         call('BuiltDate: 2022-12-02T00:00:00Z\n'),
+         call('ValidUntilDate: 2022-12-03T00:00:00Z\n')])

--- a/tests/writer/tagvalue/test_tagvalue_writer.py
+++ b/tests/writer/tagvalue/test_tagvalue_writer.py
@@ -10,21 +10,10 @@
 #  limitations under the License.
 
 import os
-from datetime import datetime
 
 import pytest
 
-from spdx.model.actor import Actor, ActorType
-from spdx.model.annotation import Annotation, AnnotationType
-from spdx.model.checksum import ChecksumAlgorithm, Checksum
-from spdx.model.document import CreationInfo, Document
-from spdx.model.external_document_ref import ExternalDocumentRef
-from spdx.model.extracted_licensing_info import ExtractedLicensingInfo
-from spdx.model.file import File
-from spdx.model.package import Package
-from spdx.model.relationship import RelationshipType, Relationship
-from spdx.model.snippet import Snippet
-from spdx.model.spdx_none import SpdxNone
+from tests.fixtures import document_fixture
 from spdx.writer.tagvalue.tagvalue_writer import write_document_to_file
 
 
@@ -36,26 +25,7 @@ def temporary_file_path() -> str:
 
 
 def test_write_tag_value(temporary_file_path: str):
-    creation_info = CreationInfo("spdxVersion", "documentId", "documentName", "documentNamespace",
-                                 [Actor(ActorType.TOOL, "tools-python", "tools-python@github.com")],
-                                 datetime(2022, 12, 1), document_comment="comment", data_license="dataLicense",
-                                 external_document_refs=[ExternalDocumentRef("docRefId", "externalDocumentUri",
-                                                                             Checksum(ChecksumAlgorithm.SHA1,
-                                                                                      "externalRefSha1"))])
-    package = Package("packageId", "packageName", SpdxNone())
-    file = File("fileName", "fileId", [Checksum(ChecksumAlgorithm.SHA1, "fileSha1")])
-    snippet = Snippet("snippetId", "fileId", (1, 2))
-    annotations = [
-        Annotation("documentId", AnnotationType.REVIEW, Actor(ActorType.PERSON, "reviewerName"), datetime(2022, 12, 2),
-                   "reviewComment"),
-        Annotation("fileId", AnnotationType.OTHER, Actor(ActorType.TOOL, "toolName"), datetime(2022, 12, 3),
-                   "otherComment")]
-    extracted_licensing_info = [ExtractedLicensingInfo("licenseId", "licenseText")]
-    relationships = [Relationship(creation_info.spdx_id, RelationshipType.DESCRIBES, "packageId"),
-                     Relationship(creation_info.spdx_id, RelationshipType.DESCRIBES, "fileId", "relationshipComment"),
-                     Relationship("relationshipOriginId", RelationshipType.AMENDS, "relationShipTargetId")]
-    document = Document(creation_info, annotations=annotations, extracted_licensing_info=extracted_licensing_info,
-                        relationships=relationships, packages=[package], files=[file], snippets=[snippet])
+    document = document_fixture()
 
     write_document_to_file(document, temporary_file_path)
 


### PR DESCRIPTION
Addition to #409: Use fixtures in writer tests and enable validation in test_write_json (fixes TODO comment). The second commit deltes unused imports, which is only a minor fix and therefore doesn't need its own PR. 