### PR TITLE
Reimplemented parse_anything.py to handle SBOMs with incorrect file extensions. 

### DIFF
--- a/spdx/parsers/parse_anything.py
+++ b/spdx/parsers/parse_anything.py
@@ -22,33 +22,25 @@ from spdx.parsers.builderexceptions import FileTypeError
 
 
 def parse_file(fn):
-    buildermodule = jsonyamlxmlbuilders
-    read_data = False
-    if fn.endswith(".rdf") or fn.endswith(".rdf.xml"):
-        parsing_module = rdf
-        buildermodule = rdfbuilders
-    elif fn.endswith(".spdx"):
-        parsing_module = rdf
-        buildermodule = rdfbuilders
-    elif fn.endswith(".tag"):
-        parsing_module = tagvalue
-        buildermodule = tagvaluebuilders
-        read_data = True
-    elif fn.endswith(".json"):
-        parsing_module = jsonparser
-    elif fn.endswith(".xml"):
-        parsing_module = xmlparser
-    elif fn.endswith(".yaml") or fn.endswith(".yml"):
-        parsing_module = yamlparser
-    else:
-        raise FileTypeError("FileType Not Supported" + str(fn))
+    buildermodules = [rdfbuilders, jsonyamlxmlbuilders, jsonyamlxmlbuilders, jsonyamlxmlbuilders, tagvaluebuilders]
+    parsing_modules = [rdf, xmlparser, yamlparser, jsonparser, tagvalue]
+    read_datas = [False, False, False, False, True]
+    for i in range(len(buildermodules)):
+        parsing_module = parsing_modules[i]
+        buildermodule = buildermodules[i]
+        read_data = read_datas[i]
+        try:
+            p = parsing_module.Parser(buildermodule.Builder(), StandardLogger())
+            if hasattr(p, "build"):
+                p.build()
+            with open(fn) as f:
+                if read_data:
+                    data = f.read()
+                    return p.parse(data)
+                else:
+                    return p.parse(f)
+        except:
+            if i == len(buildermodules) - 1:
+                raise FileTypeError("FileType Not Supported" + str(fn))
 
-    p = parsing_module.Parser(buildermodule.Builder(), StandardLogger())
-    if hasattr(p, "build"):
-        p.build()
-    with open(fn) as f:
-        if read_data:
-            data = f.read()
-            return  p.parse(data)
-        else:
-            return  p.parse(f)
+

--- a/tests/data/parse_anything_test_files/SPDXJsonExample.json
+++ b/tests/data/parse_anything_test_files/SPDXJsonExample.json
@@ -1,0 +1,223 @@
+{
+    "Document": {
+        "comment": "This is a sample spreadsheet", 
+        "name": "Sample_Document-V2.1", 
+        "documentDescribes": [
+            {
+                "Package": {
+                    "SPDXID": "SPDXRef-Package", 
+                    "originator": "Organization: SPDX", 
+                    "files": [
+                        {
+                            "File": {
+                                "comment": "This file belongs to Jena", 
+                                "licenseInfoFromFiles": [
+                                    "LicenseRef-1"
+                                ], 
+                                "sha1": "3ab4e1c67a2d28fced849ee1bb76e7391b93f125", 
+                                "name": "Jenna-2.6.3/jena-2.6.3-sources.jar", 
+                                "copyrightText": "(c) Copyright 2000, 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009 Hewlett-Packard Development Company, LP", 
+                                "artifactOf" : [ 
+                                    {
+                                        "name" : "Jena",
+                                        "homePage" : "http://www.openjena.org/",
+                                        "projectUri" : "http://subversion.apache.org/doap.rdf"
+                                    } 
+                                ],
+                                "licenseConcluded": "LicenseRef-1", 
+                                "licenseComments": "This license is used by Jena", 
+                                "checksums": [
+                                    {
+                                        "checksumValue": "3ab4e1c67a2d28fced849ee1bb76e7391b93f125", 
+                                        "algorithm": "checksumAlgorithm_sha1"
+                                    }
+                                ], 
+                                "fileTypes": [
+                                    "fileType_archive"
+                                ], 
+                                "SPDXID": "SPDXRef-File1"
+                            }
+                        }, 
+                        {
+                            "File": {
+                                "licenseInfoFromFiles": [
+                                    "Apache-2.0"
+                                ], 
+                                "sha1": "2fd4e1c67a2d28fced849ee1bb76e7391b93eb12", 
+                                "name": "src/org/spdx/parser/DOAPProject.java", 
+                                "copyrightText": "Copyright 2010, 2011 Source Auditor Inc.", 
+                                "licenseConcluded": "Apache-2.0", 
+                                "checksums": [
+                                    {
+                                        "checksumValue": "2fd4e1c67a2d28fced849ee1bb76e7391b93eb12", 
+                                        "algorithm": "checksumAlgorithm_sha1"
+                                    }
+                                ], 
+                                "fileTypes": [
+                                    "fileType_source"
+                                ], 
+                                "SPDXID": "SPDXRef-File2"
+                            }
+                        }
+                    ], 
+                    "licenseInfoFromFiles": [
+                        "Apache-1.0", 
+                        "LicenseRef-3", 
+                        "MPL-1.1", 
+                        "LicenseRef-2", 
+                        "LicenseRef-4", 
+                        "Apache-2.0", 
+                        "LicenseRef-1"
+                    ], 
+                    "sha1": "2fd4e1c67a2d28fced849ee1bb76e7391b93eb12", 
+                    "name": "SPDX Translator", 
+                    "packageFileName": "spdxtranslator-1.0.zip", 
+                    "licenseComments": "The declared license information can be found in the NOTICE file at the root of the archive file", 
+                    "summary": "SPDX Translator utility", 
+                    "sourceInfo": "Version 1.0 of the SPDX Translator application", 
+                    "copyrightText": " Copyright 2010, 2011 Source Auditor Inc.", 
+                    "packageVerificationCode": {
+                        "packageVerificationCodeValue": "4e3211c67a2d28fced849ee1bb76e7391b93feba", 
+                        "packageVerificationCodeExcludedFiles": [
+                            "SpdxTranslatorSpdx.rdf", 
+                            "SpdxTranslatorSpdx.txt"
+                        ]
+                    }, 
+                    "licenseConcluded": "(Apache-1.0 AND LicenseRef-2 AND MPL-1.1 AND LicenseRef-3 AND LicenseRef-4 AND Apache-2.0 AND LicenseRef-1)", 
+                    "supplier": "Organization: Linux Foundation", 
+                    "attributionTexts" : [ "The GNU C Library is free software.  See the file COPYING.LIB for copying conditions, and LICENSES for notices about a few contributions that require these additional notices to be distributed.  License copyright years may be listed using range notation, e.g., 1996-2015, indicating that every year in the range, inclusive, is a copyrightable year that would otherwise be listed individually." ],
+                    "checksums": [
+                        {
+                            "checksumValue": "2fd4e1c67a2d28fced849ee1bb76e7391b93eb12", 
+                            "algorithm": "checksumAlgorithm_sha1"
+                        }
+                    ], 
+                    "versionInfo": "Version 0.9.2", 
+                    "licenseDeclared": "(LicenseRef-4 AND LicenseRef-3 AND Apache-2.0 AND LicenseRef-2 AND MPL-1.1 AND LicenseRef-1)", 
+                    "downloadLocation": "http://www.spdx.org/tools", 
+                    "description": "This utility translates and SPDX RDF XML document to a spreadsheet, translates a spreadsheet to an SPDX RDF XML document and translates an SPDX RDFa document to an SPDX RDF XML document."
+                }
+            }
+        ], 
+        "creationInfo": {
+            "comment": "This is an example of an SPDX spreadsheet format", 
+            "creators": [
+                "Tool: SourceAuditor-V1.2", 
+                "Person: Gary O'Neall", 
+                "Organization: Source Auditor Inc."
+            ], 
+            "licenseListVersion": "3.6", 
+            "created": "2010-02-03T00:00:00Z"
+        }, 
+        "externalDocumentRefs": [
+            {
+                "checksum": {
+                    "checksumValue": "d6a770ba38583ed4bb4525bd96e50461655d2759", 
+                    "algorithm": "checksumAlgorithm_sha1"
+                }, 
+                "spdxDocument": "https://spdx.org/spdxdocs/spdx-tools-v2.1-3F2504E0-4F89-41D3-9A0C-0305E82C3301", 
+                "externalDocumentId": "DocumentRef-spdx-tool-2.1"
+            }
+        ], 
+        "documentNamespace": "https://spdx.org/spdxdocs/spdx-example-444504E0-4F89-41D3-9A0C-0305E82C3301", 
+        "annotations": [
+            {
+                "comment": "This is just an example. Some of the non-standard licenses look like they are actually BSD 3 clause licenses", 
+                "annotationType": "REVIEW", 
+                "SPDXID": "SPDXRef-45", 
+                "annotationDate": "2012-06-13T00:00:00Z", 
+                "annotator": "Person: Jim Reviewer"
+            }
+        ],
+        "relationships" : [ {
+    "spdxElementId" : "SPDXRef-DOCUMENT",
+    "relatedSpdxElement" : "SPDXRef-Package",
+    "relationshipType" : "CONTAINS"
+  }, {
+    "spdxElementId" : "SPDXRef-DOCUMENT",
+    "relatedSpdxElement" : "SPDXRef-File",
+    "relationshipType" : "DESCRIBES"
+  }, {
+    "spdxElementId" : "SPDXRef-DOCUMENT",
+    "relatedSpdxElement" : "DocumentRef-spdx-tool-1.2:SPDXRef-ToolsElement",
+    "relationshipType" : "COPY_OF"
+  }, {
+    "spdxElementId" : "SPDXRef-DOCUMENT",
+    "relatedSpdxElement" : "SPDXRef-Package",
+    "relationshipType" : "DESCRIBES"
+  }, {
+    "spdxElementId" : "SPDXRef-Package",
+    "relatedSpdxElement" : "SPDXRef-Saxon",
+    "relationshipType" : "DYNAMIC_LINK"
+  }, {
+    "spdxElementId" : "SPDXRef-Package",
+    "relatedSpdxElement" : "SPDXRef-JenaLib",
+    "relationshipType" : "CONTAINS"
+  }, {
+    "spdxElementId" : "SPDXRef-CommonsLangSrc",
+    "relatedSpdxElement" : "NOASSERTION",
+    "relationshipType" : "GENERATED_FROM"
+  }, {
+    "spdxElementId" : "SPDXRef-JenaLib",
+    "relatedSpdxElement" : "SPDXRef-Package",
+    "relationshipType" : "CONTAINS"
+  }, {
+    "spdxElementId" : "SPDXRef-File",
+    "relatedSpdxElement" : "SPDXRef-fromDoap-0",
+    "relationshipType" : "GENERATED_FROM"
+  } ], 
+        "dataLicense": "CC0-1.0", 
+        "reviewers": [
+            {
+                "comment": "This is just an example.  Some of the non-standard licenses look like they are actually BSD 3 clause licenses", 
+                "reviewer": "Person: Joe Reviewer", 
+                "reviewDate": "2010-02-10T00:00:00Z"
+            }, 
+            {
+                "comment": "Another example reviewer.", 
+                "reviewer": "Person: Suzanne Reviewer", 
+                "reviewDate": "2011-03-13T00:00:00Z"
+            }
+        ], 
+        "hasExtractedLicensingInfos": [
+            {
+                "extractedText": "This package includes the GRDDL parser developed by Hewlett Packard under the following license:\n\u00a9 Copyright 2007 Hewlett-Packard Development Company, LP\n\nRedistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met: \n\nRedistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer. \nRedistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution. \nThe name of the author may not be used to endorse or promote products derived from this software without specific prior written permission. \nTHIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. ", 
+                "licenseId": "LicenseRef-2"
+            }, 
+            {
+                "extractedText": "The CyberNeko Software License, Version 1.0\n\n \n(C) Copyright 2002-2005, Andy Clark.  All rights reserved.\n \nRedistribution and use in source and binary forms, with or without\nmodification, are permitted provided that the following conditions\nare met:\n\n1. Redistributions of source code must retain the above copyright\n   notice, this list of conditions and the following disclaimer. \n\n2. Redistributions in binary form must reproduce the above copyright\n   notice, this list of conditions and the following disclaimer in\n   the documentation and/or other materials provided with the\n   distribution.\n\n3. The end-user documentation included with the redistribution,\n   if any, must include the following acknowledgment:  \n     \"This product includes software developed by Andy Clark.\"\n   Alternately, this acknowledgment may appear in the software itself,\n   if and wherever such third-party acknowledgments normally appear.\n\n4. The names \"CyberNeko\" and \"NekoHTML\" must not be used to endorse\n   or promote products derived from this software without prior \n   written permission. For written permission, please contact \n   andyc@cyberneko.net.\n\n5. Products derived from this software may not be called \"CyberNeko\",\n   nor may \"CyberNeko\" appear in their name, without prior written\n   permission of the author.\n\nTHIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESSED OR IMPLIED\nWARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES\nOF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE\nDISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR OTHER CONTRIBUTORS\nBE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, \nOR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT \nOF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR \nBUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, \nWHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE \nOR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, \nEVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.", 
+                "comment": "This is tye CyperNeko License", 
+                "licenseId": "LicenseRef-3", 
+                "name": "CyberNeko License", 
+                "seeAlso": [
+                    "http://justasample.url.com", 
+                    "http://people.apache.org/~andyc/neko/LICENSE"
+                ]
+            }, 
+            {
+                "extractedText": "/*\n * (c) Copyright 2009 University of Bristol\n * All rights reserved.\n *\n * Redistribution and use in source and binary forms, with or without\n * modification, are permitted provided that the following conditions\n * are met:\n * 1. Redistributions of source code must retain the above copyright\n *    notice, this list of conditions and the following disclaimer.\n * 2. Redistributions in binary form must reproduce the above copyright\n *    notice, this list of conditions and the following disclaimer in the\n *    documentation and/or other materials provided with the distribution.\n * 3. The name of the author may not be used to endorse or promote products\n *    derived from this software without specific prior written permission.\n *\n * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR\n * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES\n * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.\n * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,\n * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT\n * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,\n * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY\n * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT\n * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF\n * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.\n */  ", 
+                "licenseId": "LicenseRef-4"
+            }, 
+            {
+                "extractedText": "/*\n * (c) Copyright 2000, 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009 Hewlett-Packard Development Company, LP\n * All rights reserved.\n *\n * Redistribution and use in source and binary forms, with or without\n * modification, are permitted provided that the following conditions\n * are met:\n * 1. Redistributions of source code must retain the above copyright\n *    notice, this list of conditions and the following disclaimer.\n * 2. Redistributions in binary form must reproduce the above copyright\n *    notice, this list of conditions and the following disclaimer in the\n *    documentation and/or other materials provided with the distribution.\n * 3. The name of the author may not be used to endorse or promote products\n *    derived from this software without specific prior written permission.\n *\n * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR\n * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES\n * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.\n * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,\n * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT\n * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,\n * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY\n * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT\n * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF\n * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.\n */", 
+                "licenseId": "LicenseRef-1"
+            }
+        ], 
+        "spdxVersion": "SPDX-2.1", 
+        "SPDXID": "SPDXRef-DOCUMENT", 
+        "snippets": [
+            {
+                "comment": "This snippet was identified as significant and highlighted in this Apache-2.0 file, when a commercial scanner identified it as being derived from file foo.c in package xyz which is licensed under GPL-2.0-or-later.", 
+                "name": "from linux kernel", 
+                "copyrightText": "Copyright 2008-2010 John Smith", 
+                "licenseConcluded": "Apache-2.0", 
+                "licenseInfoFromSnippet": [
+                    "Apache-2.0"
+                ], 
+                "licenseComments": "The concluded license was taken from package xyz, from which the snippet was copied into the current file. The concluded license information was found in the COPYING.txt file in package xyz.", 
+                "SPDXID": "SPDXRef-Snippet", 
+                "fileId": "SPDXRef-DoapSource"
+            }
+        ]
+    }
+}

--- a/tests/data/parse_anything_test_files/SPDXJsonExample.json.rdf
+++ b/tests/data/parse_anything_test_files/SPDXJsonExample.json.rdf
@@ -1,0 +1,223 @@
+{
+    "Document": {
+        "comment": "This is a sample spreadsheet", 
+        "name": "Sample_Document-V2.1", 
+        "documentDescribes": [
+            {
+                "Package": {
+                    "SPDXID": "SPDXRef-Package", 
+                    "originator": "Organization: SPDX", 
+                    "files": [
+                        {
+                            "File": {
+                                "comment": "This file belongs to Jena", 
+                                "licenseInfoFromFiles": [
+                                    "LicenseRef-1"
+                                ], 
+                                "sha1": "3ab4e1c67a2d28fced849ee1bb76e7391b93f125", 
+                                "name": "Jenna-2.6.3/jena-2.6.3-sources.jar", 
+                                "copyrightText": "(c) Copyright 2000, 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009 Hewlett-Packard Development Company, LP", 
+                                "artifactOf" : [ 
+                                    {
+                                        "name" : "Jena",
+                                        "homePage" : "http://www.openjena.org/",
+                                        "projectUri" : "http://subversion.apache.org/doap.rdf"
+                                    } 
+                                ],
+                                "licenseConcluded": "LicenseRef-1", 
+                                "licenseComments": "This license is used by Jena", 
+                                "checksums": [
+                                    {
+                                        "checksumValue": "3ab4e1c67a2d28fced849ee1bb76e7391b93f125", 
+                                        "algorithm": "checksumAlgorithm_sha1"
+                                    }
+                                ], 
+                                "fileTypes": [
+                                    "fileType_archive"
+                                ], 
+                                "SPDXID": "SPDXRef-File1"
+                            }
+                        }, 
+                        {
+                            "File": {
+                                "licenseInfoFromFiles": [
+                                    "Apache-2.0"
+                                ], 
+                                "sha1": "2fd4e1c67a2d28fced849ee1bb76e7391b93eb12", 
+                                "name": "src/org/spdx/parser/DOAPProject.java", 
+                                "copyrightText": "Copyright 2010, 2011 Source Auditor Inc.", 
+                                "licenseConcluded": "Apache-2.0", 
+                                "checksums": [
+                                    {
+                                        "checksumValue": "2fd4e1c67a2d28fced849ee1bb76e7391b93eb12", 
+                                        "algorithm": "checksumAlgorithm_sha1"
+                                    }
+                                ], 
+                                "fileTypes": [
+                                    "fileType_source"
+                                ], 
+                                "SPDXID": "SPDXRef-File2"
+                            }
+                        }
+                    ], 
+                    "licenseInfoFromFiles": [
+                        "Apache-1.0", 
+                        "LicenseRef-3", 
+                        "MPL-1.1", 
+                        "LicenseRef-2", 
+                        "LicenseRef-4", 
+                        "Apache-2.0", 
+                        "LicenseRef-1"
+                    ], 
+                    "sha1": "2fd4e1c67a2d28fced849ee1bb76e7391b93eb12", 
+                    "name": "SPDX Translator", 
+                    "packageFileName": "spdxtranslator-1.0.zip", 
+                    "licenseComments": "The declared license information can be found in the NOTICE file at the root of the archive file", 
+                    "summary": "SPDX Translator utility", 
+                    "sourceInfo": "Version 1.0 of the SPDX Translator application", 
+                    "copyrightText": " Copyright 2010, 2011 Source Auditor Inc.", 
+                    "packageVerificationCode": {
+                        "packageVerificationCodeValue": "4e3211c67a2d28fced849ee1bb76e7391b93feba", 
+                        "packageVerificationCodeExcludedFiles": [
+                            "SpdxTranslatorSpdx.rdf", 
+                            "SpdxTranslatorSpdx.txt"
+                        ]
+                    }, 
+                    "licenseConcluded": "(Apache-1.0 AND LicenseRef-2 AND MPL-1.1 AND LicenseRef-3 AND LicenseRef-4 AND Apache-2.0 AND LicenseRef-1)", 
+                    "supplier": "Organization: Linux Foundation", 
+                    "attributionTexts" : [ "The GNU C Library is free software.  See the file COPYING.LIB for copying conditions, and LICENSES for notices about a few contributions that require these additional notices to be distributed.  License copyright years may be listed using range notation, e.g., 1996-2015, indicating that every year in the range, inclusive, is a copyrightable year that would otherwise be listed individually." ],
+                    "checksums": [
+                        {
+                            "checksumValue": "2fd4e1c67a2d28fced849ee1bb76e7391b93eb12", 
+                            "algorithm": "checksumAlgorithm_sha1"
+                        }
+                    ], 
+                    "versionInfo": "Version 0.9.2", 
+                    "licenseDeclared": "(LicenseRef-4 AND LicenseRef-3 AND Apache-2.0 AND LicenseRef-2 AND MPL-1.1 AND LicenseRef-1)", 
+                    "downloadLocation": "http://www.spdx.org/tools", 
+                    "description": "This utility translates and SPDX RDF XML document to a spreadsheet, translates a spreadsheet to an SPDX RDF XML document and translates an SPDX RDFa document to an SPDX RDF XML document."
+                }
+            }
+        ], 
+        "creationInfo": {
+            "comment": "This is an example of an SPDX spreadsheet format", 
+            "creators": [
+                "Tool: SourceAuditor-V1.2", 
+                "Person: Gary O'Neall", 
+                "Organization: Source Auditor Inc."
+            ], 
+            "licenseListVersion": "3.6", 
+            "created": "2010-02-03T00:00:00Z"
+        }, 
+        "externalDocumentRefs": [
+            {
+                "checksum": {
+                    "checksumValue": "d6a770ba38583ed4bb4525bd96e50461655d2759", 
+                    "algorithm": "checksumAlgorithm_sha1"
+                }, 
+                "spdxDocument": "https://spdx.org/spdxdocs/spdx-tools-v2.1-3F2504E0-4F89-41D3-9A0C-0305E82C3301", 
+                "externalDocumentId": "DocumentRef-spdx-tool-2.1"
+            }
+        ], 
+        "documentNamespace": "https://spdx.org/spdxdocs/spdx-example-444504E0-4F89-41D3-9A0C-0305E82C3301", 
+        "annotations": [
+            {
+                "comment": "This is just an example. Some of the non-standard licenses look like they are actually BSD 3 clause licenses", 
+                "annotationType": "REVIEW", 
+                "SPDXID": "SPDXRef-45", 
+                "annotationDate": "2012-06-13T00:00:00Z", 
+                "annotator": "Person: Jim Reviewer"
+            }
+        ],
+        "relationships" : [ {
+    "spdxElementId" : "SPDXRef-DOCUMENT",
+    "relatedSpdxElement" : "SPDXRef-Package",
+    "relationshipType" : "CONTAINS"
+  }, {
+    "spdxElementId" : "SPDXRef-DOCUMENT",
+    "relatedSpdxElement" : "SPDXRef-File",
+    "relationshipType" : "DESCRIBES"
+  }, {
+    "spdxElementId" : "SPDXRef-DOCUMENT",
+    "relatedSpdxElement" : "DocumentRef-spdx-tool-1.2:SPDXRef-ToolsElement",
+    "relationshipType" : "COPY_OF"
+  }, {
+    "spdxElementId" : "SPDXRef-DOCUMENT",
+    "relatedSpdxElement" : "SPDXRef-Package",
+    "relationshipType" : "DESCRIBES"
+  }, {
+    "spdxElementId" : "SPDXRef-Package",
+    "relatedSpdxElement" : "SPDXRef-Saxon",
+    "relationshipType" : "DYNAMIC_LINK"
+  }, {
+    "spdxElementId" : "SPDXRef-Package",
+    "relatedSpdxElement" : "SPDXRef-JenaLib",
+    "relationshipType" : "CONTAINS"
+  }, {
+    "spdxElementId" : "SPDXRef-CommonsLangSrc",
+    "relatedSpdxElement" : "NOASSERTION",
+    "relationshipType" : "GENERATED_FROM"
+  }, {
+    "spdxElementId" : "SPDXRef-JenaLib",
+    "relatedSpdxElement" : "SPDXRef-Package",
+    "relationshipType" : "CONTAINS"
+  }, {
+    "spdxElementId" : "SPDXRef-File",
+    "relatedSpdxElement" : "SPDXRef-fromDoap-0",
+    "relationshipType" : "GENERATED_FROM"
+  } ], 
+        "dataLicense": "CC0-1.0", 
+        "reviewers": [
+            {
+                "comment": "This is just an example.  Some of the non-standard licenses look like they are actually BSD 3 clause licenses", 
+                "reviewer": "Person: Joe Reviewer", 
+                "reviewDate": "2010-02-10T00:00:00Z"
+            }, 
+            {
+                "comment": "Another example reviewer.", 
+                "reviewer": "Person: Suzanne Reviewer", 
+                "reviewDate": "2011-03-13T00:00:00Z"
+            }
+        ], 
+        "hasExtractedLicensingInfos": [
+            {
+                "extractedText": "This package includes the GRDDL parser developed by Hewlett Packard under the following license:\n\u00a9 Copyright 2007 Hewlett-Packard Development Company, LP\n\nRedistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met: \n\nRedistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer. \nRedistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution. \nThe name of the author may not be used to endorse or promote products derived from this software without specific prior written permission. \nTHIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. ", 
+                "licenseId": "LicenseRef-2"
+            }, 
+            {
+                "extractedText": "The CyberNeko Software License, Version 1.0\n\n \n(C) Copyright 2002-2005, Andy Clark.  All rights reserved.\n \nRedistribution and use in source and binary forms, with or without\nmodification, are permitted provided that the following conditions\nare met:\n\n1. Redistributions of source code must retain the above copyright\n   notice, this list of conditions and the following disclaimer. \n\n2. Redistributions in binary form must reproduce the above copyright\n   notice, this list of conditions and the following disclaimer in\n   the documentation and/or other materials provided with the\n   distribution.\n\n3. The end-user documentation included with the redistribution,\n   if any, must include the following acknowledgment:  \n     \"This product includes software developed by Andy Clark.\"\n   Alternately, this acknowledgment may appear in the software itself,\n   if and wherever such third-party acknowledgments normally appear.\n\n4. The names \"CyberNeko\" and \"NekoHTML\" must not be used to endorse\n   or promote products derived from this software without prior \n   written permission. For written permission, please contact \n   andyc@cyberneko.net.\n\n5. Products derived from this software may not be called \"CyberNeko\",\n   nor may \"CyberNeko\" appear in their name, without prior written\n   permission of the author.\n\nTHIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESSED OR IMPLIED\nWARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES\nOF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE\nDISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR OTHER CONTRIBUTORS\nBE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, \nOR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT \nOF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR \nBUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, \nWHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE \nOR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, \nEVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.", 
+                "comment": "This is tye CyperNeko License", 
+                "licenseId": "LicenseRef-3", 
+                "name": "CyberNeko License", 
+                "seeAlso": [
+                    "http://justasample.url.com", 
+                    "http://people.apache.org/~andyc/neko/LICENSE"
+                ]
+            }, 
+            {
+                "extractedText": "/*\n * (c) Copyright 2009 University of Bristol\n * All rights reserved.\n *\n * Redistribution and use in source and binary forms, with or without\n * modification, are permitted provided that the following conditions\n * are met:\n * 1. Redistributions of source code must retain the above copyright\n *    notice, this list of conditions and the following disclaimer.\n * 2. Redistributions in binary form must reproduce the above copyright\n *    notice, this list of conditions and the following disclaimer in the\n *    documentation and/or other materials provided with the distribution.\n * 3. The name of the author may not be used to endorse or promote products\n *    derived from this software without specific prior written permission.\n *\n * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR\n * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES\n * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.\n * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,\n * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT\n * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,\n * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY\n * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT\n * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF\n * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.\n */  ", 
+                "licenseId": "LicenseRef-4"
+            }, 
+            {
+                "extractedText": "/*\n * (c) Copyright 2000, 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009 Hewlett-Packard Development Company, LP\n * All rights reserved.\n *\n * Redistribution and use in source and binary forms, with or without\n * modification, are permitted provided that the following conditions\n * are met:\n * 1. Redistributions of source code must retain the above copyright\n *    notice, this list of conditions and the following disclaimer.\n * 2. Redistributions in binary form must reproduce the above copyright\n *    notice, this list of conditions and the following disclaimer in the\n *    documentation and/or other materials provided with the distribution.\n * 3. The name of the author may not be used to endorse or promote products\n *    derived from this software without specific prior written permission.\n *\n * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR\n * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES\n * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.\n * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,\n * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT\n * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,\n * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY\n * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT\n * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF\n * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.\n */", 
+                "licenseId": "LicenseRef-1"
+            }
+        ], 
+        "spdxVersion": "SPDX-2.1", 
+        "SPDXID": "SPDXRef-DOCUMENT", 
+        "snippets": [
+            {
+                "comment": "This snippet was identified as significant and highlighted in this Apache-2.0 file, when a commercial scanner identified it as being derived from file foo.c in package xyz which is licensed under GPL-2.0-or-later.", 
+                "name": "from linux kernel", 
+                "copyrightText": "Copyright 2008-2010 John Smith", 
+                "licenseConcluded": "Apache-2.0", 
+                "licenseInfoFromSnippet": [
+                    "Apache-2.0"
+                ], 
+                "licenseComments": "The concluded license was taken from package xyz, from which the snippet was copied into the current file. The concluded license information was found in the COPYING.txt file in package xyz.", 
+                "SPDXID": "SPDXRef-Snippet", 
+                "fileId": "SPDXRef-DoapSource"
+            }
+        ]
+    }
+}

--- a/tests/data/parse_anything_test_files/SPDXJsonExample.json.spdx
+++ b/tests/data/parse_anything_test_files/SPDXJsonExample.json.spdx
@@ -1,0 +1,223 @@
+{
+    "Document": {
+        "comment": "This is a sample spreadsheet", 
+        "name": "Sample_Document-V2.1", 
+        "documentDescribes": [
+            {
+                "Package": {
+                    "SPDXID": "SPDXRef-Package", 
+                    "originator": "Organization: SPDX", 
+                    "files": [
+                        {
+                            "File": {
+                                "comment": "This file belongs to Jena", 
+                                "licenseInfoFromFiles": [
+                                    "LicenseRef-1"
+                                ], 
+                                "sha1": "3ab4e1c67a2d28fced849ee1bb76e7391b93f125", 
+                                "name": "Jenna-2.6.3/jena-2.6.3-sources.jar", 
+                                "copyrightText": "(c) Copyright 2000, 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009 Hewlett-Packard Development Company, LP", 
+                                "artifactOf" : [ 
+                                    {
+                                        "name" : "Jena",
+                                        "homePage" : "http://www.openjena.org/",
+                                        "projectUri" : "http://subversion.apache.org/doap.rdf"
+                                    } 
+                                ],
+                                "licenseConcluded": "LicenseRef-1", 
+                                "licenseComments": "This license is used by Jena", 
+                                "checksums": [
+                                    {
+                                        "checksumValue": "3ab4e1c67a2d28fced849ee1bb76e7391b93f125", 
+                                        "algorithm": "checksumAlgorithm_sha1"
+                                    }
+                                ], 
+                                "fileTypes": [
+                                    "fileType_archive"
+                                ], 
+                                "SPDXID": "SPDXRef-File1"
+                            }
+                        }, 
+                        {
+                            "File": {
+                                "licenseInfoFromFiles": [
+                                    "Apache-2.0"
+                                ], 
+                                "sha1": "2fd4e1c67a2d28fced849ee1bb76e7391b93eb12", 
+                                "name": "src/org/spdx/parser/DOAPProject.java", 
+                                "copyrightText": "Copyright 2010, 2011 Source Auditor Inc.", 
+                                "licenseConcluded": "Apache-2.0", 
+                                "checksums": [
+                                    {
+                                        "checksumValue": "2fd4e1c67a2d28fced849ee1bb76e7391b93eb12", 
+                                        "algorithm": "checksumAlgorithm_sha1"
+                                    }
+                                ], 
+                                "fileTypes": [
+                                    "fileType_source"
+                                ], 
+                                "SPDXID": "SPDXRef-File2"
+                            }
+                        }
+                    ], 
+                    "licenseInfoFromFiles": [
+                        "Apache-1.0", 
+                        "LicenseRef-3", 
+                        "MPL-1.1", 
+                        "LicenseRef-2", 
+                        "LicenseRef-4", 
+                        "Apache-2.0", 
+                        "LicenseRef-1"
+                    ], 
+                    "sha1": "2fd4e1c67a2d28fced849ee1bb76e7391b93eb12", 
+                    "name": "SPDX Translator", 
+                    "packageFileName": "spdxtranslator-1.0.zip", 
+                    "licenseComments": "The declared license information can be found in the NOTICE file at the root of the archive file", 
+                    "summary": "SPDX Translator utility", 
+                    "sourceInfo": "Version 1.0 of the SPDX Translator application", 
+                    "copyrightText": " Copyright 2010, 2011 Source Auditor Inc.", 
+                    "packageVerificationCode": {
+                        "packageVerificationCodeValue": "4e3211c67a2d28fced849ee1bb76e7391b93feba", 
+                        "packageVerificationCodeExcludedFiles": [
+                            "SpdxTranslatorSpdx.rdf", 
+                            "SpdxTranslatorSpdx.txt"
+                        ]
+                    }, 
+                    "licenseConcluded": "(Apache-1.0 AND LicenseRef-2 AND MPL-1.1 AND LicenseRef-3 AND LicenseRef-4 AND Apache-2.0 AND LicenseRef-1)", 
+                    "supplier": "Organization: Linux Foundation", 
+                    "attributionTexts" : [ "The GNU C Library is free software.  See the file COPYING.LIB for copying conditions, and LICENSES for notices about a few contributions that require these additional notices to be distributed.  License copyright years may be listed using range notation, e.g., 1996-2015, indicating that every year in the range, inclusive, is a copyrightable year that would otherwise be listed individually." ],
+                    "checksums": [
+                        {
+                            "checksumValue": "2fd4e1c67a2d28fced849ee1bb76e7391b93eb12", 
+                            "algorithm": "checksumAlgorithm_sha1"
+                        }
+                    ], 
+                    "versionInfo": "Version 0.9.2", 
+                    "licenseDeclared": "(LicenseRef-4 AND LicenseRef-3 AND Apache-2.0 AND LicenseRef-2 AND MPL-1.1 AND LicenseRef-1)", 
+                    "downloadLocation": "http://www.spdx.org/tools", 
+                    "description": "This utility translates and SPDX RDF XML document to a spreadsheet, translates a spreadsheet to an SPDX RDF XML document and translates an SPDX RDFa document to an SPDX RDF XML document."
+                }
+            }
+        ], 
+        "creationInfo": {
+            "comment": "This is an example of an SPDX spreadsheet format", 
+            "creators": [
+                "Tool: SourceAuditor-V1.2", 
+                "Person: Gary O'Neall", 
+                "Organization: Source Auditor Inc."
+            ], 
+            "licenseListVersion": "3.6", 
+            "created": "2010-02-03T00:00:00Z"
+        }, 
+        "externalDocumentRefs": [
+            {
+                "checksum": {
+                    "checksumValue": "d6a770ba38583ed4bb4525bd96e50461655d2759", 
+                    "algorithm": "checksumAlgorithm_sha1"
+                }, 
+                "spdxDocument": "https://spdx.org/spdxdocs/spdx-tools-v2.1-3F2504E0-4F89-41D3-9A0C-0305E82C3301", 
+                "externalDocumentId": "DocumentRef-spdx-tool-2.1"
+            }
+        ], 
+        "documentNamespace": "https://spdx.org/spdxdocs/spdx-example-444504E0-4F89-41D3-9A0C-0305E82C3301", 
+        "annotations": [
+            {
+                "comment": "This is just an example. Some of the non-standard licenses look like they are actually BSD 3 clause licenses", 
+                "annotationType": "REVIEW", 
+                "SPDXID": "SPDXRef-45", 
+                "annotationDate": "2012-06-13T00:00:00Z", 
+                "annotator": "Person: Jim Reviewer"
+            }
+        ],
+        "relationships" : [ {
+    "spdxElementId" : "SPDXRef-DOCUMENT",
+    "relatedSpdxElement" : "SPDXRef-Package",
+    "relationshipType" : "CONTAINS"
+  }, {
+    "spdxElementId" : "SPDXRef-DOCUMENT",
+    "relatedSpdxElement" : "SPDXRef-File",
+    "relationshipType" : "DESCRIBES"
+  }, {
+    "spdxElementId" : "SPDXRef-DOCUMENT",
+    "relatedSpdxElement" : "DocumentRef-spdx-tool-1.2:SPDXRef-ToolsElement",
+    "relationshipType" : "COPY_OF"
+  }, {
+    "spdxElementId" : "SPDXRef-DOCUMENT",
+    "relatedSpdxElement" : "SPDXRef-Package",
+    "relationshipType" : "DESCRIBES"
+  }, {
+    "spdxElementId" : "SPDXRef-Package",
+    "relatedSpdxElement" : "SPDXRef-Saxon",
+    "relationshipType" : "DYNAMIC_LINK"
+  }, {
+    "spdxElementId" : "SPDXRef-Package",
+    "relatedSpdxElement" : "SPDXRef-JenaLib",
+    "relationshipType" : "CONTAINS"
+  }, {
+    "spdxElementId" : "SPDXRef-CommonsLangSrc",
+    "relatedSpdxElement" : "NOASSERTION",
+    "relationshipType" : "GENERATED_FROM"
+  }, {
+    "spdxElementId" : "SPDXRef-JenaLib",
+    "relatedSpdxElement" : "SPDXRef-Package",
+    "relationshipType" : "CONTAINS"
+  }, {
+    "spdxElementId" : "SPDXRef-File",
+    "relatedSpdxElement" : "SPDXRef-fromDoap-0",
+    "relationshipType" : "GENERATED_FROM"
+  } ], 
+        "dataLicense": "CC0-1.0", 
+        "reviewers": [
+            {
+                "comment": "This is just an example.  Some of the non-standard licenses look like they are actually BSD 3 clause licenses", 
+                "reviewer": "Person: Joe Reviewer", 
+                "reviewDate": "2010-02-10T00:00:00Z"
+            }, 
+            {
+                "comment": "Another example reviewer.", 
+                "reviewer": "Person: Suzanne Reviewer", 
+                "reviewDate": "2011-03-13T00:00:00Z"
+            }
+        ], 
+        "hasExtractedLicensingInfos": [
+            {
+                "extractedText": "This package includes the GRDDL parser developed by Hewlett Packard under the following license:\n\u00a9 Copyright 2007 Hewlett-Packard Development Company, LP\n\nRedistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met: \n\nRedistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer. \nRedistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution. \nThe name of the author may not be used to endorse or promote products derived from this software without specific prior written permission. \nTHIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. ", 
+                "licenseId": "LicenseRef-2"
+            }, 
+            {
+                "extractedText": "The CyberNeko Software License, Version 1.0\n\n \n(C) Copyright 2002-2005, Andy Clark.  All rights reserved.\n \nRedistribution and use in source and binary forms, with or without\nmodification, are permitted provided that the following conditions\nare met:\n\n1. Redistributions of source code must retain the above copyright\n   notice, this list of conditions and the following disclaimer. \n\n2. Redistributions in binary form must reproduce the above copyright\n   notice, this list of conditions and the following disclaimer in\n   the documentation and/or other materials provided with the\n   distribution.\n\n3. The end-user documentation included with the redistribution,\n   if any, must include the following acknowledgment:  \n     \"This product includes software developed by Andy Clark.\"\n   Alternately, this acknowledgment may appear in the software itself,\n   if and wherever such third-party acknowledgments normally appear.\n\n4. The names \"CyberNeko\" and \"NekoHTML\" must not be used to endorse\n   or promote products derived from this software without prior \n   written permission. For written permission, please contact \n   andyc@cyberneko.net.\n\n5. Products derived from this software may not be called \"CyberNeko\",\n   nor may \"CyberNeko\" appear in their name, without prior written\n   permission of the author.\n\nTHIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESSED OR IMPLIED\nWARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES\nOF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE\nDISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR OTHER CONTRIBUTORS\nBE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, \nOR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT \nOF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR \nBUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, \nWHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE \nOR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, \nEVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.", 
+                "comment": "This is tye CyperNeko License", 
+                "licenseId": "LicenseRef-3", 
+                "name": "CyberNeko License", 
+                "seeAlso": [
+                    "http://justasample.url.com", 
+                    "http://people.apache.org/~andyc/neko/LICENSE"
+                ]
+            }, 
+            {
+                "extractedText": "/*\n * (c) Copyright 2009 University of Bristol\n * All rights reserved.\n *\n * Redistribution and use in source and binary forms, with or without\n * modification, are permitted provided that the following conditions\n * are met:\n * 1. Redistributions of source code must retain the above copyright\n *    notice, this list of conditions and the following disclaimer.\n * 2. Redistributions in binary form must reproduce the above copyright\n *    notice, this list of conditions and the following disclaimer in the\n *    documentation and/or other materials provided with the distribution.\n * 3. The name of the author may not be used to endorse or promote products\n *    derived from this software without specific prior written permission.\n *\n * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR\n * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES\n * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.\n * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,\n * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT\n * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,\n * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY\n * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT\n * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF\n * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.\n */  ", 
+                "licenseId": "LicenseRef-4"
+            }, 
+            {
+                "extractedText": "/*\n * (c) Copyright 2000, 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009 Hewlett-Packard Development Company, LP\n * All rights reserved.\n *\n * Redistribution and use in source and binary forms, with or without\n * modification, are permitted provided that the following conditions\n * are met:\n * 1. Redistributions of source code must retain the above copyright\n *    notice, this list of conditions and the following disclaimer.\n * 2. Redistributions in binary form must reproduce the above copyright\n *    notice, this list of conditions and the following disclaimer in the\n *    documentation and/or other materials provided with the distribution.\n * 3. The name of the author may not be used to endorse or promote products\n *    derived from this software without specific prior written permission.\n *\n * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR\n * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES\n * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.\n * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,\n * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT\n * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,\n * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY\n * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT\n * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF\n * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.\n */", 
+                "licenseId": "LicenseRef-1"
+            }
+        ], 
+        "spdxVersion": "SPDX-2.1", 
+        "SPDXID": "SPDXRef-DOCUMENT", 
+        "snippets": [
+            {
+                "comment": "This snippet was identified as significant and highlighted in this Apache-2.0 file, when a commercial scanner identified it as being derived from file foo.c in package xyz which is licensed under GPL-2.0-or-later.", 
+                "name": "from linux kernel", 
+                "copyrightText": "Copyright 2008-2010 John Smith", 
+                "licenseConcluded": "Apache-2.0", 
+                "licenseInfoFromSnippet": [
+                    "Apache-2.0"
+                ], 
+                "licenseComments": "The concluded license was taken from package xyz, from which the snippet was copied into the current file. The concluded license information was found in the COPYING.txt file in package xyz.", 
+                "SPDXID": "SPDXRef-Snippet", 
+                "fileId": "SPDXRef-DoapSource"
+            }
+        ]
+    }
+}

--- a/tests/data/parse_anything_test_files/SPDXJsonExample.json.spdx.yml
+++ b/tests/data/parse_anything_test_files/SPDXJsonExample.json.spdx.yml
@@ -1,0 +1,223 @@
+{
+    "Document": {
+        "comment": "This is a sample spreadsheet", 
+        "name": "Sample_Document-V2.1", 
+        "documentDescribes": [
+            {
+                "Package": {
+                    "SPDXID": "SPDXRef-Package", 
+                    "originator": "Organization: SPDX", 
+                    "files": [
+                        {
+                            "File": {
+                                "comment": "This file belongs to Jena", 
+                                "licenseInfoFromFiles": [
+                                    "LicenseRef-1"
+                                ], 
+                                "sha1": "3ab4e1c67a2d28fced849ee1bb76e7391b93f125", 
+                                "name": "Jenna-2.6.3/jena-2.6.3-sources.jar", 
+                                "copyrightText": "(c) Copyright 2000, 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009 Hewlett-Packard Development Company, LP", 
+                                "artifactOf" : [ 
+                                    {
+                                        "name" : "Jena",
+                                        "homePage" : "http://www.openjena.org/",
+                                        "projectUri" : "http://subversion.apache.org/doap.rdf"
+                                    } 
+                                ],
+                                "licenseConcluded": "LicenseRef-1", 
+                                "licenseComments": "This license is used by Jena", 
+                                "checksums": [
+                                    {
+                                        "checksumValue": "3ab4e1c67a2d28fced849ee1bb76e7391b93f125", 
+                                        "algorithm": "checksumAlgorithm_sha1"
+                                    }
+                                ], 
+                                "fileTypes": [
+                                    "fileType_archive"
+                                ], 
+                                "SPDXID": "SPDXRef-File1"
+                            }
+                        }, 
+                        {
+                            "File": {
+                                "licenseInfoFromFiles": [
+                                    "Apache-2.0"
+                                ], 
+                                "sha1": "2fd4e1c67a2d28fced849ee1bb76e7391b93eb12", 
+                                "name": "src/org/spdx/parser/DOAPProject.java", 
+                                "copyrightText": "Copyright 2010, 2011 Source Auditor Inc.", 
+                                "licenseConcluded": "Apache-2.0", 
+                                "checksums": [
+                                    {
+                                        "checksumValue": "2fd4e1c67a2d28fced849ee1bb76e7391b93eb12", 
+                                        "algorithm": "checksumAlgorithm_sha1"
+                                    }
+                                ], 
+                                "fileTypes": [
+                                    "fileType_source"
+                                ], 
+                                "SPDXID": "SPDXRef-File2"
+                            }
+                        }
+                    ], 
+                    "licenseInfoFromFiles": [
+                        "Apache-1.0", 
+                        "LicenseRef-3", 
+                        "MPL-1.1", 
+                        "LicenseRef-2", 
+                        "LicenseRef-4", 
+                        "Apache-2.0", 
+                        "LicenseRef-1"
+                    ], 
+                    "sha1": "2fd4e1c67a2d28fced849ee1bb76e7391b93eb12", 
+                    "name": "SPDX Translator", 
+                    "packageFileName": "spdxtranslator-1.0.zip", 
+                    "licenseComments": "The declared license information can be found in the NOTICE file at the root of the archive file", 
+                    "summary": "SPDX Translator utility", 
+                    "sourceInfo": "Version 1.0 of the SPDX Translator application", 
+                    "copyrightText": " Copyright 2010, 2011 Source Auditor Inc.", 
+                    "packageVerificationCode": {
+                        "packageVerificationCodeValue": "4e3211c67a2d28fced849ee1bb76e7391b93feba", 
+                        "packageVerificationCodeExcludedFiles": [
+                            "SpdxTranslatorSpdx.rdf", 
+                            "SpdxTranslatorSpdx.txt"
+                        ]
+                    }, 
+                    "licenseConcluded": "(Apache-1.0 AND LicenseRef-2 AND MPL-1.1 AND LicenseRef-3 AND LicenseRef-4 AND Apache-2.0 AND LicenseRef-1)", 
+                    "supplier": "Organization: Linux Foundation", 
+                    "attributionTexts" : [ "The GNU C Library is free software.  See the file COPYING.LIB for copying conditions, and LICENSES for notices about a few contributions that require these additional notices to be distributed.  License copyright years may be listed using range notation, e.g., 1996-2015, indicating that every year in the range, inclusive, is a copyrightable year that would otherwise be listed individually." ],
+                    "checksums": [
+                        {
+                            "checksumValue": "2fd4e1c67a2d28fced849ee1bb76e7391b93eb12", 
+                            "algorithm": "checksumAlgorithm_sha1"
+                        }
+                    ], 
+                    "versionInfo": "Version 0.9.2", 
+                    "licenseDeclared": "(LicenseRef-4 AND LicenseRef-3 AND Apache-2.0 AND LicenseRef-2 AND MPL-1.1 AND LicenseRef-1)", 
+                    "downloadLocation": "http://www.spdx.org/tools", 
+                    "description": "This utility translates and SPDX RDF XML document to a spreadsheet, translates a spreadsheet to an SPDX RDF XML document and translates an SPDX RDFa document to an SPDX RDF XML document."
+                }
+            }
+        ], 
+        "creationInfo": {
+            "comment": "This is an example of an SPDX spreadsheet format", 
+            "creators": [
+                "Tool: SourceAuditor-V1.2", 
+                "Person: Gary O'Neall", 
+                "Organization: Source Auditor Inc."
+            ], 
+            "licenseListVersion": "3.6", 
+            "created": "2010-02-03T00:00:00Z"
+        }, 
+        "externalDocumentRefs": [
+            {
+                "checksum": {
+                    "checksumValue": "d6a770ba38583ed4bb4525bd96e50461655d2759", 
+                    "algorithm": "checksumAlgorithm_sha1"
+                }, 
+                "spdxDocument": "https://spdx.org/spdxdocs/spdx-tools-v2.1-3F2504E0-4F89-41D3-9A0C-0305E82C3301", 
+                "externalDocumentId": "DocumentRef-spdx-tool-2.1"
+            }
+        ], 
+        "documentNamespace": "https://spdx.org/spdxdocs/spdx-example-444504E0-4F89-41D3-9A0C-0305E82C3301", 
+        "annotations": [
+            {
+                "comment": "This is just an example. Some of the non-standard licenses look like they are actually BSD 3 clause licenses", 
+                "annotationType": "REVIEW", 
+                "SPDXID": "SPDXRef-45", 
+                "annotationDate": "2012-06-13T00:00:00Z", 
+                "annotator": "Person: Jim Reviewer"
+            }
+        ],
+        "relationships" : [ {
+    "spdxElementId" : "SPDXRef-DOCUMENT",
+    "relatedSpdxElement" : "SPDXRef-Package",
+    "relationshipType" : "CONTAINS"
+  }, {
+    "spdxElementId" : "SPDXRef-DOCUMENT",
+    "relatedSpdxElement" : "SPDXRef-File",
+    "relationshipType" : "DESCRIBES"
+  }, {
+    "spdxElementId" : "SPDXRef-DOCUMENT",
+    "relatedSpdxElement" : "DocumentRef-spdx-tool-1.2:SPDXRef-ToolsElement",
+    "relationshipType" : "COPY_OF"
+  }, {
+    "spdxElementId" : "SPDXRef-DOCUMENT",
+    "relatedSpdxElement" : "SPDXRef-Package",
+    "relationshipType" : "DESCRIBES"
+  }, {
+    "spdxElementId" : "SPDXRef-Package",
+    "relatedSpdxElement" : "SPDXRef-Saxon",
+    "relationshipType" : "DYNAMIC_LINK"
+  }, {
+    "spdxElementId" : "SPDXRef-Package",
+    "relatedSpdxElement" : "SPDXRef-JenaLib",
+    "relationshipType" : "CONTAINS"
+  }, {
+    "spdxElementId" : "SPDXRef-CommonsLangSrc",
+    "relatedSpdxElement" : "NOASSERTION",
+    "relationshipType" : "GENERATED_FROM"
+  }, {
+    "spdxElementId" : "SPDXRef-JenaLib",
+    "relatedSpdxElement" : "SPDXRef-Package",
+    "relationshipType" : "CONTAINS"
+  }, {
+    "spdxElementId" : "SPDXRef-File",
+    "relatedSpdxElement" : "SPDXRef-fromDoap-0",
+    "relationshipType" : "GENERATED_FROM"
+  } ], 
+        "dataLicense": "CC0-1.0", 
+        "reviewers": [
+            {
+                "comment": "This is just an example.  Some of the non-standard licenses look like they are actually BSD 3 clause licenses", 
+                "reviewer": "Person: Joe Reviewer", 
+                "reviewDate": "2010-02-10T00:00:00Z"
+            }, 
+            {
+                "comment": "Another example reviewer.", 
+                "reviewer": "Person: Suzanne Reviewer", 
+                "reviewDate": "2011-03-13T00:00:00Z"
+            }
+        ], 
+        "hasExtractedLicensingInfos": [
+            {
+                "extractedText": "This package includes the GRDDL parser developed by Hewlett Packard under the following license:\n\u00a9 Copyright 2007 Hewlett-Packard Development Company, LP\n\nRedistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met: \n\nRedistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer. \nRedistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution. \nThe name of the author may not be used to endorse or promote products derived from this software without specific prior written permission. \nTHIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. ", 
+                "licenseId": "LicenseRef-2"
+            }, 
+            {
+                "extractedText": "The CyberNeko Software License, Version 1.0\n\n \n(C) Copyright 2002-2005, Andy Clark.  All rights reserved.\n \nRedistribution and use in source and binary forms, with or without\nmodification, are permitted provided that the following conditions\nare met:\n\n1. Redistributions of source code must retain the above copyright\n   notice, this list of conditions and the following disclaimer. \n\n2. Redistributions in binary form must reproduce the above copyright\n   notice, this list of conditions and the following disclaimer in\n   the documentation and/or other materials provided with the\n   distribution.\n\n3. The end-user documentation included with the redistribution,\n   if any, must include the following acknowledgment:  \n     \"This product includes software developed by Andy Clark.\"\n   Alternately, this acknowledgment may appear in the software itself,\n   if and wherever such third-party acknowledgments normally appear.\n\n4. The names \"CyberNeko\" and \"NekoHTML\" must not be used to endorse\n   or promote products derived from this software without prior \n   written permission. For written permission, please contact \n   andyc@cyberneko.net.\n\n5. Products derived from this software may not be called \"CyberNeko\",\n   nor may \"CyberNeko\" appear in their name, without prior written\n   permission of the author.\n\nTHIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESSED OR IMPLIED\nWARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES\nOF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE\nDISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR OTHER CONTRIBUTORS\nBE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, \nOR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT \nOF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR \nBUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, \nWHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE \nOR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, \nEVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.", 
+                "comment": "This is tye CyperNeko License", 
+                "licenseId": "LicenseRef-3", 
+                "name": "CyberNeko License", 
+                "seeAlso": [
+                    "http://justasample.url.com", 
+                    "http://people.apache.org/~andyc/neko/LICENSE"
+                ]
+            }, 
+            {
+                "extractedText": "/*\n * (c) Copyright 2009 University of Bristol\n * All rights reserved.\n *\n * Redistribution and use in source and binary forms, with or without\n * modification, are permitted provided that the following conditions\n * are met:\n * 1. Redistributions of source code must retain the above copyright\n *    notice, this list of conditions and the following disclaimer.\n * 2. Redistributions in binary form must reproduce the above copyright\n *    notice, this list of conditions and the following disclaimer in the\n *    documentation and/or other materials provided with the distribution.\n * 3. The name of the author may not be used to endorse or promote products\n *    derived from this software without specific prior written permission.\n *\n * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR\n * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES\n * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.\n * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,\n * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT\n * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,\n * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY\n * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT\n * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF\n * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.\n */  ", 
+                "licenseId": "LicenseRef-4"
+            }, 
+            {
+                "extractedText": "/*\n * (c) Copyright 2000, 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009 Hewlett-Packard Development Company, LP\n * All rights reserved.\n *\n * Redistribution and use in source and binary forms, with or without\n * modification, are permitted provided that the following conditions\n * are met:\n * 1. Redistributions of source code must retain the above copyright\n *    notice, this list of conditions and the following disclaimer.\n * 2. Redistributions in binary form must reproduce the above copyright\n *    notice, this list of conditions and the following disclaimer in the\n *    documentation and/or other materials provided with the distribution.\n * 3. The name of the author may not be used to endorse or promote products\n *    derived from this software without specific prior written permission.\n *\n * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR\n * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES\n * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.\n * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,\n * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT\n * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,\n * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY\n * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT\n * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF\n * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.\n */", 
+                "licenseId": "LicenseRef-1"
+            }
+        ], 
+        "spdxVersion": "SPDX-2.1", 
+        "SPDXID": "SPDXRef-DOCUMENT", 
+        "snippets": [
+            {
+                "comment": "This snippet was identified as significant and highlighted in this Apache-2.0 file, when a commercial scanner identified it as being derived from file foo.c in package xyz which is licensed under GPL-2.0-or-later.", 
+                "name": "from linux kernel", 
+                "copyrightText": "Copyright 2008-2010 John Smith", 
+                "licenseConcluded": "Apache-2.0", 
+                "licenseInfoFromSnippet": [
+                    "Apache-2.0"
+                ], 
+                "licenseComments": "The concluded license was taken from package xyz, from which the snippet was copied into the current file. The concluded license information was found in the COPYING.txt file in package xyz.", 
+                "SPDXID": "SPDXRef-Snippet", 
+                "fileId": "SPDXRef-DoapSource"
+            }
+        ]
+    }
+}

--- a/tests/data/parse_anything_test_files/SPDXJsonExample.json.tag
+++ b/tests/data/parse_anything_test_files/SPDXJsonExample.json.tag
@@ -1,0 +1,223 @@
+{
+    "Document": {
+        "comment": "This is a sample spreadsheet", 
+        "name": "Sample_Document-V2.1", 
+        "documentDescribes": [
+            {
+                "Package": {
+                    "SPDXID": "SPDXRef-Package", 
+                    "originator": "Organization: SPDX", 
+                    "files": [
+                        {
+                            "File": {
+                                "comment": "This file belongs to Jena", 
+                                "licenseInfoFromFiles": [
+                                    "LicenseRef-1"
+                                ], 
+                                "sha1": "3ab4e1c67a2d28fced849ee1bb76e7391b93f125", 
+                                "name": "Jenna-2.6.3/jena-2.6.3-sources.jar", 
+                                "copyrightText": "(c) Copyright 2000, 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009 Hewlett-Packard Development Company, LP", 
+                                "artifactOf" : [ 
+                                    {
+                                        "name" : "Jena",
+                                        "homePage" : "http://www.openjena.org/",
+                                        "projectUri" : "http://subversion.apache.org/doap.rdf"
+                                    } 
+                                ],
+                                "licenseConcluded": "LicenseRef-1", 
+                                "licenseComments": "This license is used by Jena", 
+                                "checksums": [
+                                    {
+                                        "checksumValue": "3ab4e1c67a2d28fced849ee1bb76e7391b93f125", 
+                                        "algorithm": "checksumAlgorithm_sha1"
+                                    }
+                                ], 
+                                "fileTypes": [
+                                    "fileType_archive"
+                                ], 
+                                "SPDXID": "SPDXRef-File1"
+                            }
+                        }, 
+                        {
+                            "File": {
+                                "licenseInfoFromFiles": [
+                                    "Apache-2.0"
+                                ], 
+                                "sha1": "2fd4e1c67a2d28fced849ee1bb76e7391b93eb12", 
+                                "name": "src/org/spdx/parser/DOAPProject.java", 
+                                "copyrightText": "Copyright 2010, 2011 Source Auditor Inc.", 
+                                "licenseConcluded": "Apache-2.0", 
+                                "checksums": [
+                                    {
+                                        "checksumValue": "2fd4e1c67a2d28fced849ee1bb76e7391b93eb12", 
+                                        "algorithm": "checksumAlgorithm_sha1"
+                                    }
+                                ], 
+                                "fileTypes": [
+                                    "fileType_source"
+                                ], 
+                                "SPDXID": "SPDXRef-File2"
+                            }
+                        }
+                    ], 
+                    "licenseInfoFromFiles": [
+                        "Apache-1.0", 
+                        "LicenseRef-3", 
+                        "MPL-1.1", 
+                        "LicenseRef-2", 
+                        "LicenseRef-4", 
+                        "Apache-2.0", 
+                        "LicenseRef-1"
+                    ], 
+                    "sha1": "2fd4e1c67a2d28fced849ee1bb76e7391b93eb12", 
+                    "name": "SPDX Translator", 
+                    "packageFileName": "spdxtranslator-1.0.zip", 
+                    "licenseComments": "The declared license information can be found in the NOTICE file at the root of the archive file", 
+                    "summary": "SPDX Translator utility", 
+                    "sourceInfo": "Version 1.0 of the SPDX Translator application", 
+                    "copyrightText": " Copyright 2010, 2011 Source Auditor Inc.", 
+                    "packageVerificationCode": {
+                        "packageVerificationCodeValue": "4e3211c67a2d28fced849ee1bb76e7391b93feba", 
+                        "packageVerificationCodeExcludedFiles": [
+                            "SpdxTranslatorSpdx.rdf", 
+                            "SpdxTranslatorSpdx.txt"
+                        ]
+                    }, 
+                    "licenseConcluded": "(Apache-1.0 AND LicenseRef-2 AND MPL-1.1 AND LicenseRef-3 AND LicenseRef-4 AND Apache-2.0 AND LicenseRef-1)", 
+                    "supplier": "Organization: Linux Foundation", 
+                    "attributionTexts" : [ "The GNU C Library is free software.  See the file COPYING.LIB for copying conditions, and LICENSES for notices about a few contributions that require these additional notices to be distributed.  License copyright years may be listed using range notation, e.g., 1996-2015, indicating that every year in the range, inclusive, is a copyrightable year that would otherwise be listed individually." ],
+                    "checksums": [
+                        {
+                            "checksumValue": "2fd4e1c67a2d28fced849ee1bb76e7391b93eb12", 
+                            "algorithm": "checksumAlgorithm_sha1"
+                        }
+                    ], 
+                    "versionInfo": "Version 0.9.2", 
+                    "licenseDeclared": "(LicenseRef-4 AND LicenseRef-3 AND Apache-2.0 AND LicenseRef-2 AND MPL-1.1 AND LicenseRef-1)", 
+                    "downloadLocation": "http://www.spdx.org/tools", 
+                    "description": "This utility translates and SPDX RDF XML document to a spreadsheet, translates a spreadsheet to an SPDX RDF XML document and translates an SPDX RDFa document to an SPDX RDF XML document."
+                }
+            }
+        ], 
+        "creationInfo": {
+            "comment": "This is an example of an SPDX spreadsheet format", 
+            "creators": [
+                "Tool: SourceAuditor-V1.2", 
+                "Person: Gary O'Neall", 
+                "Organization: Source Auditor Inc."
+            ], 
+            "licenseListVersion": "3.6", 
+            "created": "2010-02-03T00:00:00Z"
+        }, 
+        "externalDocumentRefs": [
+            {
+                "checksum": {
+                    "checksumValue": "d6a770ba38583ed4bb4525bd96e50461655d2759", 
+                    "algorithm": "checksumAlgorithm_sha1"
+                }, 
+                "spdxDocument": "https://spdx.org/spdxdocs/spdx-tools-v2.1-3F2504E0-4F89-41D3-9A0C-0305E82C3301", 
+                "externalDocumentId": "DocumentRef-spdx-tool-2.1"
+            }
+        ], 
+        "documentNamespace": "https://spdx.org/spdxdocs/spdx-example-444504E0-4F89-41D3-9A0C-0305E82C3301", 
+        "annotations": [
+            {
+                "comment": "This is just an example. Some of the non-standard licenses look like they are actually BSD 3 clause licenses", 
+                "annotationType": "REVIEW", 
+                "SPDXID": "SPDXRef-45", 
+                "annotationDate": "2012-06-13T00:00:00Z", 
+                "annotator": "Person: Jim Reviewer"
+            }
+        ],
+        "relationships" : [ {
+    "spdxElementId" : "SPDXRef-DOCUMENT",
+    "relatedSpdxElement" : "SPDXRef-Package",
+    "relationshipType" : "CONTAINS"
+  }, {
+    "spdxElementId" : "SPDXRef-DOCUMENT",
+    "relatedSpdxElement" : "SPDXRef-File",
+    "relationshipType" : "DESCRIBES"
+  }, {
+    "spdxElementId" : "SPDXRef-DOCUMENT",
+    "relatedSpdxElement" : "DocumentRef-spdx-tool-1.2:SPDXRef-ToolsElement",
+    "relationshipType" : "COPY_OF"
+  }, {
+    "spdxElementId" : "SPDXRef-DOCUMENT",
+    "relatedSpdxElement" : "SPDXRef-Package",
+    "relationshipType" : "DESCRIBES"
+  }, {
+    "spdxElementId" : "SPDXRef-Package",
+    "relatedSpdxElement" : "SPDXRef-Saxon",
+    "relationshipType" : "DYNAMIC_LINK"
+  }, {
+    "spdxElementId" : "SPDXRef-Package",
+    "relatedSpdxElement" : "SPDXRef-JenaLib",
+    "relationshipType" : "CONTAINS"
+  }, {
+    "spdxElementId" : "SPDXRef-CommonsLangSrc",
+    "relatedSpdxElement" : "NOASSERTION",
+    "relationshipType" : "GENERATED_FROM"
+  }, {
+    "spdxElementId" : "SPDXRef-JenaLib",
+    "relatedSpdxElement" : "SPDXRef-Package",
+    "relationshipType" : "CONTAINS"
+  }, {
+    "spdxElementId" : "SPDXRef-File",
+    "relatedSpdxElement" : "SPDXRef-fromDoap-0",
+    "relationshipType" : "GENERATED_FROM"
+  } ], 
+        "dataLicense": "CC0-1.0", 
+        "reviewers": [
+            {
+                "comment": "This is just an example.  Some of the non-standard licenses look like they are actually BSD 3 clause licenses", 
+                "reviewer": "Person: Joe Reviewer", 
+                "reviewDate": "2010-02-10T00:00:00Z"
+            }, 
+            {
+                "comment": "Another example reviewer.", 
+                "reviewer": "Person: Suzanne Reviewer", 
+                "reviewDate": "2011-03-13T00:00:00Z"
+            }
+        ], 
+        "hasExtractedLicensingInfos": [
+            {
+                "extractedText": "This package includes the GRDDL parser developed by Hewlett Packard under the following license:\n\u00a9 Copyright 2007 Hewlett-Packard Development Company, LP\n\nRedistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met: \n\nRedistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer. \nRedistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution. \nThe name of the author may not be used to endorse or promote products derived from this software without specific prior written permission. \nTHIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. ", 
+                "licenseId": "LicenseRef-2"
+            }, 
+            {
+                "extractedText": "The CyberNeko Software License, Version 1.0\n\n \n(C) Copyright 2002-2005, Andy Clark.  All rights reserved.\n \nRedistribution and use in source and binary forms, with or without\nmodification, are permitted provided that the following conditions\nare met:\n\n1. Redistributions of source code must retain the above copyright\n   notice, this list of conditions and the following disclaimer. \n\n2. Redistributions in binary form must reproduce the above copyright\n   notice, this list of conditions and the following disclaimer in\n   the documentation and/or other materials provided with the\n   distribution.\n\n3. The end-user documentation included with the redistribution,\n   if any, must include the following acknowledgment:  \n     \"This product includes software developed by Andy Clark.\"\n   Alternately, this acknowledgment may appear in the software itself,\n   if and wherever such third-party acknowledgments normally appear.\n\n4. The names \"CyberNeko\" and \"NekoHTML\" must not be used to endorse\n   or promote products derived from this software without prior \n   written permission. For written permission, please contact \n   andyc@cyberneko.net.\n\n5. Products derived from this software may not be called \"CyberNeko\",\n   nor may \"CyberNeko\" appear in their name, without prior written\n   permission of the author.\n\nTHIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESSED OR IMPLIED\nWARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES\nOF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE\nDISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR OTHER CONTRIBUTORS\nBE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, \nOR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT \nOF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR \nBUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, \nWHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE \nOR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, \nEVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.", 
+                "comment": "This is tye CyperNeko License", 
+                "licenseId": "LicenseRef-3", 
+                "name": "CyberNeko License", 
+                "seeAlso": [
+                    "http://justasample.url.com", 
+                    "http://people.apache.org/~andyc/neko/LICENSE"
+                ]
+            }, 
+            {
+                "extractedText": "/*\n * (c) Copyright 2009 University of Bristol\n * All rights reserved.\n *\n * Redistribution and use in source and binary forms, with or without\n * modification, are permitted provided that the following conditions\n * are met:\n * 1. Redistributions of source code must retain the above copyright\n *    notice, this list of conditions and the following disclaimer.\n * 2. Redistributions in binary form must reproduce the above copyright\n *    notice, this list of conditions and the following disclaimer in the\n *    documentation and/or other materials provided with the distribution.\n * 3. The name of the author may not be used to endorse or promote products\n *    derived from this software without specific prior written permission.\n *\n * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR\n * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES\n * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.\n * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,\n * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT\n * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,\n * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY\n * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT\n * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF\n * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.\n */  ", 
+                "licenseId": "LicenseRef-4"
+            }, 
+            {
+                "extractedText": "/*\n * (c) Copyright 2000, 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009 Hewlett-Packard Development Company, LP\n * All rights reserved.\n *\n * Redistribution and use in source and binary forms, with or without\n * modification, are permitted provided that the following conditions\n * are met:\n * 1. Redistributions of source code must retain the above copyright\n *    notice, this list of conditions and the following disclaimer.\n * 2. Redistributions in binary form must reproduce the above copyright\n *    notice, this list of conditions and the following disclaimer in the\n *    documentation and/or other materials provided with the distribution.\n * 3. The name of the author may not be used to endorse or promote products\n *    derived from this software without specific prior written permission.\n *\n * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR\n * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES\n * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.\n * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,\n * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT\n * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,\n * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY\n * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT\n * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF\n * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.\n */", 
+                "licenseId": "LicenseRef-1"
+            }
+        ], 
+        "spdxVersion": "SPDX-2.1", 
+        "SPDXID": "SPDXRef-DOCUMENT", 
+        "snippets": [
+            {
+                "comment": "This snippet was identified as significant and highlighted in this Apache-2.0 file, when a commercial scanner identified it as being derived from file foo.c in package xyz which is licensed under GPL-2.0-or-later.", 
+                "name": "from linux kernel", 
+                "copyrightText": "Copyright 2008-2010 John Smith", 
+                "licenseConcluded": "Apache-2.0", 
+                "licenseInfoFromSnippet": [
+                    "Apache-2.0"
+                ], 
+                "licenseComments": "The concluded license was taken from package xyz, from which the snippet was copied into the current file. The concluded license information was found in the COPYING.txt file in package xyz.", 
+                "SPDXID": "SPDXRef-Snippet", 
+                "fileId": "SPDXRef-DoapSource"
+            }
+        ]
+    }
+}

--- a/tests/data/parse_anything_test_files/SPDXJsonExample.json.xml
+++ b/tests/data/parse_anything_test_files/SPDXJsonExample.json.xml
@@ -1,0 +1,223 @@
+{
+    "Document": {
+        "comment": "This is a sample spreadsheet", 
+        "name": "Sample_Document-V2.1", 
+        "documentDescribes": [
+            {
+                "Package": {
+                    "SPDXID": "SPDXRef-Package", 
+                    "originator": "Organization: SPDX", 
+                    "files": [
+                        {
+                            "File": {
+                                "comment": "This file belongs to Jena", 
+                                "licenseInfoFromFiles": [
+                                    "LicenseRef-1"
+                                ], 
+                                "sha1": "3ab4e1c67a2d28fced849ee1bb76e7391b93f125", 
+                                "name": "Jenna-2.6.3/jena-2.6.3-sources.jar", 
+                                "copyrightText": "(c) Copyright 2000, 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009 Hewlett-Packard Development Company, LP", 
+                                "artifactOf" : [ 
+                                    {
+                                        "name" : "Jena",
+                                        "homePage" : "http://www.openjena.org/",
+                                        "projectUri" : "http://subversion.apache.org/doap.rdf"
+                                    } 
+                                ],
+                                "licenseConcluded": "LicenseRef-1", 
+                                "licenseComments": "This license is used by Jena", 
+                                "checksums": [
+                                    {
+                                        "checksumValue": "3ab4e1c67a2d28fced849ee1bb76e7391b93f125", 
+                                        "algorithm": "checksumAlgorithm_sha1"
+                                    }
+                                ], 
+                                "fileTypes": [
+                                    "fileType_archive"
+                                ], 
+                                "SPDXID": "SPDXRef-File1"
+                            }
+                        }, 
+                        {
+                            "File": {
+                                "licenseInfoFromFiles": [
+                                    "Apache-2.0"
+                                ], 
+                                "sha1": "2fd4e1c67a2d28fced849ee1bb76e7391b93eb12", 
+                                "name": "src/org/spdx/parser/DOAPProject.java", 
+                                "copyrightText": "Copyright 2010, 2011 Source Auditor Inc.", 
+                                "licenseConcluded": "Apache-2.0", 
+                                "checksums": [
+                                    {
+                                        "checksumValue": "2fd4e1c67a2d28fced849ee1bb76e7391b93eb12", 
+                                        "algorithm": "checksumAlgorithm_sha1"
+                                    }
+                                ], 
+                                "fileTypes": [
+                                    "fileType_source"
+                                ], 
+                                "SPDXID": "SPDXRef-File2"
+                            }
+                        }
+                    ], 
+                    "licenseInfoFromFiles": [
+                        "Apache-1.0", 
+                        "LicenseRef-3", 
+                        "MPL-1.1", 
+                        "LicenseRef-2", 
+                        "LicenseRef-4", 
+                        "Apache-2.0", 
+                        "LicenseRef-1"
+                    ], 
+                    "sha1": "2fd4e1c67a2d28fced849ee1bb76e7391b93eb12", 
+                    "name": "SPDX Translator", 
+                    "packageFileName": "spdxtranslator-1.0.zip", 
+                    "licenseComments": "The declared license information can be found in the NOTICE file at the root of the archive file", 
+                    "summary": "SPDX Translator utility", 
+                    "sourceInfo": "Version 1.0 of the SPDX Translator application", 
+                    "copyrightText": " Copyright 2010, 2011 Source Auditor Inc.", 
+                    "packageVerificationCode": {
+                        "packageVerificationCodeValue": "4e3211c67a2d28fced849ee1bb76e7391b93feba", 
+                        "packageVerificationCodeExcludedFiles": [
+                            "SpdxTranslatorSpdx.rdf", 
+                            "SpdxTranslatorSpdx.txt"
+                        ]
+                    }, 
+                    "licenseConcluded": "(Apache-1.0 AND LicenseRef-2 AND MPL-1.1 AND LicenseRef-3 AND LicenseRef-4 AND Apache-2.0 AND LicenseRef-1)", 
+                    "supplier": "Organization: Linux Foundation", 
+                    "attributionTexts" : [ "The GNU C Library is free software.  See the file COPYING.LIB for copying conditions, and LICENSES for notices about a few contributions that require these additional notices to be distributed.  License copyright years may be listed using range notation, e.g., 1996-2015, indicating that every year in the range, inclusive, is a copyrightable year that would otherwise be listed individually." ],
+                    "checksums": [
+                        {
+                            "checksumValue": "2fd4e1c67a2d28fced849ee1bb76e7391b93eb12", 
+                            "algorithm": "checksumAlgorithm_sha1"
+                        }
+                    ], 
+                    "versionInfo": "Version 0.9.2", 
+                    "licenseDeclared": "(LicenseRef-4 AND LicenseRef-3 AND Apache-2.0 AND LicenseRef-2 AND MPL-1.1 AND LicenseRef-1)", 
+                    "downloadLocation": "http://www.spdx.org/tools", 
+                    "description": "This utility translates and SPDX RDF XML document to a spreadsheet, translates a spreadsheet to an SPDX RDF XML document and translates an SPDX RDFa document to an SPDX RDF XML document."
+                }
+            }
+        ], 
+        "creationInfo": {
+            "comment": "This is an example of an SPDX spreadsheet format", 
+            "creators": [
+                "Tool: SourceAuditor-V1.2", 
+                "Person: Gary O'Neall", 
+                "Organization: Source Auditor Inc."
+            ], 
+            "licenseListVersion": "3.6", 
+            "created": "2010-02-03T00:00:00Z"
+        }, 
+        "externalDocumentRefs": [
+            {
+                "checksum": {
+                    "checksumValue": "d6a770ba38583ed4bb4525bd96e50461655d2759", 
+                    "algorithm": "checksumAlgorithm_sha1"
+                }, 
+                "spdxDocument": "https://spdx.org/spdxdocs/spdx-tools-v2.1-3F2504E0-4F89-41D3-9A0C-0305E82C3301", 
+                "externalDocumentId": "DocumentRef-spdx-tool-2.1"
+            }
+        ], 
+        "documentNamespace": "https://spdx.org/spdxdocs/spdx-example-444504E0-4F89-41D3-9A0C-0305E82C3301", 
+        "annotations": [
+            {
+                "comment": "This is just an example. Some of the non-standard licenses look like they are actually BSD 3 clause licenses", 
+                "annotationType": "REVIEW", 
+                "SPDXID": "SPDXRef-45", 
+                "annotationDate": "2012-06-13T00:00:00Z", 
+                "annotator": "Person: Jim Reviewer"
+            }
+        ],
+        "relationships" : [ {
+    "spdxElementId" : "SPDXRef-DOCUMENT",
+    "relatedSpdxElement" : "SPDXRef-Package",
+    "relationshipType" : "CONTAINS"
+  }, {
+    "spdxElementId" : "SPDXRef-DOCUMENT",
+    "relatedSpdxElement" : "SPDXRef-File",
+    "relationshipType" : "DESCRIBES"
+  }, {
+    "spdxElementId" : "SPDXRef-DOCUMENT",
+    "relatedSpdxElement" : "DocumentRef-spdx-tool-1.2:SPDXRef-ToolsElement",
+    "relationshipType" : "COPY_OF"
+  }, {
+    "spdxElementId" : "SPDXRef-DOCUMENT",
+    "relatedSpdxElement" : "SPDXRef-Package",
+    "relationshipType" : "DESCRIBES"
+  }, {
+    "spdxElementId" : "SPDXRef-Package",
+    "relatedSpdxElement" : "SPDXRef-Saxon",
+    "relationshipType" : "DYNAMIC_LINK"
+  }, {
+    "spdxElementId" : "SPDXRef-Package",
+    "relatedSpdxElement" : "SPDXRef-JenaLib",
+    "relationshipType" : "CONTAINS"
+  }, {
+    "spdxElementId" : "SPDXRef-CommonsLangSrc",
+    "relatedSpdxElement" : "NOASSERTION",
+    "relationshipType" : "GENERATED_FROM"
+  }, {
+    "spdxElementId" : "SPDXRef-JenaLib",
+    "relatedSpdxElement" : "SPDXRef-Package",
+    "relationshipType" : "CONTAINS"
+  }, {
+    "spdxElementId" : "SPDXRef-File",
+    "relatedSpdxElement" : "SPDXRef-fromDoap-0",
+    "relationshipType" : "GENERATED_FROM"
+  } ], 
+        "dataLicense": "CC0-1.0", 
+        "reviewers": [
+            {
+                "comment": "This is just an example.  Some of the non-standard licenses look like they are actually BSD 3 clause licenses", 
+                "reviewer": "Person: Joe Reviewer", 
+                "reviewDate": "2010-02-10T00:00:00Z"
+            }, 
+            {
+                "comment": "Another example reviewer.", 
+                "reviewer": "Person: Suzanne Reviewer", 
+                "reviewDate": "2011-03-13T00:00:00Z"
+            }
+        ], 
+        "hasExtractedLicensingInfos": [
+            {
+                "extractedText": "This package includes the GRDDL parser developed by Hewlett Packard under the following license:\n\u00a9 Copyright 2007 Hewlett-Packard Development Company, LP\n\nRedistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met: \n\nRedistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer. \nRedistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution. \nThe name of the author may not be used to endorse or promote products derived from this software without specific prior written permission. \nTHIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. ", 
+                "licenseId": "LicenseRef-2"
+            }, 
+            {
+                "extractedText": "The CyberNeko Software License, Version 1.0\n\n \n(C) Copyright 2002-2005, Andy Clark.  All rights reserved.\n \nRedistribution and use in source and binary forms, with or without\nmodification, are permitted provided that the following conditions\nare met:\n\n1. Redistributions of source code must retain the above copyright\n   notice, this list of conditions and the following disclaimer. \n\n2. Redistributions in binary form must reproduce the above copyright\n   notice, this list of conditions and the following disclaimer in\n   the documentation and/or other materials provided with the\n   distribution.\n\n3. The end-user documentation included with the redistribution,\n   if any, must include the following acknowledgment:  \n     \"This product includes software developed by Andy Clark.\"\n   Alternately, this acknowledgment may appear in the software itself,\n   if and wherever such third-party acknowledgments normally appear.\n\n4. The names \"CyberNeko\" and \"NekoHTML\" must not be used to endorse\n   or promote products derived from this software without prior \n   written permission. For written permission, please contact \n   andyc@cyberneko.net.\n\n5. Products derived from this software may not be called \"CyberNeko\",\n   nor may \"CyberNeko\" appear in their name, without prior written\n   permission of the author.\n\nTHIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESSED OR IMPLIED\nWARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES\nOF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE\nDISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR OTHER CONTRIBUTORS\nBE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, \nOR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT \nOF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR \nBUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, \nWHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE \nOR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, \nEVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.", 
+                "comment": "This is tye CyperNeko License", 
+                "licenseId": "LicenseRef-3", 
+                "name": "CyberNeko License", 
+                "seeAlso": [
+                    "http://justasample.url.com", 
+                    "http://people.apache.org/~andyc/neko/LICENSE"
+                ]
+            }, 
+            {
+                "extractedText": "/*\n * (c) Copyright 2009 University of Bristol\n * All rights reserved.\n *\n * Redistribution and use in source and binary forms, with or without\n * modification, are permitted provided that the following conditions\n * are met:\n * 1. Redistributions of source code must retain the above copyright\n *    notice, this list of conditions and the following disclaimer.\n * 2. Redistributions in binary form must reproduce the above copyright\n *    notice, this list of conditions and the following disclaimer in the\n *    documentation and/or other materials provided with the distribution.\n * 3. The name of the author may not be used to endorse or promote products\n *    derived from this software without specific prior written permission.\n *\n * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR\n * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES\n * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.\n * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,\n * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT\n * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,\n * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY\n * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT\n * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF\n * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.\n */  ", 
+                "licenseId": "LicenseRef-4"
+            }, 
+            {
+                "extractedText": "/*\n * (c) Copyright 2000, 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009 Hewlett-Packard Development Company, LP\n * All rights reserved.\n *\n * Redistribution and use in source and binary forms, with or without\n * modification, are permitted provided that the following conditions\n * are met:\n * 1. Redistributions of source code must retain the above copyright\n *    notice, this list of conditions and the following disclaimer.\n * 2. Redistributions in binary form must reproduce the above copyright\n *    notice, this list of conditions and the following disclaimer in the\n *    documentation and/or other materials provided with the distribution.\n * 3. The name of the author may not be used to endorse or promote products\n *    derived from this software without specific prior written permission.\n *\n * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR\n * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES\n * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.\n * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,\n * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT\n * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,\n * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY\n * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT\n * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF\n * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.\n */", 
+                "licenseId": "LicenseRef-1"
+            }
+        ], 
+        "spdxVersion": "SPDX-2.1", 
+        "SPDXID": "SPDXRef-DOCUMENT", 
+        "snippets": [
+            {
+                "comment": "This snippet was identified as significant and highlighted in this Apache-2.0 file, when a commercial scanner identified it as being derived from file foo.c in package xyz which is licensed under GPL-2.0-or-later.", 
+                "name": "from linux kernel", 
+                "copyrightText": "Copyright 2008-2010 John Smith", 
+                "licenseConcluded": "Apache-2.0", 
+                "licenseInfoFromSnippet": [
+                    "Apache-2.0"
+                ], 
+                "licenseComments": "The concluded license was taken from package xyz, from which the snippet was copied into the current file. The concluded license information was found in the COPYING.txt file in package xyz.", 
+                "SPDXID": "SPDXRef-Snippet", 
+                "fileId": "SPDXRef-DoapSource"
+            }
+        ]
+    }
+}

--- a/tests/data/parse_anything_test_files/SPDXJsonExample.json.yaml
+++ b/tests/data/parse_anything_test_files/SPDXJsonExample.json.yaml
@@ -1,0 +1,223 @@
+{
+    "Document": {
+        "comment": "This is a sample spreadsheet", 
+        "name": "Sample_Document-V2.1", 
+        "documentDescribes": [
+            {
+                "Package": {
+                    "SPDXID": "SPDXRef-Package", 
+                    "originator": "Organization: SPDX", 
+                    "files": [
+                        {
+                            "File": {
+                                "comment": "This file belongs to Jena", 
+                                "licenseInfoFromFiles": [
+                                    "LicenseRef-1"
+                                ], 
+                                "sha1": "3ab4e1c67a2d28fced849ee1bb76e7391b93f125", 
+                                "name": "Jenna-2.6.3/jena-2.6.3-sources.jar", 
+                                "copyrightText": "(c) Copyright 2000, 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009 Hewlett-Packard Development Company, LP", 
+                                "artifactOf" : [ 
+                                    {
+                                        "name" : "Jena",
+                                        "homePage" : "http://www.openjena.org/",
+                                        "projectUri" : "http://subversion.apache.org/doap.rdf"
+                                    } 
+                                ],
+                                "licenseConcluded": "LicenseRef-1", 
+                                "licenseComments": "This license is used by Jena", 
+                                "checksums": [
+                                    {
+                                        "checksumValue": "3ab4e1c67a2d28fced849ee1bb76e7391b93f125", 
+                                        "algorithm": "checksumAlgorithm_sha1"
+                                    }
+                                ], 
+                                "fileTypes": [
+                                    "fileType_archive"
+                                ], 
+                                "SPDXID": "SPDXRef-File1"
+                            }
+                        }, 
+                        {
+                            "File": {
+                                "licenseInfoFromFiles": [
+                                    "Apache-2.0"
+                                ], 
+                                "sha1": "2fd4e1c67a2d28fced849ee1bb76e7391b93eb12", 
+                                "name": "src/org/spdx/parser/DOAPProject.java", 
+                                "copyrightText": "Copyright 2010, 2011 Source Auditor Inc.", 
+                                "licenseConcluded": "Apache-2.0", 
+                                "checksums": [
+                                    {
+                                        "checksumValue": "2fd4e1c67a2d28fced849ee1bb76e7391b93eb12", 
+                                        "algorithm": "checksumAlgorithm_sha1"
+                                    }
+                                ], 
+                                "fileTypes": [
+                                    "fileType_source"
+                                ], 
+                                "SPDXID": "SPDXRef-File2"
+                            }
+                        }
+                    ], 
+                    "licenseInfoFromFiles": [
+                        "Apache-1.0", 
+                        "LicenseRef-3", 
+                        "MPL-1.1", 
+                        "LicenseRef-2", 
+                        "LicenseRef-4", 
+                        "Apache-2.0", 
+                        "LicenseRef-1"
+                    ], 
+                    "sha1": "2fd4e1c67a2d28fced849ee1bb76e7391b93eb12", 
+                    "name": "SPDX Translator", 
+                    "packageFileName": "spdxtranslator-1.0.zip", 
+                    "licenseComments": "The declared license information can be found in the NOTICE file at the root of the archive file", 
+                    "summary": "SPDX Translator utility", 
+                    "sourceInfo": "Version 1.0 of the SPDX Translator application", 
+                    "copyrightText": " Copyright 2010, 2011 Source Auditor Inc.", 
+                    "packageVerificationCode": {
+                        "packageVerificationCodeValue": "4e3211c67a2d28fced849ee1bb76e7391b93feba", 
+                        "packageVerificationCodeExcludedFiles": [
+                            "SpdxTranslatorSpdx.rdf", 
+                            "SpdxTranslatorSpdx.txt"
+                        ]
+                    }, 
+                    "licenseConcluded": "(Apache-1.0 AND LicenseRef-2 AND MPL-1.1 AND LicenseRef-3 AND LicenseRef-4 AND Apache-2.0 AND LicenseRef-1)", 
+                    "supplier": "Organization: Linux Foundation", 
+                    "attributionTexts" : [ "The GNU C Library is free software.  See the file COPYING.LIB for copying conditions, and LICENSES for notices about a few contributions that require these additional notices to be distributed.  License copyright years may be listed using range notation, e.g., 1996-2015, indicating that every year in the range, inclusive, is a copyrightable year that would otherwise be listed individually." ],
+                    "checksums": [
+                        {
+                            "checksumValue": "2fd4e1c67a2d28fced849ee1bb76e7391b93eb12", 
+                            "algorithm": "checksumAlgorithm_sha1"
+                        }
+                    ], 
+                    "versionInfo": "Version 0.9.2", 
+                    "licenseDeclared": "(LicenseRef-4 AND LicenseRef-3 AND Apache-2.0 AND LicenseRef-2 AND MPL-1.1 AND LicenseRef-1)", 
+                    "downloadLocation": "http://www.spdx.org/tools", 
+                    "description": "This utility translates and SPDX RDF XML document to a spreadsheet, translates a spreadsheet to an SPDX RDF XML document and translates an SPDX RDFa document to an SPDX RDF XML document."
+                }
+            }
+        ], 
+        "creationInfo": {
+            "comment": "This is an example of an SPDX spreadsheet format", 
+            "creators": [
+                "Tool: SourceAuditor-V1.2", 
+                "Person: Gary O'Neall", 
+                "Organization: Source Auditor Inc."
+            ], 
+            "licenseListVersion": "3.6", 
+            "created": "2010-02-03T00:00:00Z"
+        }, 
+        "externalDocumentRefs": [
+            {
+                "checksum": {
+                    "checksumValue": "d6a770ba38583ed4bb4525bd96e50461655d2759", 
+                    "algorithm": "checksumAlgorithm_sha1"
+                }, 
+                "spdxDocument": "https://spdx.org/spdxdocs/spdx-tools-v2.1-3F2504E0-4F89-41D3-9A0C-0305E82C3301", 
+                "externalDocumentId": "DocumentRef-spdx-tool-2.1"
+            }
+        ], 
+        "documentNamespace": "https://spdx.org/spdxdocs/spdx-example-444504E0-4F89-41D3-9A0C-0305E82C3301", 
+        "annotations": [
+            {
+                "comment": "This is just an example. Some of the non-standard licenses look like they are actually BSD 3 clause licenses", 
+                "annotationType": "REVIEW", 
+                "SPDXID": "SPDXRef-45", 
+                "annotationDate": "2012-06-13T00:00:00Z", 
+                "annotator": "Person: Jim Reviewer"
+            }
+        ],
+        "relationships" : [ {
+    "spdxElementId" : "SPDXRef-DOCUMENT",
+    "relatedSpdxElement" : "SPDXRef-Package",
+    "relationshipType" : "CONTAINS"
+  }, {
+    "spdxElementId" : "SPDXRef-DOCUMENT",
+    "relatedSpdxElement" : "SPDXRef-File",
+    "relationshipType" : "DESCRIBES"
+  }, {
+    "spdxElementId" : "SPDXRef-DOCUMENT",
+    "relatedSpdxElement" : "DocumentRef-spdx-tool-1.2:SPDXRef-ToolsElement",
+    "relationshipType" : "COPY_OF"
+  }, {
+    "spdxElementId" : "SPDXRef-DOCUMENT",
+    "relatedSpdxElement" : "SPDXRef-Package",
+    "relationshipType" : "DESCRIBES"
+  }, {
+    "spdxElementId" : "SPDXRef-Package",
+    "relatedSpdxElement" : "SPDXRef-Saxon",
+    "relationshipType" : "DYNAMIC_LINK"
+  }, {
+    "spdxElementId" : "SPDXRef-Package",
+    "relatedSpdxElement" : "SPDXRef-JenaLib",
+    "relationshipType" : "CONTAINS"
+  }, {
+    "spdxElementId" : "SPDXRef-CommonsLangSrc",
+    "relatedSpdxElement" : "NOASSERTION",
+    "relationshipType" : "GENERATED_FROM"
+  }, {
+    "spdxElementId" : "SPDXRef-JenaLib",
+    "relatedSpdxElement" : "SPDXRef-Package",
+    "relationshipType" : "CONTAINS"
+  }, {
+    "spdxElementId" : "SPDXRef-File",
+    "relatedSpdxElement" : "SPDXRef-fromDoap-0",
+    "relationshipType" : "GENERATED_FROM"
+  } ], 
+        "dataLicense": "CC0-1.0", 
+        "reviewers": [
+            {
+                "comment": "This is just an example.  Some of the non-standard licenses look like they are actually BSD 3 clause licenses", 
+                "reviewer": "Person: Joe Reviewer", 
+                "reviewDate": "2010-02-10T00:00:00Z"
+            }, 
+            {
+                "comment": "Another example reviewer.", 
+                "reviewer": "Person: Suzanne Reviewer", 
+                "reviewDate": "2011-03-13T00:00:00Z"
+            }
+        ], 
+        "hasExtractedLicensingInfos": [
+            {
+                "extractedText": "This package includes the GRDDL parser developed by Hewlett Packard under the following license:\n\u00a9 Copyright 2007 Hewlett-Packard Development Company, LP\n\nRedistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met: \n\nRedistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer. \nRedistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution. \nThe name of the author may not be used to endorse or promote products derived from this software without specific prior written permission. \nTHIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. ", 
+                "licenseId": "LicenseRef-2"
+            }, 
+            {
+                "extractedText": "The CyberNeko Software License, Version 1.0\n\n \n(C) Copyright 2002-2005, Andy Clark.  All rights reserved.\n \nRedistribution and use in source and binary forms, with or without\nmodification, are permitted provided that the following conditions\nare met:\n\n1. Redistributions of source code must retain the above copyright\n   notice, this list of conditions and the following disclaimer. \n\n2. Redistributions in binary form must reproduce the above copyright\n   notice, this list of conditions and the following disclaimer in\n   the documentation and/or other materials provided with the\n   distribution.\n\n3. The end-user documentation included with the redistribution,\n   if any, must include the following acknowledgment:  \n     \"This product includes software developed by Andy Clark.\"\n   Alternately, this acknowledgment may appear in the software itself,\n   if and wherever such third-party acknowledgments normally appear.\n\n4. The names \"CyberNeko\" and \"NekoHTML\" must not be used to endorse\n   or promote products derived from this software without prior \n   written permission. For written permission, please contact \n   andyc@cyberneko.net.\n\n5. Products derived from this software may not be called \"CyberNeko\",\n   nor may \"CyberNeko\" appear in their name, without prior written\n   permission of the author.\n\nTHIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESSED OR IMPLIED\nWARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES\nOF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE\nDISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR OTHER CONTRIBUTORS\nBE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, \nOR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT \nOF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR \nBUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, \nWHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE \nOR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, \nEVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.", 
+                "comment": "This is tye CyperNeko License", 
+                "licenseId": "LicenseRef-3", 
+                "name": "CyberNeko License", 
+                "seeAlso": [
+                    "http://justasample.url.com", 
+                    "http://people.apache.org/~andyc/neko/LICENSE"
+                ]
+            }, 
+            {
+                "extractedText": "/*\n * (c) Copyright 2009 University of Bristol\n * All rights reserved.\n *\n * Redistribution and use in source and binary forms, with or without\n * modification, are permitted provided that the following conditions\n * are met:\n * 1. Redistributions of source code must retain the above copyright\n *    notice, this list of conditions and the following disclaimer.\n * 2. Redistributions in binary form must reproduce the above copyright\n *    notice, this list of conditions and the following disclaimer in the\n *    documentation and/or other materials provided with the distribution.\n * 3. The name of the author may not be used to endorse or promote products\n *    derived from this software without specific prior written permission.\n *\n * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR\n * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES\n * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.\n * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,\n * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT\n * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,\n * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY\n * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT\n * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF\n * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.\n */  ", 
+                "licenseId": "LicenseRef-4"
+            }, 
+            {
+                "extractedText": "/*\n * (c) Copyright 2000, 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009 Hewlett-Packard Development Company, LP\n * All rights reserved.\n *\n * Redistribution and use in source and binary forms, with or without\n * modification, are permitted provided that the following conditions\n * are met:\n * 1. Redistributions of source code must retain the above copyright\n *    notice, this list of conditions and the following disclaimer.\n * 2. Redistributions in binary form must reproduce the above copyright\n *    notice, this list of conditions and the following disclaimer in the\n *    documentation and/or other materials provided with the distribution.\n * 3. The name of the author may not be used to endorse or promote products\n *    derived from this software without specific prior written permission.\n *\n * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR\n * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES\n * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.\n * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,\n * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT\n * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,\n * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY\n * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT\n * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF\n * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.\n */", 
+                "licenseId": "LicenseRef-1"
+            }
+        ], 
+        "spdxVersion": "SPDX-2.1", 
+        "SPDXID": "SPDXRef-DOCUMENT", 
+        "snippets": [
+            {
+                "comment": "This snippet was identified as significant and highlighted in this Apache-2.0 file, when a commercial scanner identified it as being derived from file foo.c in package xyz which is licensed under GPL-2.0-or-later.", 
+                "name": "from linux kernel", 
+                "copyrightText": "Copyright 2008-2010 John Smith", 
+                "licenseConcluded": "Apache-2.0", 
+                "licenseInfoFromSnippet": [
+                    "Apache-2.0"
+                ], 
+                "licenseComments": "The concluded license was taken from package xyz, from which the snippet was copied into the current file. The concluded license information was found in the COPYING.txt file in package xyz.", 
+                "SPDXID": "SPDXRef-Snippet", 
+                "fileId": "SPDXRef-DoapSource"
+            }
+        ]
+    }
+}

--- a/tests/data/parse_anything_test_files/SPDXRdfExample.rdf
+++ b/tests/data/parse_anything_test_files/SPDXRdfExample.rdf
@@ -1,0 +1,305 @@
+<rdf:RDF
+    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+    xmlns:j.0="http://usefulinc.com/ns/doap#"
+    xmlns="http://spdx.org/rdf/terms#"
+    xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">
+  <Snippet rdf:about="http://spdx.org/spdxdocs/spdx-example-444504E0-4F89-41D3-9A0C-0305E82C3301#SPDXRef-Snippet">
+    <snippetFromFile>
+      <File rdf:about="http://spdx.org/spdxdocs/spdx-example-444504E0-4F89-41D3-9A0C-0305E82C3301#SPDXRef-DoapSource"/>
+    </snippetFromFile>
+    <name>from linux kernel</name>
+    <copyrightText>Copyright 2008-2010 John Smith</copyrightText>
+    <licenseComments>The concluded license was taken from package xyz, from which the snippet was copied into the current file. The concluded license information was found in the COPYING.txt file in package xyz.</licenseComments>
+    <rdfs:comment>This snippet was identified as significant and highlighted in this Apache-2.0 file, when a commercial scanner identified it as being derived from file foo.c in package xyz which is licensed under GPL-2.0-or-later.</rdfs:comment>
+    <licenseConcluded rdf:resource="http://spdx.org/licenses/Apache-2.0"/>
+    <licenseInfoInSnippet rdf:resource="http://spdx.org/licenses/Apache-2.0"/>
+  </Snippet>
+  <SpdxDocument rdf:about="https://spdx.org/spdxdocs/spdx-example-444504E0-4F89-41D3-9A0C-0305E82C3301#SPDXRef-DOCUMENT">
+    <name>Sample_Document-V2.1</name>
+    <creationInfo>
+      <CreationInfo>
+        <created>2010-02-03T00:00:00Z</created>
+        <rdfs:comment>This is an example of an SPDX spreadsheet format</rdfs:comment>
+        <creator>Tool: SourceAuditor-V1.2</creator>
+        <creator>Organization: Source Auditor Inc.</creator>
+        <creator>Person: Gary O'Neall</creator>
+      </CreationInfo>
+    </creationInfo>
+    <specVersion>SPDX-2.1</specVersion>
+    <externalDocumentRef>
+      <ExternalDocumentRef>
+        <externalDocumentId>DocumentRef-spdx-tool-2.1</externalDocumentId>
+        <spdxDocument rdf:resource="https://spdx.org/spdxdocs/spdx-tools-v2.1-3F2504E0-4F89-41D3-9A0C-0305E82C3301"/>
+        <checksum>
+          <Checksum>
+            <checksumValue>d6a770ba38583ed4bb4525bd96e50461655d2759</checksumValue>
+            <algorithm rdf:resource="http://spdx.org/rdf/terms#checksumAlgorithm_sha1"/>
+          </Checksum>
+        </checksum>
+      </ExternalDocumentRef>
+    </externalDocumentRef>
+    <referencesFile>
+      <File rdf:about="https://spdx.org/spdxdocs/spdx-example-444504E0-4F89-41D3-9A0C-0305E82C3301#SPDXRef-File1">>
+        <licenseConcluded>
+          <ExtractedLicensingInfo rdf:nodeID="A1">
+            <extractedText>/*
+ * (c) Copyright 2000, 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009 Hewlett-Packard Development Company, LP
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. The name of the author may not be used to endorse or promote products
+ *    derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */</extractedText>
+            <licenseId>LicenseRef-1</licenseId>
+          </ExtractedLicensingInfo>
+        </licenseConcluded>
+        <artifactOf>
+          <j.0:Project>
+            <j.0:homepage>http://www.openjena.org/</j.0:homepage>
+            <j.0:name>Jena</j.0:name>
+          </j.0:Project>
+        </artifactOf>
+        <licenseComments>This license is used by Jena</licenseComments>
+        <fileName>Jenna-2.6.3/jena-2.6.3-sources.jar</fileName>
+        <fileType rdf:resource="http://spdx.org/rdf/terms#fileType_archive"/>
+        <copyrightText>(c) Copyright 2000, 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009 Hewlett-Packard Development Company, LP</copyrightText>
+        <licenseInfoInFile rdf:nodeID="A1"/>
+        <rdfs:comment>This file belongs to Jena</rdfs:comment>
+        <checksum>
+          <Checksum>
+            <checksumValue>3ab4e1c67a2d28fced849ee1bb76e7391b93f125</checksumValue>
+            <algorithm rdf:resource="http://spdx.org/rdf/terms#checksumAlgorithm_sha1"/>
+          </Checksum>
+        </checksum>
+      </File>
+    </referencesFile>
+    <reviewed>
+      <Review>
+        <rdfs:comment>This is just an example.  Some of the non-standard licenses look like they are actually BSD 3 clause licenses</rdfs:comment>
+        <reviewDate>2010-02-10T00:00:00Z</reviewDate>
+        <reviewer>Person: Joe Reviewer</reviewer>
+      </Review>
+    </reviewed>
+    <dataLicense rdf:resource="http://spdx.org/licenses/CC0-1.0"/>
+    <hasExtractedLicensingInfo rdf:nodeID="A1"/>
+    <reviewed>
+      <Review>
+        <rdfs:comment>Another example reviewer.</rdfs:comment>
+        <reviewDate>2011-03-13T00:00:00Z</reviewDate>
+        <reviewer>Person: Suzanne Reviewer</reviewer>
+      </Review>
+    </reviewed>
+    <annotation>
+      <Annotation rdf:about="https://spdx.org/spdxdocs/spdx-example-444504E0-4F89-41D3-9A0C-0305E82C3301#SPDXRef-45">
+        <annotationType rdf:resource="http://spdx.org/rdf/terms#annotationType_review"/>
+        <rdfs:comment>This is just an example. Some of the non-standard licenses look like they are actually BSD 3 clause licenses</rdfs:comment>
+        <annotationDate>2012-06-13T00:00:00Z</annotationDate>
+        <annotator>Person: Jim Reviewer</annotator>
+      </Annotation>
+    </annotation>
+    <relationship>
+      <Relationship>
+        <relationshipType rdf:resource="http://spdx.org/rdf/terms#relationshipType_describes"/>
+        <relatedSpdxElement rdf:resource="http://spdx.org/spdxdocs/spdx-example-444504E0-4F89-41D3-9A0C-0305E82C3301#SPDXRef-Package"/>
+      </Relationship>
+    </relationship>
+    <referencesFile>
+      <File rdf:about="https://spdx.org/spdxdocs/spdx-example-444504E0-4F89-41D3-9A0C-0305E82C3301#SPDXRef-File2">
+        <copyrightText>Copyright 2010, 2011 Source Auditor Inc.</copyrightText>
+        <licenseInfoInFile rdf:resource="http://spdx.org/licenses/Apache-2.0"/>
+        <licenseConcluded rdf:resource="http://spdx.org/licenses/Apache-2.0"/>
+        <fileType rdf:resource="http://spdx.org/rdf/terms#fileType_source"/>
+        <checksum>
+          <Checksum>
+            <checksumValue>2fd4e1c67a2d28fced849ee1bb76e7391b93eb12</checksumValue>
+            <algorithm rdf:resource="http://spdx.org/rdf/terms#checksumAlgorithm_sha1"/>
+          </Checksum>
+        </checksum>
+        <fileName>src/org/spdx/parser/DOAPProject.java</fileName>
+      </File>
+    </referencesFile>
+    <describesPackage>
+      <Package rdf:about="http://www.spdx.org/tools#SPDXRef-Package">
+        <licenseInfoFromFiles rdf:resource="http://spdx.org/licenses/Apache-1.0"/>
+        <downloadLocation>http://www.spdx.org/tools</downloadLocation>
+        <filesAnalyzed>true</filesAnalyzed>
+        <supplier>Organization:Linux Foundation</supplier>
+        <hasFile rdf:nodeID="A0"/>
+        <licenseInfoFromFiles rdf:resource="http://spdx.org/licenses/Apache-2.0"/>
+        <packageVerificationCode>
+          <PackageVerificationCode>
+            <packageVerificationCodeValue>4e3211c67a2d28fced849ee1bb76e7391b93feba</packageVerificationCodeValue>
+            <packageVerificationCodeExcludedFile>SpdxTranslatorSpdx.txt</packageVerificationCodeExcludedFile>
+            <packageVerificationCodeExcludedFile>SpdxTranslatorSpdx.rdf</packageVerificationCodeExcludedFile>
+          </PackageVerificationCode>
+        </packageVerificationCode>
+        <licenseConcluded>
+          <ConjunctiveLicenseSet>
+            <member>
+              <ExtractedLicensingInfo rdf:nodeID="A3">
+                <extractedText>This package includes the GRDDL parser developed by Hewlett Packard under the following license:
+© Copyright 2007 Hewlett-Packard Development Company, LP
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met: 
+
+Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer. 
+Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution. 
+The name of the author may not be used to endorse or promote products derived from this software without specific prior written permission. 
+THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. </extractedText>
+                <licenseId>LicenseRef-2</licenseId>
+              </ExtractedLicensingInfo>
+            </member>
+            <member rdf:nodeID="A1"/>
+            <member rdf:resource="http://spdx.org/licenses/Apache-2.0"/>
+            <member rdf:resource="http://spdx.org/licenses/MPL-1.1"/>
+            <member rdf:resource="http://spdx.org/licenses/Apache-1.0"/>
+            <member>
+              <ExtractedLicensingInfo rdf:nodeID="A4">
+                <extractedText>/*
+ * (c) Copyright 2009 University of Bristol
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. The name of the author may not be used to endorse or promote products
+ *    derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */  </extractedText>
+                <licenseId>LicenseRef-4</licenseId>
+              </ExtractedLicensingInfo>
+            </member>
+            <member>
+              <ExtractedLicensingInfo rdf:nodeID="A5">
+                <rdfs:seeAlso>http://justasample.url.com</rdfs:seeAlso>
+                <rdfs:seeAlso>http://people.apache.org/~andyc/neko/LICENSE</rdfs:seeAlso>
+                <licenseName>CyberNeko License</licenseName>
+                <rdfs:comment>This is tye CyperNeko License</rdfs:comment>
+                <extractedText>The CyberNeko Software License, Version 1.0
+
+ 
+(C) Copyright 2002-2005, Andy Clark.  All rights reserved.
+ 
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer. 
+
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in
+   the documentation and/or other materials provided with the
+   distribution.
+
+3. The end-user documentation included with the redistribution,
+   if any, must include the following acknowledgment:  
+     "This product includes software developed by Andy Clark."
+   Alternately, this acknowledgment may appear in the software itself,
+   if and wherever such third-party acknowledgments normally appear.
+
+4. The names "CyberNeko" and "NekoHTML" must not be used to endorse
+   or promote products derived from this software without prior 
+   written permission. For written permission, please contact 
+   andyc@cyberneko.net.
+
+5. Products derived from this software may not be called "CyberNeko",
+   nor may "CyberNeko" appear in their name, without prior written
+   permission of the author.
+
+THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESSED OR IMPLIED
+WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR OTHER CONTRIBUTORS
+BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, 
+OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT 
+OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR 
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE 
+OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, 
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.</extractedText>
+                <licenseId>LicenseRef-3</licenseId>
+              </ExtractedLicensingInfo>
+            </member>
+          </ConjunctiveLicenseSet>
+        </licenseConcluded>
+        <sourceInfo>Version 1.0 of the SPDX Translator application</sourceInfo>
+        <checksum>
+          <Checksum>
+            <checksumValue>2fd4e1c67a2d28fced849ee1bb76e7391b93eb12</checksumValue>
+            <algorithm rdf:resource="http://spdx.org/rdf/terms#checksumAlgorithm_sha1"/>
+          </Checksum>
+        </checksum>
+        <packageFileName>spdxtranslator-1.0.zip</packageFileName>
+        <description>This utility translates and SPDX RDF XML document to a spreadsheet, translates a spreadsheet to an SPDX RDF XML document and translates an SPDX RDFa document to an SPDX RDF XML document.</description>
+        <licenseInfoFromFiles rdf:nodeID="A4"/>
+        <name>SPDX Translator</name>
+        <versionInfo>Version 0.9.2</versionInfo>
+        <licenseInfoFromFiles rdf:nodeID="A1"/>
+        <hasFile rdf:nodeID="A2"/>
+        <licenseInfoFromFiles rdf:nodeID="A3"/>
+        <copyrightText> Copyright 2010, 2011 Source Auditor Inc.</copyrightText>
+        <licenseDeclared>
+          <ConjunctiveLicenseSet>
+            <member rdf:nodeID="A3"/>
+            <member rdf:nodeID="A1"/>
+            <member rdf:resource="http://spdx.org/licenses/Apache-2.0"/>
+            <member rdf:resource="http://spdx.org/licenses/MPL-1.1"/>
+            <member rdf:nodeID="A4"/>
+            <member rdf:nodeID="A5"/>
+          </ConjunctiveLicenseSet>
+        </licenseDeclared>
+        <licenseInfoFromFiles rdf:nodeID="A5"/>
+        <originator>Organization:SPDX</originator>
+        <licenseComments>The declared license information can be found in the NOTICE file at the root of the archive file</licenseComments>
+        <summary>SPDX Translator utility</summary>
+        <licenseInfoFromFiles rdf:resource="http://spdx.org/licenses/MPL-1.1"/>
+        <externalRef>
+          <ExternalRef>
+            <referenceCategory rdf:resource="http://spdx.org/rdf/terms#referenceCategory_packageManager"/>
+            <referenceType rdf:resource="http://spdx.org/rdf/references/maven-central"/>
+            <referenceLocator>org.apache.commons:commons-lang:3.2.1</referenceLocator>
+            <rdfs:comment>NIST National Vulnerability Database (NVD) describes security vulnerabilities (CVEs) which affect Vendor Product Version acmecorp:acmenator:6.6.6</rdfs:comment>
+          </ExternalRef>
+        </externalRef>
+      </Package>
+    </describesPackage>
+    <rdfs:comment>This is a sample spreadsheet</rdfs:comment>
+    <hasExtractedLicensingInfo rdf:nodeID="A4"/>
+    <hasExtractedLicensingInfo rdf:nodeID="A5"/>
+    <hasExtractedLicensingInfo rdf:nodeID="A3"/>
+  </SpdxDocument>
+</rdf:RDF>

--- a/tests/data/parse_anything_test_files/SPDXRdfExample.rdf.json
+++ b/tests/data/parse_anything_test_files/SPDXRdfExample.rdf.json
@@ -1,0 +1,305 @@
+<rdf:RDF
+    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+    xmlns:j.0="http://usefulinc.com/ns/doap#"
+    xmlns="http://spdx.org/rdf/terms#"
+    xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">
+  <Snippet rdf:about="http://spdx.org/spdxdocs/spdx-example-444504E0-4F89-41D3-9A0C-0305E82C3301#SPDXRef-Snippet">
+    <snippetFromFile>
+      <File rdf:about="http://spdx.org/spdxdocs/spdx-example-444504E0-4F89-41D3-9A0C-0305E82C3301#SPDXRef-DoapSource"/>
+    </snippetFromFile>
+    <name>from linux kernel</name>
+    <copyrightText>Copyright 2008-2010 John Smith</copyrightText>
+    <licenseComments>The concluded license was taken from package xyz, from which the snippet was copied into the current file. The concluded license information was found in the COPYING.txt file in package xyz.</licenseComments>
+    <rdfs:comment>This snippet was identified as significant and highlighted in this Apache-2.0 file, when a commercial scanner identified it as being derived from file foo.c in package xyz which is licensed under GPL-2.0-or-later.</rdfs:comment>
+    <licenseConcluded rdf:resource="http://spdx.org/licenses/Apache-2.0"/>
+    <licenseInfoInSnippet rdf:resource="http://spdx.org/licenses/Apache-2.0"/>
+  </Snippet>
+  <SpdxDocument rdf:about="https://spdx.org/spdxdocs/spdx-example-444504E0-4F89-41D3-9A0C-0305E82C3301#SPDXRef-DOCUMENT">
+    <name>Sample_Document-V2.1</name>
+    <creationInfo>
+      <CreationInfo>
+        <created>2010-02-03T00:00:00Z</created>
+        <rdfs:comment>This is an example of an SPDX spreadsheet format</rdfs:comment>
+        <creator>Tool: SourceAuditor-V1.2</creator>
+        <creator>Organization: Source Auditor Inc.</creator>
+        <creator>Person: Gary O'Neall</creator>
+      </CreationInfo>
+    </creationInfo>
+    <specVersion>SPDX-2.1</specVersion>
+    <externalDocumentRef>
+      <ExternalDocumentRef>
+        <externalDocumentId>DocumentRef-spdx-tool-2.1</externalDocumentId>
+        <spdxDocument rdf:resource="https://spdx.org/spdxdocs/spdx-tools-v2.1-3F2504E0-4F89-41D3-9A0C-0305E82C3301"/>
+        <checksum>
+          <Checksum>
+            <checksumValue>d6a770ba38583ed4bb4525bd96e50461655d2759</checksumValue>
+            <algorithm rdf:resource="http://spdx.org/rdf/terms#checksumAlgorithm_sha1"/>
+          </Checksum>
+        </checksum>
+      </ExternalDocumentRef>
+    </externalDocumentRef>
+    <referencesFile>
+      <File rdf:about="https://spdx.org/spdxdocs/spdx-example-444504E0-4F89-41D3-9A0C-0305E82C3301#SPDXRef-File1">>
+        <licenseConcluded>
+          <ExtractedLicensingInfo rdf:nodeID="A1">
+            <extractedText>/*
+ * (c) Copyright 2000, 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009 Hewlett-Packard Development Company, LP
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. The name of the author may not be used to endorse or promote products
+ *    derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */</extractedText>
+            <licenseId>LicenseRef-1</licenseId>
+          </ExtractedLicensingInfo>
+        </licenseConcluded>
+        <artifactOf>
+          <j.0:Project>
+            <j.0:homepage>http://www.openjena.org/</j.0:homepage>
+            <j.0:name>Jena</j.0:name>
+          </j.0:Project>
+        </artifactOf>
+        <licenseComments>This license is used by Jena</licenseComments>
+        <fileName>Jenna-2.6.3/jena-2.6.3-sources.jar</fileName>
+        <fileType rdf:resource="http://spdx.org/rdf/terms#fileType_archive"/>
+        <copyrightText>(c) Copyright 2000, 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009 Hewlett-Packard Development Company, LP</copyrightText>
+        <licenseInfoInFile rdf:nodeID="A1"/>
+        <rdfs:comment>This file belongs to Jena</rdfs:comment>
+        <checksum>
+          <Checksum>
+            <checksumValue>3ab4e1c67a2d28fced849ee1bb76e7391b93f125</checksumValue>
+            <algorithm rdf:resource="http://spdx.org/rdf/terms#checksumAlgorithm_sha1"/>
+          </Checksum>
+        </checksum>
+      </File>
+    </referencesFile>
+    <reviewed>
+      <Review>
+        <rdfs:comment>This is just an example.  Some of the non-standard licenses look like they are actually BSD 3 clause licenses</rdfs:comment>
+        <reviewDate>2010-02-10T00:00:00Z</reviewDate>
+        <reviewer>Person: Joe Reviewer</reviewer>
+      </Review>
+    </reviewed>
+    <dataLicense rdf:resource="http://spdx.org/licenses/CC0-1.0"/>
+    <hasExtractedLicensingInfo rdf:nodeID="A1"/>
+    <reviewed>
+      <Review>
+        <rdfs:comment>Another example reviewer.</rdfs:comment>
+        <reviewDate>2011-03-13T00:00:00Z</reviewDate>
+        <reviewer>Person: Suzanne Reviewer</reviewer>
+      </Review>
+    </reviewed>
+    <annotation>
+      <Annotation rdf:about="https://spdx.org/spdxdocs/spdx-example-444504E0-4F89-41D3-9A0C-0305E82C3301#SPDXRef-45">
+        <annotationType rdf:resource="http://spdx.org/rdf/terms#annotationType_review"/>
+        <rdfs:comment>This is just an example. Some of the non-standard licenses look like they are actually BSD 3 clause licenses</rdfs:comment>
+        <annotationDate>2012-06-13T00:00:00Z</annotationDate>
+        <annotator>Person: Jim Reviewer</annotator>
+      </Annotation>
+    </annotation>
+    <relationship>
+      <Relationship>
+        <relationshipType rdf:resource="http://spdx.org/rdf/terms#relationshipType_describes"/>
+        <relatedSpdxElement rdf:resource="http://spdx.org/spdxdocs/spdx-example-444504E0-4F89-41D3-9A0C-0305E82C3301#SPDXRef-Package"/>
+      </Relationship>
+    </relationship>
+    <referencesFile>
+      <File rdf:about="https://spdx.org/spdxdocs/spdx-example-444504E0-4F89-41D3-9A0C-0305E82C3301#SPDXRef-File2">
+        <copyrightText>Copyright 2010, 2011 Source Auditor Inc.</copyrightText>
+        <licenseInfoInFile rdf:resource="http://spdx.org/licenses/Apache-2.0"/>
+        <licenseConcluded rdf:resource="http://spdx.org/licenses/Apache-2.0"/>
+        <fileType rdf:resource="http://spdx.org/rdf/terms#fileType_source"/>
+        <checksum>
+          <Checksum>
+            <checksumValue>2fd4e1c67a2d28fced849ee1bb76e7391b93eb12</checksumValue>
+            <algorithm rdf:resource="http://spdx.org/rdf/terms#checksumAlgorithm_sha1"/>
+          </Checksum>
+        </checksum>
+        <fileName>src/org/spdx/parser/DOAPProject.java</fileName>
+      </File>
+    </referencesFile>
+    <describesPackage>
+      <Package rdf:about="http://www.spdx.org/tools#SPDXRef-Package">
+        <licenseInfoFromFiles rdf:resource="http://spdx.org/licenses/Apache-1.0"/>
+        <downloadLocation>http://www.spdx.org/tools</downloadLocation>
+        <filesAnalyzed>true</filesAnalyzed>
+        <supplier>Organization:Linux Foundation</supplier>
+        <hasFile rdf:nodeID="A0"/>
+        <licenseInfoFromFiles rdf:resource="http://spdx.org/licenses/Apache-2.0"/>
+        <packageVerificationCode>
+          <PackageVerificationCode>
+            <packageVerificationCodeValue>4e3211c67a2d28fced849ee1bb76e7391b93feba</packageVerificationCodeValue>
+            <packageVerificationCodeExcludedFile>SpdxTranslatorSpdx.txt</packageVerificationCodeExcludedFile>
+            <packageVerificationCodeExcludedFile>SpdxTranslatorSpdx.rdf</packageVerificationCodeExcludedFile>
+          </PackageVerificationCode>
+        </packageVerificationCode>
+        <licenseConcluded>
+          <ConjunctiveLicenseSet>
+            <member>
+              <ExtractedLicensingInfo rdf:nodeID="A3">
+                <extractedText>This package includes the GRDDL parser developed by Hewlett Packard under the following license:
+© Copyright 2007 Hewlett-Packard Development Company, LP
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met: 
+
+Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer. 
+Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution. 
+The name of the author may not be used to endorse or promote products derived from this software without specific prior written permission. 
+THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. </extractedText>
+                <licenseId>LicenseRef-2</licenseId>
+              </ExtractedLicensingInfo>
+            </member>
+            <member rdf:nodeID="A1"/>
+            <member rdf:resource="http://spdx.org/licenses/Apache-2.0"/>
+            <member rdf:resource="http://spdx.org/licenses/MPL-1.1"/>
+            <member rdf:resource="http://spdx.org/licenses/Apache-1.0"/>
+            <member>
+              <ExtractedLicensingInfo rdf:nodeID="A4">
+                <extractedText>/*
+ * (c) Copyright 2009 University of Bristol
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. The name of the author may not be used to endorse or promote products
+ *    derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */  </extractedText>
+                <licenseId>LicenseRef-4</licenseId>
+              </ExtractedLicensingInfo>
+            </member>
+            <member>
+              <ExtractedLicensingInfo rdf:nodeID="A5">
+                <rdfs:seeAlso>http://justasample.url.com</rdfs:seeAlso>
+                <rdfs:seeAlso>http://people.apache.org/~andyc/neko/LICENSE</rdfs:seeAlso>
+                <licenseName>CyberNeko License</licenseName>
+                <rdfs:comment>This is tye CyperNeko License</rdfs:comment>
+                <extractedText>The CyberNeko Software License, Version 1.0
+
+ 
+(C) Copyright 2002-2005, Andy Clark.  All rights reserved.
+ 
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer. 
+
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in
+   the documentation and/or other materials provided with the
+   distribution.
+
+3. The end-user documentation included with the redistribution,
+   if any, must include the following acknowledgment:  
+     "This product includes software developed by Andy Clark."
+   Alternately, this acknowledgment may appear in the software itself,
+   if and wherever such third-party acknowledgments normally appear.
+
+4. The names "CyberNeko" and "NekoHTML" must not be used to endorse
+   or promote products derived from this software without prior 
+   written permission. For written permission, please contact 
+   andyc@cyberneko.net.
+
+5. Products derived from this software may not be called "CyberNeko",
+   nor may "CyberNeko" appear in their name, without prior written
+   permission of the author.
+
+THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESSED OR IMPLIED
+WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR OTHER CONTRIBUTORS
+BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, 
+OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT 
+OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR 
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE 
+OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, 
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.</extractedText>
+                <licenseId>LicenseRef-3</licenseId>
+              </ExtractedLicensingInfo>
+            </member>
+          </ConjunctiveLicenseSet>
+        </licenseConcluded>
+        <sourceInfo>Version 1.0 of the SPDX Translator application</sourceInfo>
+        <checksum>
+          <Checksum>
+            <checksumValue>2fd4e1c67a2d28fced849ee1bb76e7391b93eb12</checksumValue>
+            <algorithm rdf:resource="http://spdx.org/rdf/terms#checksumAlgorithm_sha1"/>
+          </Checksum>
+        </checksum>
+        <packageFileName>spdxtranslator-1.0.zip</packageFileName>
+        <description>This utility translates and SPDX RDF XML document to a spreadsheet, translates a spreadsheet to an SPDX RDF XML document and translates an SPDX RDFa document to an SPDX RDF XML document.</description>
+        <licenseInfoFromFiles rdf:nodeID="A4"/>
+        <name>SPDX Translator</name>
+        <versionInfo>Version 0.9.2</versionInfo>
+        <licenseInfoFromFiles rdf:nodeID="A1"/>
+        <hasFile rdf:nodeID="A2"/>
+        <licenseInfoFromFiles rdf:nodeID="A3"/>
+        <copyrightText> Copyright 2010, 2011 Source Auditor Inc.</copyrightText>
+        <licenseDeclared>
+          <ConjunctiveLicenseSet>
+            <member rdf:nodeID="A3"/>
+            <member rdf:nodeID="A1"/>
+            <member rdf:resource="http://spdx.org/licenses/Apache-2.0"/>
+            <member rdf:resource="http://spdx.org/licenses/MPL-1.1"/>
+            <member rdf:nodeID="A4"/>
+            <member rdf:nodeID="A5"/>
+          </ConjunctiveLicenseSet>
+        </licenseDeclared>
+        <licenseInfoFromFiles rdf:nodeID="A5"/>
+        <originator>Organization:SPDX</originator>
+        <licenseComments>The declared license information can be found in the NOTICE file at the root of the archive file</licenseComments>
+        <summary>SPDX Translator utility</summary>
+        <licenseInfoFromFiles rdf:resource="http://spdx.org/licenses/MPL-1.1"/>
+        <externalRef>
+          <ExternalRef>
+            <referenceCategory rdf:resource="http://spdx.org/rdf/terms#referenceCategory_packageManager"/>
+            <referenceType rdf:resource="http://spdx.org/rdf/references/maven-central"/>
+            <referenceLocator>org.apache.commons:commons-lang:3.2.1</referenceLocator>
+            <rdfs:comment>NIST National Vulnerability Database (NVD) describes security vulnerabilities (CVEs) which affect Vendor Product Version acmecorp:acmenator:6.6.6</rdfs:comment>
+          </ExternalRef>
+        </externalRef>
+      </Package>
+    </describesPackage>
+    <rdfs:comment>This is a sample spreadsheet</rdfs:comment>
+    <hasExtractedLicensingInfo rdf:nodeID="A4"/>
+    <hasExtractedLicensingInfo rdf:nodeID="A5"/>
+    <hasExtractedLicensingInfo rdf:nodeID="A3"/>
+  </SpdxDocument>
+</rdf:RDF>

--- a/tests/data/parse_anything_test_files/SPDXRdfExample.rdf.spdx
+++ b/tests/data/parse_anything_test_files/SPDXRdfExample.rdf.spdx
@@ -1,0 +1,305 @@
+<rdf:RDF
+    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+    xmlns:j.0="http://usefulinc.com/ns/doap#"
+    xmlns="http://spdx.org/rdf/terms#"
+    xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">
+  <Snippet rdf:about="http://spdx.org/spdxdocs/spdx-example-444504E0-4F89-41D3-9A0C-0305E82C3301#SPDXRef-Snippet">
+    <snippetFromFile>
+      <File rdf:about="http://spdx.org/spdxdocs/spdx-example-444504E0-4F89-41D3-9A0C-0305E82C3301#SPDXRef-DoapSource"/>
+    </snippetFromFile>
+    <name>from linux kernel</name>
+    <copyrightText>Copyright 2008-2010 John Smith</copyrightText>
+    <licenseComments>The concluded license was taken from package xyz, from which the snippet was copied into the current file. The concluded license information was found in the COPYING.txt file in package xyz.</licenseComments>
+    <rdfs:comment>This snippet was identified as significant and highlighted in this Apache-2.0 file, when a commercial scanner identified it as being derived from file foo.c in package xyz which is licensed under GPL-2.0-or-later.</rdfs:comment>
+    <licenseConcluded rdf:resource="http://spdx.org/licenses/Apache-2.0"/>
+    <licenseInfoInSnippet rdf:resource="http://spdx.org/licenses/Apache-2.0"/>
+  </Snippet>
+  <SpdxDocument rdf:about="https://spdx.org/spdxdocs/spdx-example-444504E0-4F89-41D3-9A0C-0305E82C3301#SPDXRef-DOCUMENT">
+    <name>Sample_Document-V2.1</name>
+    <creationInfo>
+      <CreationInfo>
+        <created>2010-02-03T00:00:00Z</created>
+        <rdfs:comment>This is an example of an SPDX spreadsheet format</rdfs:comment>
+        <creator>Tool: SourceAuditor-V1.2</creator>
+        <creator>Organization: Source Auditor Inc.</creator>
+        <creator>Person: Gary O'Neall</creator>
+      </CreationInfo>
+    </creationInfo>
+    <specVersion>SPDX-2.1</specVersion>
+    <externalDocumentRef>
+      <ExternalDocumentRef>
+        <externalDocumentId>DocumentRef-spdx-tool-2.1</externalDocumentId>
+        <spdxDocument rdf:resource="https://spdx.org/spdxdocs/spdx-tools-v2.1-3F2504E0-4F89-41D3-9A0C-0305E82C3301"/>
+        <checksum>
+          <Checksum>
+            <checksumValue>d6a770ba38583ed4bb4525bd96e50461655d2759</checksumValue>
+            <algorithm rdf:resource="http://spdx.org/rdf/terms#checksumAlgorithm_sha1"/>
+          </Checksum>
+        </checksum>
+      </ExternalDocumentRef>
+    </externalDocumentRef>
+    <referencesFile>
+      <File rdf:about="https://spdx.org/spdxdocs/spdx-example-444504E0-4F89-41D3-9A0C-0305E82C3301#SPDXRef-File1">>
+        <licenseConcluded>
+          <ExtractedLicensingInfo rdf:nodeID="A1">
+            <extractedText>/*
+ * (c) Copyright 2000, 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009 Hewlett-Packard Development Company, LP
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. The name of the author may not be used to endorse or promote products
+ *    derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */</extractedText>
+            <licenseId>LicenseRef-1</licenseId>
+          </ExtractedLicensingInfo>
+        </licenseConcluded>
+        <artifactOf>
+          <j.0:Project>
+            <j.0:homepage>http://www.openjena.org/</j.0:homepage>
+            <j.0:name>Jena</j.0:name>
+          </j.0:Project>
+        </artifactOf>
+        <licenseComments>This license is used by Jena</licenseComments>
+        <fileName>Jenna-2.6.3/jena-2.6.3-sources.jar</fileName>
+        <fileType rdf:resource="http://spdx.org/rdf/terms#fileType_archive"/>
+        <copyrightText>(c) Copyright 2000, 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009 Hewlett-Packard Development Company, LP</copyrightText>
+        <licenseInfoInFile rdf:nodeID="A1"/>
+        <rdfs:comment>This file belongs to Jena</rdfs:comment>
+        <checksum>
+          <Checksum>
+            <checksumValue>3ab4e1c67a2d28fced849ee1bb76e7391b93f125</checksumValue>
+            <algorithm rdf:resource="http://spdx.org/rdf/terms#checksumAlgorithm_sha1"/>
+          </Checksum>
+        </checksum>
+      </File>
+    </referencesFile>
+    <reviewed>
+      <Review>
+        <rdfs:comment>This is just an example.  Some of the non-standard licenses look like they are actually BSD 3 clause licenses</rdfs:comment>
+        <reviewDate>2010-02-10T00:00:00Z</reviewDate>
+        <reviewer>Person: Joe Reviewer</reviewer>
+      </Review>
+    </reviewed>
+    <dataLicense rdf:resource="http://spdx.org/licenses/CC0-1.0"/>
+    <hasExtractedLicensingInfo rdf:nodeID="A1"/>
+    <reviewed>
+      <Review>
+        <rdfs:comment>Another example reviewer.</rdfs:comment>
+        <reviewDate>2011-03-13T00:00:00Z</reviewDate>
+        <reviewer>Person: Suzanne Reviewer</reviewer>
+      </Review>
+    </reviewed>
+    <annotation>
+      <Annotation rdf:about="https://spdx.org/spdxdocs/spdx-example-444504E0-4F89-41D3-9A0C-0305E82C3301#SPDXRef-45">
+        <annotationType rdf:resource="http://spdx.org/rdf/terms#annotationType_review"/>
+        <rdfs:comment>This is just an example. Some of the non-standard licenses look like they are actually BSD 3 clause licenses</rdfs:comment>
+        <annotationDate>2012-06-13T00:00:00Z</annotationDate>
+        <annotator>Person: Jim Reviewer</annotator>
+      </Annotation>
+    </annotation>
+    <relationship>
+      <Relationship>
+        <relationshipType rdf:resource="http://spdx.org/rdf/terms#relationshipType_describes"/>
+        <relatedSpdxElement rdf:resource="http://spdx.org/spdxdocs/spdx-example-444504E0-4F89-41D3-9A0C-0305E82C3301#SPDXRef-Package"/>
+      </Relationship>
+    </relationship>
+    <referencesFile>
+      <File rdf:about="https://spdx.org/spdxdocs/spdx-example-444504E0-4F89-41D3-9A0C-0305E82C3301#SPDXRef-File2">
+        <copyrightText>Copyright 2010, 2011 Source Auditor Inc.</copyrightText>
+        <licenseInfoInFile rdf:resource="http://spdx.org/licenses/Apache-2.0"/>
+        <licenseConcluded rdf:resource="http://spdx.org/licenses/Apache-2.0"/>
+        <fileType rdf:resource="http://spdx.org/rdf/terms#fileType_source"/>
+        <checksum>
+          <Checksum>
+            <checksumValue>2fd4e1c67a2d28fced849ee1bb76e7391b93eb12</checksumValue>
+            <algorithm rdf:resource="http://spdx.org/rdf/terms#checksumAlgorithm_sha1"/>
+          </Checksum>
+        </checksum>
+        <fileName>src/org/spdx/parser/DOAPProject.java</fileName>
+      </File>
+    </referencesFile>
+    <describesPackage>
+      <Package rdf:about="http://www.spdx.org/tools#SPDXRef-Package">
+        <licenseInfoFromFiles rdf:resource="http://spdx.org/licenses/Apache-1.0"/>
+        <downloadLocation>http://www.spdx.org/tools</downloadLocation>
+        <filesAnalyzed>true</filesAnalyzed>
+        <supplier>Organization:Linux Foundation</supplier>
+        <hasFile rdf:nodeID="A0"/>
+        <licenseInfoFromFiles rdf:resource="http://spdx.org/licenses/Apache-2.0"/>
+        <packageVerificationCode>
+          <PackageVerificationCode>
+            <packageVerificationCodeValue>4e3211c67a2d28fced849ee1bb76e7391b93feba</packageVerificationCodeValue>
+            <packageVerificationCodeExcludedFile>SpdxTranslatorSpdx.txt</packageVerificationCodeExcludedFile>
+            <packageVerificationCodeExcludedFile>SpdxTranslatorSpdx.rdf</packageVerificationCodeExcludedFile>
+          </PackageVerificationCode>
+        </packageVerificationCode>
+        <licenseConcluded>
+          <ConjunctiveLicenseSet>
+            <member>
+              <ExtractedLicensingInfo rdf:nodeID="A3">
+                <extractedText>This package includes the GRDDL parser developed by Hewlett Packard under the following license:
+© Copyright 2007 Hewlett-Packard Development Company, LP
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met: 
+
+Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer. 
+Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution. 
+The name of the author may not be used to endorse or promote products derived from this software without specific prior written permission. 
+THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. </extractedText>
+                <licenseId>LicenseRef-2</licenseId>
+              </ExtractedLicensingInfo>
+            </member>
+            <member rdf:nodeID="A1"/>
+            <member rdf:resource="http://spdx.org/licenses/Apache-2.0"/>
+            <member rdf:resource="http://spdx.org/licenses/MPL-1.1"/>
+            <member rdf:resource="http://spdx.org/licenses/Apache-1.0"/>
+            <member>
+              <ExtractedLicensingInfo rdf:nodeID="A4">
+                <extractedText>/*
+ * (c) Copyright 2009 University of Bristol
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. The name of the author may not be used to endorse or promote products
+ *    derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */  </extractedText>
+                <licenseId>LicenseRef-4</licenseId>
+              </ExtractedLicensingInfo>
+            </member>
+            <member>
+              <ExtractedLicensingInfo rdf:nodeID="A5">
+                <rdfs:seeAlso>http://justasample.url.com</rdfs:seeAlso>
+                <rdfs:seeAlso>http://people.apache.org/~andyc/neko/LICENSE</rdfs:seeAlso>
+                <licenseName>CyberNeko License</licenseName>
+                <rdfs:comment>This is tye CyperNeko License</rdfs:comment>
+                <extractedText>The CyberNeko Software License, Version 1.0
+
+ 
+(C) Copyright 2002-2005, Andy Clark.  All rights reserved.
+ 
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer. 
+
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in
+   the documentation and/or other materials provided with the
+   distribution.
+
+3. The end-user documentation included with the redistribution,
+   if any, must include the following acknowledgment:  
+     "This product includes software developed by Andy Clark."
+   Alternately, this acknowledgment may appear in the software itself,
+   if and wherever such third-party acknowledgments normally appear.
+
+4. The names "CyberNeko" and "NekoHTML" must not be used to endorse
+   or promote products derived from this software without prior 
+   written permission. For written permission, please contact 
+   andyc@cyberneko.net.
+
+5. Products derived from this software may not be called "CyberNeko",
+   nor may "CyberNeko" appear in their name, without prior written
+   permission of the author.
+
+THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESSED OR IMPLIED
+WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR OTHER CONTRIBUTORS
+BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, 
+OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT 
+OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR 
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE 
+OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, 
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.</extractedText>
+                <licenseId>LicenseRef-3</licenseId>
+              </ExtractedLicensingInfo>
+            </member>
+          </ConjunctiveLicenseSet>
+        </licenseConcluded>
+        <sourceInfo>Version 1.0 of the SPDX Translator application</sourceInfo>
+        <checksum>
+          <Checksum>
+            <checksumValue>2fd4e1c67a2d28fced849ee1bb76e7391b93eb12</checksumValue>
+            <algorithm rdf:resource="http://spdx.org/rdf/terms#checksumAlgorithm_sha1"/>
+          </Checksum>
+        </checksum>
+        <packageFileName>spdxtranslator-1.0.zip</packageFileName>
+        <description>This utility translates and SPDX RDF XML document to a spreadsheet, translates a spreadsheet to an SPDX RDF XML document and translates an SPDX RDFa document to an SPDX RDF XML document.</description>
+        <licenseInfoFromFiles rdf:nodeID="A4"/>
+        <name>SPDX Translator</name>
+        <versionInfo>Version 0.9.2</versionInfo>
+        <licenseInfoFromFiles rdf:nodeID="A1"/>
+        <hasFile rdf:nodeID="A2"/>
+        <licenseInfoFromFiles rdf:nodeID="A3"/>
+        <copyrightText> Copyright 2010, 2011 Source Auditor Inc.</copyrightText>
+        <licenseDeclared>
+          <ConjunctiveLicenseSet>
+            <member rdf:nodeID="A3"/>
+            <member rdf:nodeID="A1"/>
+            <member rdf:resource="http://spdx.org/licenses/Apache-2.0"/>
+            <member rdf:resource="http://spdx.org/licenses/MPL-1.1"/>
+            <member rdf:nodeID="A4"/>
+            <member rdf:nodeID="A5"/>
+          </ConjunctiveLicenseSet>
+        </licenseDeclared>
+        <licenseInfoFromFiles rdf:nodeID="A5"/>
+        <originator>Organization:SPDX</originator>
+        <licenseComments>The declared license information can be found in the NOTICE file at the root of the archive file</licenseComments>
+        <summary>SPDX Translator utility</summary>
+        <licenseInfoFromFiles rdf:resource="http://spdx.org/licenses/MPL-1.1"/>
+        <externalRef>
+          <ExternalRef>
+            <referenceCategory rdf:resource="http://spdx.org/rdf/terms#referenceCategory_packageManager"/>
+            <referenceType rdf:resource="http://spdx.org/rdf/references/maven-central"/>
+            <referenceLocator>org.apache.commons:commons-lang:3.2.1</referenceLocator>
+            <rdfs:comment>NIST National Vulnerability Database (NVD) describes security vulnerabilities (CVEs) which affect Vendor Product Version acmecorp:acmenator:6.6.6</rdfs:comment>
+          </ExternalRef>
+        </externalRef>
+      </Package>
+    </describesPackage>
+    <rdfs:comment>This is a sample spreadsheet</rdfs:comment>
+    <hasExtractedLicensingInfo rdf:nodeID="A4"/>
+    <hasExtractedLicensingInfo rdf:nodeID="A5"/>
+    <hasExtractedLicensingInfo rdf:nodeID="A3"/>
+  </SpdxDocument>
+</rdf:RDF>

--- a/tests/data/parse_anything_test_files/SPDXRdfExample.rdf.spdx.yml
+++ b/tests/data/parse_anything_test_files/SPDXRdfExample.rdf.spdx.yml
@@ -1,0 +1,305 @@
+<rdf:RDF
+    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+    xmlns:j.0="http://usefulinc.com/ns/doap#"
+    xmlns="http://spdx.org/rdf/terms#"
+    xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">
+  <Snippet rdf:about="http://spdx.org/spdxdocs/spdx-example-444504E0-4F89-41D3-9A0C-0305E82C3301#SPDXRef-Snippet">
+    <snippetFromFile>
+      <File rdf:about="http://spdx.org/spdxdocs/spdx-example-444504E0-4F89-41D3-9A0C-0305E82C3301#SPDXRef-DoapSource"/>
+    </snippetFromFile>
+    <name>from linux kernel</name>
+    <copyrightText>Copyright 2008-2010 John Smith</copyrightText>
+    <licenseComments>The concluded license was taken from package xyz, from which the snippet was copied into the current file. The concluded license information was found in the COPYING.txt file in package xyz.</licenseComments>
+    <rdfs:comment>This snippet was identified as significant and highlighted in this Apache-2.0 file, when a commercial scanner identified it as being derived from file foo.c in package xyz which is licensed under GPL-2.0-or-later.</rdfs:comment>
+    <licenseConcluded rdf:resource="http://spdx.org/licenses/Apache-2.0"/>
+    <licenseInfoInSnippet rdf:resource="http://spdx.org/licenses/Apache-2.0"/>
+  </Snippet>
+  <SpdxDocument rdf:about="https://spdx.org/spdxdocs/spdx-example-444504E0-4F89-41D3-9A0C-0305E82C3301#SPDXRef-DOCUMENT">
+    <name>Sample_Document-V2.1</name>
+    <creationInfo>
+      <CreationInfo>
+        <created>2010-02-03T00:00:00Z</created>
+        <rdfs:comment>This is an example of an SPDX spreadsheet format</rdfs:comment>
+        <creator>Tool: SourceAuditor-V1.2</creator>
+        <creator>Organization: Source Auditor Inc.</creator>
+        <creator>Person: Gary O'Neall</creator>
+      </CreationInfo>
+    </creationInfo>
+    <specVersion>SPDX-2.1</specVersion>
+    <externalDocumentRef>
+      <ExternalDocumentRef>
+        <externalDocumentId>DocumentRef-spdx-tool-2.1</externalDocumentId>
+        <spdxDocument rdf:resource="https://spdx.org/spdxdocs/spdx-tools-v2.1-3F2504E0-4F89-41D3-9A0C-0305E82C3301"/>
+        <checksum>
+          <Checksum>
+            <checksumValue>d6a770ba38583ed4bb4525bd96e50461655d2759</checksumValue>
+            <algorithm rdf:resource="http://spdx.org/rdf/terms#checksumAlgorithm_sha1"/>
+          </Checksum>
+        </checksum>
+      </ExternalDocumentRef>
+    </externalDocumentRef>
+    <referencesFile>
+      <File rdf:about="https://spdx.org/spdxdocs/spdx-example-444504E0-4F89-41D3-9A0C-0305E82C3301#SPDXRef-File1">>
+        <licenseConcluded>
+          <ExtractedLicensingInfo rdf:nodeID="A1">
+            <extractedText>/*
+ * (c) Copyright 2000, 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009 Hewlett-Packard Development Company, LP
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. The name of the author may not be used to endorse or promote products
+ *    derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */</extractedText>
+            <licenseId>LicenseRef-1</licenseId>
+          </ExtractedLicensingInfo>
+        </licenseConcluded>
+        <artifactOf>
+          <j.0:Project>
+            <j.0:homepage>http://www.openjena.org/</j.0:homepage>
+            <j.0:name>Jena</j.0:name>
+          </j.0:Project>
+        </artifactOf>
+        <licenseComments>This license is used by Jena</licenseComments>
+        <fileName>Jenna-2.6.3/jena-2.6.3-sources.jar</fileName>
+        <fileType rdf:resource="http://spdx.org/rdf/terms#fileType_archive"/>
+        <copyrightText>(c) Copyright 2000, 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009 Hewlett-Packard Development Company, LP</copyrightText>
+        <licenseInfoInFile rdf:nodeID="A1"/>
+        <rdfs:comment>This file belongs to Jena</rdfs:comment>
+        <checksum>
+          <Checksum>
+            <checksumValue>3ab4e1c67a2d28fced849ee1bb76e7391b93f125</checksumValue>
+            <algorithm rdf:resource="http://spdx.org/rdf/terms#checksumAlgorithm_sha1"/>
+          </Checksum>
+        </checksum>
+      </File>
+    </referencesFile>
+    <reviewed>
+      <Review>
+        <rdfs:comment>This is just an example.  Some of the non-standard licenses look like they are actually BSD 3 clause licenses</rdfs:comment>
+        <reviewDate>2010-02-10T00:00:00Z</reviewDate>
+        <reviewer>Person: Joe Reviewer</reviewer>
+      </Review>
+    </reviewed>
+    <dataLicense rdf:resource="http://spdx.org/licenses/CC0-1.0"/>
+    <hasExtractedLicensingInfo rdf:nodeID="A1"/>
+    <reviewed>
+      <Review>
+        <rdfs:comment>Another example reviewer.</rdfs:comment>
+        <reviewDate>2011-03-13T00:00:00Z</reviewDate>
+        <reviewer>Person: Suzanne Reviewer</reviewer>
+      </Review>
+    </reviewed>
+    <annotation>
+      <Annotation rdf:about="https://spdx.org/spdxdocs/spdx-example-444504E0-4F89-41D3-9A0C-0305E82C3301#SPDXRef-45">
+        <annotationType rdf:resource="http://spdx.org/rdf/terms#annotationType_review"/>
+        <rdfs:comment>This is just an example. Some of the non-standard licenses look like they are actually BSD 3 clause licenses</rdfs:comment>
+        <annotationDate>2012-06-13T00:00:00Z</annotationDate>
+        <annotator>Person: Jim Reviewer</annotator>
+      </Annotation>
+    </annotation>
+    <relationship>
+      <Relationship>
+        <relationshipType rdf:resource="http://spdx.org/rdf/terms#relationshipType_describes"/>
+        <relatedSpdxElement rdf:resource="http://spdx.org/spdxdocs/spdx-example-444504E0-4F89-41D3-9A0C-0305E82C3301#SPDXRef-Package"/>
+      </Relationship>
+    </relationship>
+    <referencesFile>
+      <File rdf:about="https://spdx.org/spdxdocs/spdx-example-444504E0-4F89-41D3-9A0C-0305E82C3301#SPDXRef-File2">
+        <copyrightText>Copyright 2010, 2011 Source Auditor Inc.</copyrightText>
+        <licenseInfoInFile rdf:resource="http://spdx.org/licenses/Apache-2.0"/>
+        <licenseConcluded rdf:resource="http://spdx.org/licenses/Apache-2.0"/>
+        <fileType rdf:resource="http://spdx.org/rdf/terms#fileType_source"/>
+        <checksum>
+          <Checksum>
+            <checksumValue>2fd4e1c67a2d28fced849ee1bb76e7391b93eb12</checksumValue>
+            <algorithm rdf:resource="http://spdx.org/rdf/terms#checksumAlgorithm_sha1"/>
+          </Checksum>
+        </checksum>
+        <fileName>src/org/spdx/parser/DOAPProject.java</fileName>
+      </File>
+    </referencesFile>
+    <describesPackage>
+      <Package rdf:about="http://www.spdx.org/tools#SPDXRef-Package">
+        <licenseInfoFromFiles rdf:resource="http://spdx.org/licenses/Apache-1.0"/>
+        <downloadLocation>http://www.spdx.org/tools</downloadLocation>
+        <filesAnalyzed>true</filesAnalyzed>
+        <supplier>Organization:Linux Foundation</supplier>
+        <hasFile rdf:nodeID="A0"/>
+        <licenseInfoFromFiles rdf:resource="http://spdx.org/licenses/Apache-2.0"/>
+        <packageVerificationCode>
+          <PackageVerificationCode>
+            <packageVerificationCodeValue>4e3211c67a2d28fced849ee1bb76e7391b93feba</packageVerificationCodeValue>
+            <packageVerificationCodeExcludedFile>SpdxTranslatorSpdx.txt</packageVerificationCodeExcludedFile>
+            <packageVerificationCodeExcludedFile>SpdxTranslatorSpdx.rdf</packageVerificationCodeExcludedFile>
+          </PackageVerificationCode>
+        </packageVerificationCode>
+        <licenseConcluded>
+          <ConjunctiveLicenseSet>
+            <member>
+              <ExtractedLicensingInfo rdf:nodeID="A3">
+                <extractedText>This package includes the GRDDL parser developed by Hewlett Packard under the following license:
+© Copyright 2007 Hewlett-Packard Development Company, LP
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met: 
+
+Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer. 
+Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution. 
+The name of the author may not be used to endorse or promote products derived from this software without specific prior written permission. 
+THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. </extractedText>
+                <licenseId>LicenseRef-2</licenseId>
+              </ExtractedLicensingInfo>
+            </member>
+            <member rdf:nodeID="A1"/>
+            <member rdf:resource="http://spdx.org/licenses/Apache-2.0"/>
+            <member rdf:resource="http://spdx.org/licenses/MPL-1.1"/>
+            <member rdf:resource="http://spdx.org/licenses/Apache-1.0"/>
+            <member>
+              <ExtractedLicensingInfo rdf:nodeID="A4">
+                <extractedText>/*
+ * (c) Copyright 2009 University of Bristol
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. The name of the author may not be used to endorse or promote products
+ *    derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */  </extractedText>
+                <licenseId>LicenseRef-4</licenseId>
+              </ExtractedLicensingInfo>
+            </member>
+            <member>
+              <ExtractedLicensingInfo rdf:nodeID="A5">
+                <rdfs:seeAlso>http://justasample.url.com</rdfs:seeAlso>
+                <rdfs:seeAlso>http://people.apache.org/~andyc/neko/LICENSE</rdfs:seeAlso>
+                <licenseName>CyberNeko License</licenseName>
+                <rdfs:comment>This is tye CyperNeko License</rdfs:comment>
+                <extractedText>The CyberNeko Software License, Version 1.0
+
+ 
+(C) Copyright 2002-2005, Andy Clark.  All rights reserved.
+ 
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer. 
+
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in
+   the documentation and/or other materials provided with the
+   distribution.
+
+3. The end-user documentation included with the redistribution,
+   if any, must include the following acknowledgment:  
+     "This product includes software developed by Andy Clark."
+   Alternately, this acknowledgment may appear in the software itself,
+   if and wherever such third-party acknowledgments normally appear.
+
+4. The names "CyberNeko" and "NekoHTML" must not be used to endorse
+   or promote products derived from this software without prior 
+   written permission. For written permission, please contact 
+   andyc@cyberneko.net.
+
+5. Products derived from this software may not be called "CyberNeko",
+   nor may "CyberNeko" appear in their name, without prior written
+   permission of the author.
+
+THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESSED OR IMPLIED
+WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR OTHER CONTRIBUTORS
+BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, 
+OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT 
+OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR 
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE 
+OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, 
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.</extractedText>
+                <licenseId>LicenseRef-3</licenseId>
+              </ExtractedLicensingInfo>
+            </member>
+          </ConjunctiveLicenseSet>
+        </licenseConcluded>
+        <sourceInfo>Version 1.0 of the SPDX Translator application</sourceInfo>
+        <checksum>
+          <Checksum>
+            <checksumValue>2fd4e1c67a2d28fced849ee1bb76e7391b93eb12</checksumValue>
+            <algorithm rdf:resource="http://spdx.org/rdf/terms#checksumAlgorithm_sha1"/>
+          </Checksum>
+        </checksum>
+        <packageFileName>spdxtranslator-1.0.zip</packageFileName>
+        <description>This utility translates and SPDX RDF XML document to a spreadsheet, translates a spreadsheet to an SPDX RDF XML document and translates an SPDX RDFa document to an SPDX RDF XML document.</description>
+        <licenseInfoFromFiles rdf:nodeID="A4"/>
+        <name>SPDX Translator</name>
+        <versionInfo>Version 0.9.2</versionInfo>
+        <licenseInfoFromFiles rdf:nodeID="A1"/>
+        <hasFile rdf:nodeID="A2"/>
+        <licenseInfoFromFiles rdf:nodeID="A3"/>
+        <copyrightText> Copyright 2010, 2011 Source Auditor Inc.</copyrightText>
+        <licenseDeclared>
+          <ConjunctiveLicenseSet>
+            <member rdf:nodeID="A3"/>
+            <member rdf:nodeID="A1"/>
+            <member rdf:resource="http://spdx.org/licenses/Apache-2.0"/>
+            <member rdf:resource="http://spdx.org/licenses/MPL-1.1"/>
+            <member rdf:nodeID="A4"/>
+            <member rdf:nodeID="A5"/>
+          </ConjunctiveLicenseSet>
+        </licenseDeclared>
+        <licenseInfoFromFiles rdf:nodeID="A5"/>
+        <originator>Organization:SPDX</originator>
+        <licenseComments>The declared license information can be found in the NOTICE file at the root of the archive file</licenseComments>
+        <summary>SPDX Translator utility</summary>
+        <licenseInfoFromFiles rdf:resource="http://spdx.org/licenses/MPL-1.1"/>
+        <externalRef>
+          <ExternalRef>
+            <referenceCategory rdf:resource="http://spdx.org/rdf/terms#referenceCategory_packageManager"/>
+            <referenceType rdf:resource="http://spdx.org/rdf/references/maven-central"/>
+            <referenceLocator>org.apache.commons:commons-lang:3.2.1</referenceLocator>
+            <rdfs:comment>NIST National Vulnerability Database (NVD) describes security vulnerabilities (CVEs) which affect Vendor Product Version acmecorp:acmenator:6.6.6</rdfs:comment>
+          </ExternalRef>
+        </externalRef>
+      </Package>
+    </describesPackage>
+    <rdfs:comment>This is a sample spreadsheet</rdfs:comment>
+    <hasExtractedLicensingInfo rdf:nodeID="A4"/>
+    <hasExtractedLicensingInfo rdf:nodeID="A5"/>
+    <hasExtractedLicensingInfo rdf:nodeID="A3"/>
+  </SpdxDocument>
+</rdf:RDF>

--- a/tests/data/parse_anything_test_files/SPDXRdfExample.rdf.tag
+++ b/tests/data/parse_anything_test_files/SPDXRdfExample.rdf.tag
@@ -1,0 +1,305 @@
+<rdf:RDF
+    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+    xmlns:j.0="http://usefulinc.com/ns/doap#"
+    xmlns="http://spdx.org/rdf/terms#"
+    xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">
+  <Snippet rdf:about="http://spdx.org/spdxdocs/spdx-example-444504E0-4F89-41D3-9A0C-0305E82C3301#SPDXRef-Snippet">
+    <snippetFromFile>
+      <File rdf:about="http://spdx.org/spdxdocs/spdx-example-444504E0-4F89-41D3-9A0C-0305E82C3301#SPDXRef-DoapSource"/>
+    </snippetFromFile>
+    <name>from linux kernel</name>
+    <copyrightText>Copyright 2008-2010 John Smith</copyrightText>
+    <licenseComments>The concluded license was taken from package xyz, from which the snippet was copied into the current file. The concluded license information was found in the COPYING.txt file in package xyz.</licenseComments>
+    <rdfs:comment>This snippet was identified as significant and highlighted in this Apache-2.0 file, when a commercial scanner identified it as being derived from file foo.c in package xyz which is licensed under GPL-2.0-or-later.</rdfs:comment>
+    <licenseConcluded rdf:resource="http://spdx.org/licenses/Apache-2.0"/>
+    <licenseInfoInSnippet rdf:resource="http://spdx.org/licenses/Apache-2.0"/>
+  </Snippet>
+  <SpdxDocument rdf:about="https://spdx.org/spdxdocs/spdx-example-444504E0-4F89-41D3-9A0C-0305E82C3301#SPDXRef-DOCUMENT">
+    <name>Sample_Document-V2.1</name>
+    <creationInfo>
+      <CreationInfo>
+        <created>2010-02-03T00:00:00Z</created>
+        <rdfs:comment>This is an example of an SPDX spreadsheet format</rdfs:comment>
+        <creator>Tool: SourceAuditor-V1.2</creator>
+        <creator>Organization: Source Auditor Inc.</creator>
+        <creator>Person: Gary O'Neall</creator>
+      </CreationInfo>
+    </creationInfo>
+    <specVersion>SPDX-2.1</specVersion>
+    <externalDocumentRef>
+      <ExternalDocumentRef>
+        <externalDocumentId>DocumentRef-spdx-tool-2.1</externalDocumentId>
+        <spdxDocument rdf:resource="https://spdx.org/spdxdocs/spdx-tools-v2.1-3F2504E0-4F89-41D3-9A0C-0305E82C3301"/>
+        <checksum>
+          <Checksum>
+            <checksumValue>d6a770ba38583ed4bb4525bd96e50461655d2759</checksumValue>
+            <algorithm rdf:resource="http://spdx.org/rdf/terms#checksumAlgorithm_sha1"/>
+          </Checksum>
+        </checksum>
+      </ExternalDocumentRef>
+    </externalDocumentRef>
+    <referencesFile>
+      <File rdf:about="https://spdx.org/spdxdocs/spdx-example-444504E0-4F89-41D3-9A0C-0305E82C3301#SPDXRef-File1">>
+        <licenseConcluded>
+          <ExtractedLicensingInfo rdf:nodeID="A1">
+            <extractedText>/*
+ * (c) Copyright 2000, 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009 Hewlett-Packard Development Company, LP
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. The name of the author may not be used to endorse or promote products
+ *    derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */</extractedText>
+            <licenseId>LicenseRef-1</licenseId>
+          </ExtractedLicensingInfo>
+        </licenseConcluded>
+        <artifactOf>
+          <j.0:Project>
+            <j.0:homepage>http://www.openjena.org/</j.0:homepage>
+            <j.0:name>Jena</j.0:name>
+          </j.0:Project>
+        </artifactOf>
+        <licenseComments>This license is used by Jena</licenseComments>
+        <fileName>Jenna-2.6.3/jena-2.6.3-sources.jar</fileName>
+        <fileType rdf:resource="http://spdx.org/rdf/terms#fileType_archive"/>
+        <copyrightText>(c) Copyright 2000, 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009 Hewlett-Packard Development Company, LP</copyrightText>
+        <licenseInfoInFile rdf:nodeID="A1"/>
+        <rdfs:comment>This file belongs to Jena</rdfs:comment>
+        <checksum>
+          <Checksum>
+            <checksumValue>3ab4e1c67a2d28fced849ee1bb76e7391b93f125</checksumValue>
+            <algorithm rdf:resource="http://spdx.org/rdf/terms#checksumAlgorithm_sha1"/>
+          </Checksum>
+        </checksum>
+      </File>
+    </referencesFile>
+    <reviewed>
+      <Review>
+        <rdfs:comment>This is just an example.  Some of the non-standard licenses look like they are actually BSD 3 clause licenses</rdfs:comment>
+        <reviewDate>2010-02-10T00:00:00Z</reviewDate>
+        <reviewer>Person: Joe Reviewer</reviewer>
+      </Review>
+    </reviewed>
+    <dataLicense rdf:resource="http://spdx.org/licenses/CC0-1.0"/>
+    <hasExtractedLicensingInfo rdf:nodeID="A1"/>
+    <reviewed>
+      <Review>
+        <rdfs:comment>Another example reviewer.</rdfs:comment>
+        <reviewDate>2011-03-13T00:00:00Z</reviewDate>
+        <reviewer>Person: Suzanne Reviewer</reviewer>
+      </Review>
+    </reviewed>
+    <annotation>
+      <Annotation rdf:about="https://spdx.org/spdxdocs/spdx-example-444504E0-4F89-41D3-9A0C-0305E82C3301#SPDXRef-45">
+        <annotationType rdf:resource="http://spdx.org/rdf/terms#annotationType_review"/>
+        <rdfs:comment>This is just an example. Some of the non-standard licenses look like they are actually BSD 3 clause licenses</rdfs:comment>
+        <annotationDate>2012-06-13T00:00:00Z</annotationDate>
+        <annotator>Person: Jim Reviewer</annotator>
+      </Annotation>
+    </annotation>
+    <relationship>
+      <Relationship>
+        <relationshipType rdf:resource="http://spdx.org/rdf/terms#relationshipType_describes"/>
+        <relatedSpdxElement rdf:resource="http://spdx.org/spdxdocs/spdx-example-444504E0-4F89-41D3-9A0C-0305E82C3301#SPDXRef-Package"/>
+      </Relationship>
+    </relationship>
+    <referencesFile>
+      <File rdf:about="https://spdx.org/spdxdocs/spdx-example-444504E0-4F89-41D3-9A0C-0305E82C3301#SPDXRef-File2">
+        <copyrightText>Copyright 2010, 2011 Source Auditor Inc.</copyrightText>
+        <licenseInfoInFile rdf:resource="http://spdx.org/licenses/Apache-2.0"/>
+        <licenseConcluded rdf:resource="http://spdx.org/licenses/Apache-2.0"/>
+        <fileType rdf:resource="http://spdx.org/rdf/terms#fileType_source"/>
+        <checksum>
+          <Checksum>
+            <checksumValue>2fd4e1c67a2d28fced849ee1bb76e7391b93eb12</checksumValue>
+            <algorithm rdf:resource="http://spdx.org/rdf/terms#checksumAlgorithm_sha1"/>
+          </Checksum>
+        </checksum>
+        <fileName>src/org/spdx/parser/DOAPProject.java</fileName>
+      </File>
+    </referencesFile>
+    <describesPackage>
+      <Package rdf:about="http://www.spdx.org/tools#SPDXRef-Package">
+        <licenseInfoFromFiles rdf:resource="http://spdx.org/licenses/Apache-1.0"/>
+        <downloadLocation>http://www.spdx.org/tools</downloadLocation>
+        <filesAnalyzed>true</filesAnalyzed>
+        <supplier>Organization:Linux Foundation</supplier>
+        <hasFile rdf:nodeID="A0"/>
+        <licenseInfoFromFiles rdf:resource="http://spdx.org/licenses/Apache-2.0"/>
+        <packageVerificationCode>
+          <PackageVerificationCode>
+            <packageVerificationCodeValue>4e3211c67a2d28fced849ee1bb76e7391b93feba</packageVerificationCodeValue>
+            <packageVerificationCodeExcludedFile>SpdxTranslatorSpdx.txt</packageVerificationCodeExcludedFile>
+            <packageVerificationCodeExcludedFile>SpdxTranslatorSpdx.rdf</packageVerificationCodeExcludedFile>
+          </PackageVerificationCode>
+        </packageVerificationCode>
+        <licenseConcluded>
+          <ConjunctiveLicenseSet>
+            <member>
+              <ExtractedLicensingInfo rdf:nodeID="A3">
+                <extractedText>This package includes the GRDDL parser developed by Hewlett Packard under the following license:
+© Copyright 2007 Hewlett-Packard Development Company, LP
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met: 
+
+Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer. 
+Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution. 
+The name of the author may not be used to endorse or promote products derived from this software without specific prior written permission. 
+THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. </extractedText>
+                <licenseId>LicenseRef-2</licenseId>
+              </ExtractedLicensingInfo>
+            </member>
+            <member rdf:nodeID="A1"/>
+            <member rdf:resource="http://spdx.org/licenses/Apache-2.0"/>
+            <member rdf:resource="http://spdx.org/licenses/MPL-1.1"/>
+            <member rdf:resource="http://spdx.org/licenses/Apache-1.0"/>
+            <member>
+              <ExtractedLicensingInfo rdf:nodeID="A4">
+                <extractedText>/*
+ * (c) Copyright 2009 University of Bristol
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. The name of the author may not be used to endorse or promote products
+ *    derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */  </extractedText>
+                <licenseId>LicenseRef-4</licenseId>
+              </ExtractedLicensingInfo>
+            </member>
+            <member>
+              <ExtractedLicensingInfo rdf:nodeID="A5">
+                <rdfs:seeAlso>http://justasample.url.com</rdfs:seeAlso>
+                <rdfs:seeAlso>http://people.apache.org/~andyc/neko/LICENSE</rdfs:seeAlso>
+                <licenseName>CyberNeko License</licenseName>
+                <rdfs:comment>This is tye CyperNeko License</rdfs:comment>
+                <extractedText>The CyberNeko Software License, Version 1.0
+
+ 
+(C) Copyright 2002-2005, Andy Clark.  All rights reserved.
+ 
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer. 
+
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in
+   the documentation and/or other materials provided with the
+   distribution.
+
+3. The end-user documentation included with the redistribution,
+   if any, must include the following acknowledgment:  
+     "This product includes software developed by Andy Clark."
+   Alternately, this acknowledgment may appear in the software itself,
+   if and wherever such third-party acknowledgments normally appear.
+
+4. The names "CyberNeko" and "NekoHTML" must not be used to endorse
+   or promote products derived from this software without prior 
+   written permission. For written permission, please contact 
+   andyc@cyberneko.net.
+
+5. Products derived from this software may not be called "CyberNeko",
+   nor may "CyberNeko" appear in their name, without prior written
+   permission of the author.
+
+THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESSED OR IMPLIED
+WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR OTHER CONTRIBUTORS
+BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, 
+OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT 
+OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR 
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE 
+OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, 
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.</extractedText>
+                <licenseId>LicenseRef-3</licenseId>
+              </ExtractedLicensingInfo>
+            </member>
+          </ConjunctiveLicenseSet>
+        </licenseConcluded>
+        <sourceInfo>Version 1.0 of the SPDX Translator application</sourceInfo>
+        <checksum>
+          <Checksum>
+            <checksumValue>2fd4e1c67a2d28fced849ee1bb76e7391b93eb12</checksumValue>
+            <algorithm rdf:resource="http://spdx.org/rdf/terms#checksumAlgorithm_sha1"/>
+          </Checksum>
+        </checksum>
+        <packageFileName>spdxtranslator-1.0.zip</packageFileName>
+        <description>This utility translates and SPDX RDF XML document to a spreadsheet, translates a spreadsheet to an SPDX RDF XML document and translates an SPDX RDFa document to an SPDX RDF XML document.</description>
+        <licenseInfoFromFiles rdf:nodeID="A4"/>
+        <name>SPDX Translator</name>
+        <versionInfo>Version 0.9.2</versionInfo>
+        <licenseInfoFromFiles rdf:nodeID="A1"/>
+        <hasFile rdf:nodeID="A2"/>
+        <licenseInfoFromFiles rdf:nodeID="A3"/>
+        <copyrightText> Copyright 2010, 2011 Source Auditor Inc.</copyrightText>
+        <licenseDeclared>
+          <ConjunctiveLicenseSet>
+            <member rdf:nodeID="A3"/>
+            <member rdf:nodeID="A1"/>
+            <member rdf:resource="http://spdx.org/licenses/Apache-2.0"/>
+            <member rdf:resource="http://spdx.org/licenses/MPL-1.1"/>
+            <member rdf:nodeID="A4"/>
+            <member rdf:nodeID="A5"/>
+          </ConjunctiveLicenseSet>
+        </licenseDeclared>
+        <licenseInfoFromFiles rdf:nodeID="A5"/>
+        <originator>Organization:SPDX</originator>
+        <licenseComments>The declared license information can be found in the NOTICE file at the root of the archive file</licenseComments>
+        <summary>SPDX Translator utility</summary>
+        <licenseInfoFromFiles rdf:resource="http://spdx.org/licenses/MPL-1.1"/>
+        <externalRef>
+          <ExternalRef>
+            <referenceCategory rdf:resource="http://spdx.org/rdf/terms#referenceCategory_packageManager"/>
+            <referenceType rdf:resource="http://spdx.org/rdf/references/maven-central"/>
+            <referenceLocator>org.apache.commons:commons-lang:3.2.1</referenceLocator>
+            <rdfs:comment>NIST National Vulnerability Database (NVD) describes security vulnerabilities (CVEs) which affect Vendor Product Version acmecorp:acmenator:6.6.6</rdfs:comment>
+          </ExternalRef>
+        </externalRef>
+      </Package>
+    </describesPackage>
+    <rdfs:comment>This is a sample spreadsheet</rdfs:comment>
+    <hasExtractedLicensingInfo rdf:nodeID="A4"/>
+    <hasExtractedLicensingInfo rdf:nodeID="A5"/>
+    <hasExtractedLicensingInfo rdf:nodeID="A3"/>
+  </SpdxDocument>
+</rdf:RDF>

--- a/tests/data/parse_anything_test_files/SPDXRdfExample.rdf.xml
+++ b/tests/data/parse_anything_test_files/SPDXRdfExample.rdf.xml
@@ -1,0 +1,305 @@
+<rdf:RDF
+    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+    xmlns:j.0="http://usefulinc.com/ns/doap#"
+    xmlns="http://spdx.org/rdf/terms#"
+    xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">
+  <Snippet rdf:about="http://spdx.org/spdxdocs/spdx-example-444504E0-4F89-41D3-9A0C-0305E82C3301#SPDXRef-Snippet">
+    <snippetFromFile>
+      <File rdf:about="http://spdx.org/spdxdocs/spdx-example-444504E0-4F89-41D3-9A0C-0305E82C3301#SPDXRef-DoapSource"/>
+    </snippetFromFile>
+    <name>from linux kernel</name>
+    <copyrightText>Copyright 2008-2010 John Smith</copyrightText>
+    <licenseComments>The concluded license was taken from package xyz, from which the snippet was copied into the current file. The concluded license information was found in the COPYING.txt file in package xyz.</licenseComments>
+    <rdfs:comment>This snippet was identified as significant and highlighted in this Apache-2.0 file, when a commercial scanner identified it as being derived from file foo.c in package xyz which is licensed under GPL-2.0-or-later.</rdfs:comment>
+    <licenseConcluded rdf:resource="http://spdx.org/licenses/Apache-2.0"/>
+    <licenseInfoInSnippet rdf:resource="http://spdx.org/licenses/Apache-2.0"/>
+  </Snippet>
+  <SpdxDocument rdf:about="https://spdx.org/spdxdocs/spdx-example-444504E0-4F89-41D3-9A0C-0305E82C3301#SPDXRef-DOCUMENT">
+    <name>Sample_Document-V2.1</name>
+    <creationInfo>
+      <CreationInfo>
+        <created>2010-02-03T00:00:00Z</created>
+        <rdfs:comment>This is an example of an SPDX spreadsheet format</rdfs:comment>
+        <creator>Tool: SourceAuditor-V1.2</creator>
+        <creator>Organization: Source Auditor Inc.</creator>
+        <creator>Person: Gary O'Neall</creator>
+      </CreationInfo>
+    </creationInfo>
+    <specVersion>SPDX-2.1</specVersion>
+    <externalDocumentRef>
+      <ExternalDocumentRef>
+        <externalDocumentId>DocumentRef-spdx-tool-2.1</externalDocumentId>
+        <spdxDocument rdf:resource="https://spdx.org/spdxdocs/spdx-tools-v2.1-3F2504E0-4F89-41D3-9A0C-0305E82C3301"/>
+        <checksum>
+          <Checksum>
+            <checksumValue>d6a770ba38583ed4bb4525bd96e50461655d2759</checksumValue>
+            <algorithm rdf:resource="http://spdx.org/rdf/terms#checksumAlgorithm_sha1"/>
+          </Checksum>
+        </checksum>
+      </ExternalDocumentRef>
+    </externalDocumentRef>
+    <referencesFile>
+      <File rdf:about="https://spdx.org/spdxdocs/spdx-example-444504E0-4F89-41D3-9A0C-0305E82C3301#SPDXRef-File1">>
+        <licenseConcluded>
+          <ExtractedLicensingInfo rdf:nodeID="A1">
+            <extractedText>/*
+ * (c) Copyright 2000, 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009 Hewlett-Packard Development Company, LP
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. The name of the author may not be used to endorse or promote products
+ *    derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */</extractedText>
+            <licenseId>LicenseRef-1</licenseId>
+          </ExtractedLicensingInfo>
+        </licenseConcluded>
+        <artifactOf>
+          <j.0:Project>
+            <j.0:homepage>http://www.openjena.org/</j.0:homepage>
+            <j.0:name>Jena</j.0:name>
+          </j.0:Project>
+        </artifactOf>
+        <licenseComments>This license is used by Jena</licenseComments>
+        <fileName>Jenna-2.6.3/jena-2.6.3-sources.jar</fileName>
+        <fileType rdf:resource="http://spdx.org/rdf/terms#fileType_archive"/>
+        <copyrightText>(c) Copyright 2000, 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009 Hewlett-Packard Development Company, LP</copyrightText>
+        <licenseInfoInFile rdf:nodeID="A1"/>
+        <rdfs:comment>This file belongs to Jena</rdfs:comment>
+        <checksum>
+          <Checksum>
+            <checksumValue>3ab4e1c67a2d28fced849ee1bb76e7391b93f125</checksumValue>
+            <algorithm rdf:resource="http://spdx.org/rdf/terms#checksumAlgorithm_sha1"/>
+          </Checksum>
+        </checksum>
+      </File>
+    </referencesFile>
+    <reviewed>
+      <Review>
+        <rdfs:comment>This is just an example.  Some of the non-standard licenses look like they are actually BSD 3 clause licenses</rdfs:comment>
+        <reviewDate>2010-02-10T00:00:00Z</reviewDate>
+        <reviewer>Person: Joe Reviewer</reviewer>
+      </Review>
+    </reviewed>
+    <dataLicense rdf:resource="http://spdx.org/licenses/CC0-1.0"/>
+    <hasExtractedLicensingInfo rdf:nodeID="A1"/>
+    <reviewed>
+      <Review>
+        <rdfs:comment>Another example reviewer.</rdfs:comment>
+        <reviewDate>2011-03-13T00:00:00Z</reviewDate>
+        <reviewer>Person: Suzanne Reviewer</reviewer>
+      </Review>
+    </reviewed>
+    <annotation>
+      <Annotation rdf:about="https://spdx.org/spdxdocs/spdx-example-444504E0-4F89-41D3-9A0C-0305E82C3301#SPDXRef-45">
+        <annotationType rdf:resource="http://spdx.org/rdf/terms#annotationType_review"/>
+        <rdfs:comment>This is just an example. Some of the non-standard licenses look like they are actually BSD 3 clause licenses</rdfs:comment>
+        <annotationDate>2012-06-13T00:00:00Z</annotationDate>
+        <annotator>Person: Jim Reviewer</annotator>
+      </Annotation>
+    </annotation>
+    <relationship>
+      <Relationship>
+        <relationshipType rdf:resource="http://spdx.org/rdf/terms#relationshipType_describes"/>
+        <relatedSpdxElement rdf:resource="http://spdx.org/spdxdocs/spdx-example-444504E0-4F89-41D3-9A0C-0305E82C3301#SPDXRef-Package"/>
+      </Relationship>
+    </relationship>
+    <referencesFile>
+      <File rdf:about="https://spdx.org/spdxdocs/spdx-example-444504E0-4F89-41D3-9A0C-0305E82C3301#SPDXRef-File2">
+        <copyrightText>Copyright 2010, 2011 Source Auditor Inc.</copyrightText>
+        <licenseInfoInFile rdf:resource="http://spdx.org/licenses/Apache-2.0"/>
+        <licenseConcluded rdf:resource="http://spdx.org/licenses/Apache-2.0"/>
+        <fileType rdf:resource="http://spdx.org/rdf/terms#fileType_source"/>
+        <checksum>
+          <Checksum>
+            <checksumValue>2fd4e1c67a2d28fced849ee1bb76e7391b93eb12</checksumValue>
+            <algorithm rdf:resource="http://spdx.org/rdf/terms#checksumAlgorithm_sha1"/>
+          </Checksum>
+        </checksum>
+        <fileName>src/org/spdx/parser/DOAPProject.java</fileName>
+      </File>
+    </referencesFile>
+    <describesPackage>
+      <Package rdf:about="http://www.spdx.org/tools#SPDXRef-Package">
+        <licenseInfoFromFiles rdf:resource="http://spdx.org/licenses/Apache-1.0"/>
+        <downloadLocation>http://www.spdx.org/tools</downloadLocation>
+        <filesAnalyzed>true</filesAnalyzed>
+        <supplier>Organization:Linux Foundation</supplier>
+        <hasFile rdf:nodeID="A0"/>
+        <licenseInfoFromFiles rdf:resource="http://spdx.org/licenses/Apache-2.0"/>
+        <packageVerificationCode>
+          <PackageVerificationCode>
+            <packageVerificationCodeValue>4e3211c67a2d28fced849ee1bb76e7391b93feba</packageVerificationCodeValue>
+            <packageVerificationCodeExcludedFile>SpdxTranslatorSpdx.txt</packageVerificationCodeExcludedFile>
+            <packageVerificationCodeExcludedFile>SpdxTranslatorSpdx.rdf</packageVerificationCodeExcludedFile>
+          </PackageVerificationCode>
+        </packageVerificationCode>
+        <licenseConcluded>
+          <ConjunctiveLicenseSet>
+            <member>
+              <ExtractedLicensingInfo rdf:nodeID="A3">
+                <extractedText>This package includes the GRDDL parser developed by Hewlett Packard under the following license:
+© Copyright 2007 Hewlett-Packard Development Company, LP
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met: 
+
+Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer. 
+Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution. 
+The name of the author may not be used to endorse or promote products derived from this software without specific prior written permission. 
+THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. </extractedText>
+                <licenseId>LicenseRef-2</licenseId>
+              </ExtractedLicensingInfo>
+            </member>
+            <member rdf:nodeID="A1"/>
+            <member rdf:resource="http://spdx.org/licenses/Apache-2.0"/>
+            <member rdf:resource="http://spdx.org/licenses/MPL-1.1"/>
+            <member rdf:resource="http://spdx.org/licenses/Apache-1.0"/>
+            <member>
+              <ExtractedLicensingInfo rdf:nodeID="A4">
+                <extractedText>/*
+ * (c) Copyright 2009 University of Bristol
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. The name of the author may not be used to endorse or promote products
+ *    derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */  </extractedText>
+                <licenseId>LicenseRef-4</licenseId>
+              </ExtractedLicensingInfo>
+            </member>
+            <member>
+              <ExtractedLicensingInfo rdf:nodeID="A5">
+                <rdfs:seeAlso>http://justasample.url.com</rdfs:seeAlso>
+                <rdfs:seeAlso>http://people.apache.org/~andyc/neko/LICENSE</rdfs:seeAlso>
+                <licenseName>CyberNeko License</licenseName>
+                <rdfs:comment>This is tye CyperNeko License</rdfs:comment>
+                <extractedText>The CyberNeko Software License, Version 1.0
+
+ 
+(C) Copyright 2002-2005, Andy Clark.  All rights reserved.
+ 
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer. 
+
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in
+   the documentation and/or other materials provided with the
+   distribution.
+
+3. The end-user documentation included with the redistribution,
+   if any, must include the following acknowledgment:  
+     "This product includes software developed by Andy Clark."
+   Alternately, this acknowledgment may appear in the software itself,
+   if and wherever such third-party acknowledgments normally appear.
+
+4. The names "CyberNeko" and "NekoHTML" must not be used to endorse
+   or promote products derived from this software without prior 
+   written permission. For written permission, please contact 
+   andyc@cyberneko.net.
+
+5. Products derived from this software may not be called "CyberNeko",
+   nor may "CyberNeko" appear in their name, without prior written
+   permission of the author.
+
+THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESSED OR IMPLIED
+WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR OTHER CONTRIBUTORS
+BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, 
+OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT 
+OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR 
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE 
+OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, 
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.</extractedText>
+                <licenseId>LicenseRef-3</licenseId>
+              </ExtractedLicensingInfo>
+            </member>
+          </ConjunctiveLicenseSet>
+        </licenseConcluded>
+        <sourceInfo>Version 1.0 of the SPDX Translator application</sourceInfo>
+        <checksum>
+          <Checksum>
+            <checksumValue>2fd4e1c67a2d28fced849ee1bb76e7391b93eb12</checksumValue>
+            <algorithm rdf:resource="http://spdx.org/rdf/terms#checksumAlgorithm_sha1"/>
+          </Checksum>
+        </checksum>
+        <packageFileName>spdxtranslator-1.0.zip</packageFileName>
+        <description>This utility translates and SPDX RDF XML document to a spreadsheet, translates a spreadsheet to an SPDX RDF XML document and translates an SPDX RDFa document to an SPDX RDF XML document.</description>
+        <licenseInfoFromFiles rdf:nodeID="A4"/>
+        <name>SPDX Translator</name>
+        <versionInfo>Version 0.9.2</versionInfo>
+        <licenseInfoFromFiles rdf:nodeID="A1"/>
+        <hasFile rdf:nodeID="A2"/>
+        <licenseInfoFromFiles rdf:nodeID="A3"/>
+        <copyrightText> Copyright 2010, 2011 Source Auditor Inc.</copyrightText>
+        <licenseDeclared>
+          <ConjunctiveLicenseSet>
+            <member rdf:nodeID="A3"/>
+            <member rdf:nodeID="A1"/>
+            <member rdf:resource="http://spdx.org/licenses/Apache-2.0"/>
+            <member rdf:resource="http://spdx.org/licenses/MPL-1.1"/>
+            <member rdf:nodeID="A4"/>
+            <member rdf:nodeID="A5"/>
+          </ConjunctiveLicenseSet>
+        </licenseDeclared>
+        <licenseInfoFromFiles rdf:nodeID="A5"/>
+        <originator>Organization:SPDX</originator>
+        <licenseComments>The declared license information can be found in the NOTICE file at the root of the archive file</licenseComments>
+        <summary>SPDX Translator utility</summary>
+        <licenseInfoFromFiles rdf:resource="http://spdx.org/licenses/MPL-1.1"/>
+        <externalRef>
+          <ExternalRef>
+            <referenceCategory rdf:resource="http://spdx.org/rdf/terms#referenceCategory_packageManager"/>
+            <referenceType rdf:resource="http://spdx.org/rdf/references/maven-central"/>
+            <referenceLocator>org.apache.commons:commons-lang:3.2.1</referenceLocator>
+            <rdfs:comment>NIST National Vulnerability Database (NVD) describes security vulnerabilities (CVEs) which affect Vendor Product Version acmecorp:acmenator:6.6.6</rdfs:comment>
+          </ExternalRef>
+        </externalRef>
+      </Package>
+    </describesPackage>
+    <rdfs:comment>This is a sample spreadsheet</rdfs:comment>
+    <hasExtractedLicensingInfo rdf:nodeID="A4"/>
+    <hasExtractedLicensingInfo rdf:nodeID="A5"/>
+    <hasExtractedLicensingInfo rdf:nodeID="A3"/>
+  </SpdxDocument>
+</rdf:RDF>

--- a/tests/data/parse_anything_test_files/SPDXRdfExample.rdf.yaml
+++ b/tests/data/parse_anything_test_files/SPDXRdfExample.rdf.yaml
@@ -1,0 +1,305 @@
+<rdf:RDF
+    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+    xmlns:j.0="http://usefulinc.com/ns/doap#"
+    xmlns="http://spdx.org/rdf/terms#"
+    xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">
+  <Snippet rdf:about="http://spdx.org/spdxdocs/spdx-example-444504E0-4F89-41D3-9A0C-0305E82C3301#SPDXRef-Snippet">
+    <snippetFromFile>
+      <File rdf:about="http://spdx.org/spdxdocs/spdx-example-444504E0-4F89-41D3-9A0C-0305E82C3301#SPDXRef-DoapSource"/>
+    </snippetFromFile>
+    <name>from linux kernel</name>
+    <copyrightText>Copyright 2008-2010 John Smith</copyrightText>
+    <licenseComments>The concluded license was taken from package xyz, from which the snippet was copied into the current file. The concluded license information was found in the COPYING.txt file in package xyz.</licenseComments>
+    <rdfs:comment>This snippet was identified as significant and highlighted in this Apache-2.0 file, when a commercial scanner identified it as being derived from file foo.c in package xyz which is licensed under GPL-2.0-or-later.</rdfs:comment>
+    <licenseConcluded rdf:resource="http://spdx.org/licenses/Apache-2.0"/>
+    <licenseInfoInSnippet rdf:resource="http://spdx.org/licenses/Apache-2.0"/>
+  </Snippet>
+  <SpdxDocument rdf:about="https://spdx.org/spdxdocs/spdx-example-444504E0-4F89-41D3-9A0C-0305E82C3301#SPDXRef-DOCUMENT">
+    <name>Sample_Document-V2.1</name>
+    <creationInfo>
+      <CreationInfo>
+        <created>2010-02-03T00:00:00Z</created>
+        <rdfs:comment>This is an example of an SPDX spreadsheet format</rdfs:comment>
+        <creator>Tool: SourceAuditor-V1.2</creator>
+        <creator>Organization: Source Auditor Inc.</creator>
+        <creator>Person: Gary O'Neall</creator>
+      </CreationInfo>
+    </creationInfo>
+    <specVersion>SPDX-2.1</specVersion>
+    <externalDocumentRef>
+      <ExternalDocumentRef>
+        <externalDocumentId>DocumentRef-spdx-tool-2.1</externalDocumentId>
+        <spdxDocument rdf:resource="https://spdx.org/spdxdocs/spdx-tools-v2.1-3F2504E0-4F89-41D3-9A0C-0305E82C3301"/>
+        <checksum>
+          <Checksum>
+            <checksumValue>d6a770ba38583ed4bb4525bd96e50461655d2759</checksumValue>
+            <algorithm rdf:resource="http://spdx.org/rdf/terms#checksumAlgorithm_sha1"/>
+          </Checksum>
+        </checksum>
+      </ExternalDocumentRef>
+    </externalDocumentRef>
+    <referencesFile>
+      <File rdf:about="https://spdx.org/spdxdocs/spdx-example-444504E0-4F89-41D3-9A0C-0305E82C3301#SPDXRef-File1">>
+        <licenseConcluded>
+          <ExtractedLicensingInfo rdf:nodeID="A1">
+            <extractedText>/*
+ * (c) Copyright 2000, 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009 Hewlett-Packard Development Company, LP
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. The name of the author may not be used to endorse or promote products
+ *    derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */</extractedText>
+            <licenseId>LicenseRef-1</licenseId>
+          </ExtractedLicensingInfo>
+        </licenseConcluded>
+        <artifactOf>
+          <j.0:Project>
+            <j.0:homepage>http://www.openjena.org/</j.0:homepage>
+            <j.0:name>Jena</j.0:name>
+          </j.0:Project>
+        </artifactOf>
+        <licenseComments>This license is used by Jena</licenseComments>
+        <fileName>Jenna-2.6.3/jena-2.6.3-sources.jar</fileName>
+        <fileType rdf:resource="http://spdx.org/rdf/terms#fileType_archive"/>
+        <copyrightText>(c) Copyright 2000, 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009 Hewlett-Packard Development Company, LP</copyrightText>
+        <licenseInfoInFile rdf:nodeID="A1"/>
+        <rdfs:comment>This file belongs to Jena</rdfs:comment>
+        <checksum>
+          <Checksum>
+            <checksumValue>3ab4e1c67a2d28fced849ee1bb76e7391b93f125</checksumValue>
+            <algorithm rdf:resource="http://spdx.org/rdf/terms#checksumAlgorithm_sha1"/>
+          </Checksum>
+        </checksum>
+      </File>
+    </referencesFile>
+    <reviewed>
+      <Review>
+        <rdfs:comment>This is just an example.  Some of the non-standard licenses look like they are actually BSD 3 clause licenses</rdfs:comment>
+        <reviewDate>2010-02-10T00:00:00Z</reviewDate>
+        <reviewer>Person: Joe Reviewer</reviewer>
+      </Review>
+    </reviewed>
+    <dataLicense rdf:resource="http://spdx.org/licenses/CC0-1.0"/>
+    <hasExtractedLicensingInfo rdf:nodeID="A1"/>
+    <reviewed>
+      <Review>
+        <rdfs:comment>Another example reviewer.</rdfs:comment>
+        <reviewDate>2011-03-13T00:00:00Z</reviewDate>
+        <reviewer>Person: Suzanne Reviewer</reviewer>
+      </Review>
+    </reviewed>
+    <annotation>
+      <Annotation rdf:about="https://spdx.org/spdxdocs/spdx-example-444504E0-4F89-41D3-9A0C-0305E82C3301#SPDXRef-45">
+        <annotationType rdf:resource="http://spdx.org/rdf/terms#annotationType_review"/>
+        <rdfs:comment>This is just an example. Some of the non-standard licenses look like they are actually BSD 3 clause licenses</rdfs:comment>
+        <annotationDate>2012-06-13T00:00:00Z</annotationDate>
+        <annotator>Person: Jim Reviewer</annotator>
+      </Annotation>
+    </annotation>
+    <relationship>
+      <Relationship>
+        <relationshipType rdf:resource="http://spdx.org/rdf/terms#relationshipType_describes"/>
+        <relatedSpdxElement rdf:resource="http://spdx.org/spdxdocs/spdx-example-444504E0-4F89-41D3-9A0C-0305E82C3301#SPDXRef-Package"/>
+      </Relationship>
+    </relationship>
+    <referencesFile>
+      <File rdf:about="https://spdx.org/spdxdocs/spdx-example-444504E0-4F89-41D3-9A0C-0305E82C3301#SPDXRef-File2">
+        <copyrightText>Copyright 2010, 2011 Source Auditor Inc.</copyrightText>
+        <licenseInfoInFile rdf:resource="http://spdx.org/licenses/Apache-2.0"/>
+        <licenseConcluded rdf:resource="http://spdx.org/licenses/Apache-2.0"/>
+        <fileType rdf:resource="http://spdx.org/rdf/terms#fileType_source"/>
+        <checksum>
+          <Checksum>
+            <checksumValue>2fd4e1c67a2d28fced849ee1bb76e7391b93eb12</checksumValue>
+            <algorithm rdf:resource="http://spdx.org/rdf/terms#checksumAlgorithm_sha1"/>
+          </Checksum>
+        </checksum>
+        <fileName>src/org/spdx/parser/DOAPProject.java</fileName>
+      </File>
+    </referencesFile>
+    <describesPackage>
+      <Package rdf:about="http://www.spdx.org/tools#SPDXRef-Package">
+        <licenseInfoFromFiles rdf:resource="http://spdx.org/licenses/Apache-1.0"/>
+        <downloadLocation>http://www.spdx.org/tools</downloadLocation>
+        <filesAnalyzed>true</filesAnalyzed>
+        <supplier>Organization:Linux Foundation</supplier>
+        <hasFile rdf:nodeID="A0"/>
+        <licenseInfoFromFiles rdf:resource="http://spdx.org/licenses/Apache-2.0"/>
+        <packageVerificationCode>
+          <PackageVerificationCode>
+            <packageVerificationCodeValue>4e3211c67a2d28fced849ee1bb76e7391b93feba</packageVerificationCodeValue>
+            <packageVerificationCodeExcludedFile>SpdxTranslatorSpdx.txt</packageVerificationCodeExcludedFile>
+            <packageVerificationCodeExcludedFile>SpdxTranslatorSpdx.rdf</packageVerificationCodeExcludedFile>
+          </PackageVerificationCode>
+        </packageVerificationCode>
+        <licenseConcluded>
+          <ConjunctiveLicenseSet>
+            <member>
+              <ExtractedLicensingInfo rdf:nodeID="A3">
+                <extractedText>This package includes the GRDDL parser developed by Hewlett Packard under the following license:
+© Copyright 2007 Hewlett-Packard Development Company, LP
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met: 
+
+Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer. 
+Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution. 
+The name of the author may not be used to endorse or promote products derived from this software without specific prior written permission. 
+THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. </extractedText>
+                <licenseId>LicenseRef-2</licenseId>
+              </ExtractedLicensingInfo>
+            </member>
+            <member rdf:nodeID="A1"/>
+            <member rdf:resource="http://spdx.org/licenses/Apache-2.0"/>
+            <member rdf:resource="http://spdx.org/licenses/MPL-1.1"/>
+            <member rdf:resource="http://spdx.org/licenses/Apache-1.0"/>
+            <member>
+              <ExtractedLicensingInfo rdf:nodeID="A4">
+                <extractedText>/*
+ * (c) Copyright 2009 University of Bristol
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. The name of the author may not be used to endorse or promote products
+ *    derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */  </extractedText>
+                <licenseId>LicenseRef-4</licenseId>
+              </ExtractedLicensingInfo>
+            </member>
+            <member>
+              <ExtractedLicensingInfo rdf:nodeID="A5">
+                <rdfs:seeAlso>http://justasample.url.com</rdfs:seeAlso>
+                <rdfs:seeAlso>http://people.apache.org/~andyc/neko/LICENSE</rdfs:seeAlso>
+                <licenseName>CyberNeko License</licenseName>
+                <rdfs:comment>This is tye CyperNeko License</rdfs:comment>
+                <extractedText>The CyberNeko Software License, Version 1.0
+
+ 
+(C) Copyright 2002-2005, Andy Clark.  All rights reserved.
+ 
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer. 
+
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in
+   the documentation and/or other materials provided with the
+   distribution.
+
+3. The end-user documentation included with the redistribution,
+   if any, must include the following acknowledgment:  
+     "This product includes software developed by Andy Clark."
+   Alternately, this acknowledgment may appear in the software itself,
+   if and wherever such third-party acknowledgments normally appear.
+
+4. The names "CyberNeko" and "NekoHTML" must not be used to endorse
+   or promote products derived from this software without prior 
+   written permission. For written permission, please contact 
+   andyc@cyberneko.net.
+
+5. Products derived from this software may not be called "CyberNeko",
+   nor may "CyberNeko" appear in their name, without prior written
+   permission of the author.
+
+THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESSED OR IMPLIED
+WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR OTHER CONTRIBUTORS
+BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, 
+OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT 
+OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR 
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE 
+OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, 
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.</extractedText>
+                <licenseId>LicenseRef-3</licenseId>
+              </ExtractedLicensingInfo>
+            </member>
+          </ConjunctiveLicenseSet>
+        </licenseConcluded>
+        <sourceInfo>Version 1.0 of the SPDX Translator application</sourceInfo>
+        <checksum>
+          <Checksum>
+            <checksumValue>2fd4e1c67a2d28fced849ee1bb76e7391b93eb12</checksumValue>
+            <algorithm rdf:resource="http://spdx.org/rdf/terms#checksumAlgorithm_sha1"/>
+          </Checksum>
+        </checksum>
+        <packageFileName>spdxtranslator-1.0.zip</packageFileName>
+        <description>This utility translates and SPDX RDF XML document to a spreadsheet, translates a spreadsheet to an SPDX RDF XML document and translates an SPDX RDFa document to an SPDX RDF XML document.</description>
+        <licenseInfoFromFiles rdf:nodeID="A4"/>
+        <name>SPDX Translator</name>
+        <versionInfo>Version 0.9.2</versionInfo>
+        <licenseInfoFromFiles rdf:nodeID="A1"/>
+        <hasFile rdf:nodeID="A2"/>
+        <licenseInfoFromFiles rdf:nodeID="A3"/>
+        <copyrightText> Copyright 2010, 2011 Source Auditor Inc.</copyrightText>
+        <licenseDeclared>
+          <ConjunctiveLicenseSet>
+            <member rdf:nodeID="A3"/>
+            <member rdf:nodeID="A1"/>
+            <member rdf:resource="http://spdx.org/licenses/Apache-2.0"/>
+            <member rdf:resource="http://spdx.org/licenses/MPL-1.1"/>
+            <member rdf:nodeID="A4"/>
+            <member rdf:nodeID="A5"/>
+          </ConjunctiveLicenseSet>
+        </licenseDeclared>
+        <licenseInfoFromFiles rdf:nodeID="A5"/>
+        <originator>Organization:SPDX</originator>
+        <licenseComments>The declared license information can be found in the NOTICE file at the root of the archive file</licenseComments>
+        <summary>SPDX Translator utility</summary>
+        <licenseInfoFromFiles rdf:resource="http://spdx.org/licenses/MPL-1.1"/>
+        <externalRef>
+          <ExternalRef>
+            <referenceCategory rdf:resource="http://spdx.org/rdf/terms#referenceCategory_packageManager"/>
+            <referenceType rdf:resource="http://spdx.org/rdf/references/maven-central"/>
+            <referenceLocator>org.apache.commons:commons-lang:3.2.1</referenceLocator>
+            <rdfs:comment>NIST National Vulnerability Database (NVD) describes security vulnerabilities (CVEs) which affect Vendor Product Version acmecorp:acmenator:6.6.6</rdfs:comment>
+          </ExternalRef>
+        </externalRef>
+      </Package>
+    </describesPackage>
+    <rdfs:comment>This is a sample spreadsheet</rdfs:comment>
+    <hasExtractedLicensingInfo rdf:nodeID="A4"/>
+    <hasExtractedLicensingInfo rdf:nodeID="A5"/>
+    <hasExtractedLicensingInfo rdf:nodeID="A3"/>
+  </SpdxDocument>
+</rdf:RDF>

--- a/tests/data/parse_anything_test_files/SPDXSBOMExample.spdx.yml
+++ b/tests/data/parse_anything_test_files/SPDXSBOMExample.spdx.yml
@@ -1,0 +1,58 @@
+# example of an SBOM with several packages and filesAnalyzed=False
+# from https://github.com/spdx/spdx-spec/issues/439
+SPDXID: "SPDXRef-DOCUMENT"
+spdxVersion: "SPDX-2.2"
+creationInfo:
+  created: "2020-07-23T18:30:22Z"
+  creators:
+  - "Organization: Example Inc."
+  - "Person: Thomas Steenbergen"
+  licenseListVersion: "3.9"
+name: "xyz-0.1.0"
+dataLicense: "CC0-1.0"
+documentNamespace: "http://spdx.org/spdxdocs/spdx-document-xyz"
+documentDescribes:
+- "SPDXRef-Package-xyz"
+packages:
+- SPDXID: "SPDXRef-Package-xyz"
+  summary: "Awesome product created by Example Inc."
+  copyrightText: "copyright 2004-2020 Example Inc. All Rights Reserved."
+  downloadLocation: "git+ssh://gitlab.example.com:3389/products/xyz.git@b2c358080011af6a366d2512a25a379fbe7b1f78"
+  filesAnalyzed: false
+  homepage: "https://example.com/products/xyz"
+  licenseConcluded:  "NOASSERTION"
+  licenseDeclared: "Apache-2.0 AND curl AND LicenseRef-Proprietary-ExampleInc"
+  name: "xyz"
+  versionInfo: "0.1.0"
+- SPDXID: "SPDXRef-Package-curl"
+  description: "A command line tool and library for transferring data with URL syntax, supporting \
+     HTTP, HTTPS, FTP, FTPS, GOPHER, TFTP, SCP, SFTP, SMB, TELNET, DICT, LDAP, LDAPS, MQTT, FILE, \
+     IMAP, SMTP, POP3, RTSP and RTMP. libcurl offers a myriad of powerful features."
+  copyrightText: "Copyright (c) 1996 - 2020, Daniel Stenberg, <daniel@haxx.se>, and many
+    contributors, see the THANKS file."
+  downloadLocation: "https://github.com/curl/curl/releases/download/curl-7_70_0/curl-7.70.0.tar.gz"
+  filesAnalyzed: false
+  homepage: "https://curl.haxx.se/"
+  licenseConcluded: "NOASSERTION"
+  licenseDeclared: "curl"
+  name: "curl"
+  packageFileName: "./libs/curl"
+  versionInfo: "7.70.0"
+- SPDXID: "SPDXRef-Package-openssl"
+  description: "OpenSSL is a robust, commercial-grade, full-featured Open Source Toolkit for the Transport Layer Security (TLS) protocol formerly known as the Secure Sockets Layer (SSL) protocol. The protocol implementation is based on a full-strength general purpose cryptographic library, which can also be used stand-alone."
+  copyrightText: "copyright 2004-2020 The OpenSSL Project Authors. All Rights Reserved."
+  downloadLocation: "git+ssh://github.com/openssl/openssl.git@e2e09d9fba1187f8d6aafaa34d4172f56f1ffb72"
+  filesAnalyzed: false
+  homepage: "https://www.openssl.org/"
+  licenseConcluded: "NOASSERTION"
+  licenseDeclared: "Apache-2.0"
+  packageFileName: "./libs/openssl"
+  name: "openssl"
+  versionInfo: "1.1.1g"
+relationships:
+- spdxElementId: "SPDXRef-Package-xyz"
+  relatedSpdxElement: "SPDXRef-Package-curl"
+  relationshipType: "CONTAINS"
+- spdxElementId: "SPDXRef-Package-xyz"
+  relatedSpdxElement: "SPDXRef-Package-openssl"
+  relationshipType: "CONTAINS"

--- a/tests/data/parse_anything_test_files/SPDXSBOMExample.spdx.yml.json
+++ b/tests/data/parse_anything_test_files/SPDXSBOMExample.spdx.yml.json
@@ -1,0 +1,58 @@
+# example of an SBOM with several packages and filesAnalyzed=False
+# from https://github.com/spdx/spdx-spec/issues/439
+SPDXID: "SPDXRef-DOCUMENT"
+spdxVersion: "SPDX-2.2"
+creationInfo:
+  created: "2020-07-23T18:30:22Z"
+  creators:
+  - "Organization: Example Inc."
+  - "Person: Thomas Steenbergen"
+  licenseListVersion: "3.9"
+name: "xyz-0.1.0"
+dataLicense: "CC0-1.0"
+documentNamespace: "http://spdx.org/spdxdocs/spdx-document-xyz"
+documentDescribes:
+- "SPDXRef-Package-xyz"
+packages:
+- SPDXID: "SPDXRef-Package-xyz"
+  summary: "Awesome product created by Example Inc."
+  copyrightText: "copyright 2004-2020 Example Inc. All Rights Reserved."
+  downloadLocation: "git+ssh://gitlab.example.com:3389/products/xyz.git@b2c358080011af6a366d2512a25a379fbe7b1f78"
+  filesAnalyzed: false
+  homepage: "https://example.com/products/xyz"
+  licenseConcluded:  "NOASSERTION"
+  licenseDeclared: "Apache-2.0 AND curl AND LicenseRef-Proprietary-ExampleInc"
+  name: "xyz"
+  versionInfo: "0.1.0"
+- SPDXID: "SPDXRef-Package-curl"
+  description: "A command line tool and library for transferring data with URL syntax, supporting \
+     HTTP, HTTPS, FTP, FTPS, GOPHER, TFTP, SCP, SFTP, SMB, TELNET, DICT, LDAP, LDAPS, MQTT, FILE, \
+     IMAP, SMTP, POP3, RTSP and RTMP. libcurl offers a myriad of powerful features."
+  copyrightText: "Copyright (c) 1996 - 2020, Daniel Stenberg, <daniel@haxx.se>, and many
+    contributors, see the THANKS file."
+  downloadLocation: "https://github.com/curl/curl/releases/download/curl-7_70_0/curl-7.70.0.tar.gz"
+  filesAnalyzed: false
+  homepage: "https://curl.haxx.se/"
+  licenseConcluded: "NOASSERTION"
+  licenseDeclared: "curl"
+  name: "curl"
+  packageFileName: "./libs/curl"
+  versionInfo: "7.70.0"
+- SPDXID: "SPDXRef-Package-openssl"
+  description: "OpenSSL is a robust, commercial-grade, full-featured Open Source Toolkit for the Transport Layer Security (TLS) protocol formerly known as the Secure Sockets Layer (SSL) protocol. The protocol implementation is based on a full-strength general purpose cryptographic library, which can also be used stand-alone."
+  copyrightText: "copyright 2004-2020 The OpenSSL Project Authors. All Rights Reserved."
+  downloadLocation: "git+ssh://github.com/openssl/openssl.git@e2e09d9fba1187f8d6aafaa34d4172f56f1ffb72"
+  filesAnalyzed: false
+  homepage: "https://www.openssl.org/"
+  licenseConcluded: "NOASSERTION"
+  licenseDeclared: "Apache-2.0"
+  packageFileName: "./libs/openssl"
+  name: "openssl"
+  versionInfo: "1.1.1g"
+relationships:
+- spdxElementId: "SPDXRef-Package-xyz"
+  relatedSpdxElement: "SPDXRef-Package-curl"
+  relationshipType: "CONTAINS"
+- spdxElementId: "SPDXRef-Package-xyz"
+  relatedSpdxElement: "SPDXRef-Package-openssl"
+  relationshipType: "CONTAINS"

--- a/tests/data/parse_anything_test_files/SPDXSBOMExample.spdx.yml.rdf
+++ b/tests/data/parse_anything_test_files/SPDXSBOMExample.spdx.yml.rdf
@@ -1,0 +1,58 @@
+# example of an SBOM with several packages and filesAnalyzed=False
+# from https://github.com/spdx/spdx-spec/issues/439
+SPDXID: "SPDXRef-DOCUMENT"
+spdxVersion: "SPDX-2.2"
+creationInfo:
+  created: "2020-07-23T18:30:22Z"
+  creators:
+  - "Organization: Example Inc."
+  - "Person: Thomas Steenbergen"
+  licenseListVersion: "3.9"
+name: "xyz-0.1.0"
+dataLicense: "CC0-1.0"
+documentNamespace: "http://spdx.org/spdxdocs/spdx-document-xyz"
+documentDescribes:
+- "SPDXRef-Package-xyz"
+packages:
+- SPDXID: "SPDXRef-Package-xyz"
+  summary: "Awesome product created by Example Inc."
+  copyrightText: "copyright 2004-2020 Example Inc. All Rights Reserved."
+  downloadLocation: "git+ssh://gitlab.example.com:3389/products/xyz.git@b2c358080011af6a366d2512a25a379fbe7b1f78"
+  filesAnalyzed: false
+  homepage: "https://example.com/products/xyz"
+  licenseConcluded:  "NOASSERTION"
+  licenseDeclared: "Apache-2.0 AND curl AND LicenseRef-Proprietary-ExampleInc"
+  name: "xyz"
+  versionInfo: "0.1.0"
+- SPDXID: "SPDXRef-Package-curl"
+  description: "A command line tool and library for transferring data with URL syntax, supporting \
+     HTTP, HTTPS, FTP, FTPS, GOPHER, TFTP, SCP, SFTP, SMB, TELNET, DICT, LDAP, LDAPS, MQTT, FILE, \
+     IMAP, SMTP, POP3, RTSP and RTMP. libcurl offers a myriad of powerful features."
+  copyrightText: "Copyright (c) 1996 - 2020, Daniel Stenberg, <daniel@haxx.se>, and many
+    contributors, see the THANKS file."
+  downloadLocation: "https://github.com/curl/curl/releases/download/curl-7_70_0/curl-7.70.0.tar.gz"
+  filesAnalyzed: false
+  homepage: "https://curl.haxx.se/"
+  licenseConcluded: "NOASSERTION"
+  licenseDeclared: "curl"
+  name: "curl"
+  packageFileName: "./libs/curl"
+  versionInfo: "7.70.0"
+- SPDXID: "SPDXRef-Package-openssl"
+  description: "OpenSSL is a robust, commercial-grade, full-featured Open Source Toolkit for the Transport Layer Security (TLS) protocol formerly known as the Secure Sockets Layer (SSL) protocol. The protocol implementation is based on a full-strength general purpose cryptographic library, which can also be used stand-alone."
+  copyrightText: "copyright 2004-2020 The OpenSSL Project Authors. All Rights Reserved."
+  downloadLocation: "git+ssh://github.com/openssl/openssl.git@e2e09d9fba1187f8d6aafaa34d4172f56f1ffb72"
+  filesAnalyzed: false
+  homepage: "https://www.openssl.org/"
+  licenseConcluded: "NOASSERTION"
+  licenseDeclared: "Apache-2.0"
+  packageFileName: "./libs/openssl"
+  name: "openssl"
+  versionInfo: "1.1.1g"
+relationships:
+- spdxElementId: "SPDXRef-Package-xyz"
+  relatedSpdxElement: "SPDXRef-Package-curl"
+  relationshipType: "CONTAINS"
+- spdxElementId: "SPDXRef-Package-xyz"
+  relatedSpdxElement: "SPDXRef-Package-openssl"
+  relationshipType: "CONTAINS"

--- a/tests/data/parse_anything_test_files/SPDXSBOMExample.spdx.yml.spdx
+++ b/tests/data/parse_anything_test_files/SPDXSBOMExample.spdx.yml.spdx
@@ -1,0 +1,58 @@
+# example of an SBOM with several packages and filesAnalyzed=False
+# from https://github.com/spdx/spdx-spec/issues/439
+SPDXID: "SPDXRef-DOCUMENT"
+spdxVersion: "SPDX-2.2"
+creationInfo:
+  created: "2020-07-23T18:30:22Z"
+  creators:
+  - "Organization: Example Inc."
+  - "Person: Thomas Steenbergen"
+  licenseListVersion: "3.9"
+name: "xyz-0.1.0"
+dataLicense: "CC0-1.0"
+documentNamespace: "http://spdx.org/spdxdocs/spdx-document-xyz"
+documentDescribes:
+- "SPDXRef-Package-xyz"
+packages:
+- SPDXID: "SPDXRef-Package-xyz"
+  summary: "Awesome product created by Example Inc."
+  copyrightText: "copyright 2004-2020 Example Inc. All Rights Reserved."
+  downloadLocation: "git+ssh://gitlab.example.com:3389/products/xyz.git@b2c358080011af6a366d2512a25a379fbe7b1f78"
+  filesAnalyzed: false
+  homepage: "https://example.com/products/xyz"
+  licenseConcluded:  "NOASSERTION"
+  licenseDeclared: "Apache-2.0 AND curl AND LicenseRef-Proprietary-ExampleInc"
+  name: "xyz"
+  versionInfo: "0.1.0"
+- SPDXID: "SPDXRef-Package-curl"
+  description: "A command line tool and library for transferring data with URL syntax, supporting \
+     HTTP, HTTPS, FTP, FTPS, GOPHER, TFTP, SCP, SFTP, SMB, TELNET, DICT, LDAP, LDAPS, MQTT, FILE, \
+     IMAP, SMTP, POP3, RTSP and RTMP. libcurl offers a myriad of powerful features."
+  copyrightText: "Copyright (c) 1996 - 2020, Daniel Stenberg, <daniel@haxx.se>, and many
+    contributors, see the THANKS file."
+  downloadLocation: "https://github.com/curl/curl/releases/download/curl-7_70_0/curl-7.70.0.tar.gz"
+  filesAnalyzed: false
+  homepage: "https://curl.haxx.se/"
+  licenseConcluded: "NOASSERTION"
+  licenseDeclared: "curl"
+  name: "curl"
+  packageFileName: "./libs/curl"
+  versionInfo: "7.70.0"
+- SPDXID: "SPDXRef-Package-openssl"
+  description: "OpenSSL is a robust, commercial-grade, full-featured Open Source Toolkit for the Transport Layer Security (TLS) protocol formerly known as the Secure Sockets Layer (SSL) protocol. The protocol implementation is based on a full-strength general purpose cryptographic library, which can also be used stand-alone."
+  copyrightText: "copyright 2004-2020 The OpenSSL Project Authors. All Rights Reserved."
+  downloadLocation: "git+ssh://github.com/openssl/openssl.git@e2e09d9fba1187f8d6aafaa34d4172f56f1ffb72"
+  filesAnalyzed: false
+  homepage: "https://www.openssl.org/"
+  licenseConcluded: "NOASSERTION"
+  licenseDeclared: "Apache-2.0"
+  packageFileName: "./libs/openssl"
+  name: "openssl"
+  versionInfo: "1.1.1g"
+relationships:
+- spdxElementId: "SPDXRef-Package-xyz"
+  relatedSpdxElement: "SPDXRef-Package-curl"
+  relationshipType: "CONTAINS"
+- spdxElementId: "SPDXRef-Package-xyz"
+  relatedSpdxElement: "SPDXRef-Package-openssl"
+  relationshipType: "CONTAINS"

--- a/tests/data/parse_anything_test_files/SPDXSBOMExample.spdx.yml.tag
+++ b/tests/data/parse_anything_test_files/SPDXSBOMExample.spdx.yml.tag
@@ -1,0 +1,58 @@
+# example of an SBOM with several packages and filesAnalyzed=False
+# from https://github.com/spdx/spdx-spec/issues/439
+SPDXID: "SPDXRef-DOCUMENT"
+spdxVersion: "SPDX-2.2"
+creationInfo:
+  created: "2020-07-23T18:30:22Z"
+  creators:
+  - "Organization: Example Inc."
+  - "Person: Thomas Steenbergen"
+  licenseListVersion: "3.9"
+name: "xyz-0.1.0"
+dataLicense: "CC0-1.0"
+documentNamespace: "http://spdx.org/spdxdocs/spdx-document-xyz"
+documentDescribes:
+- "SPDXRef-Package-xyz"
+packages:
+- SPDXID: "SPDXRef-Package-xyz"
+  summary: "Awesome product created by Example Inc."
+  copyrightText: "copyright 2004-2020 Example Inc. All Rights Reserved."
+  downloadLocation: "git+ssh://gitlab.example.com:3389/products/xyz.git@b2c358080011af6a366d2512a25a379fbe7b1f78"
+  filesAnalyzed: false
+  homepage: "https://example.com/products/xyz"
+  licenseConcluded:  "NOASSERTION"
+  licenseDeclared: "Apache-2.0 AND curl AND LicenseRef-Proprietary-ExampleInc"
+  name: "xyz"
+  versionInfo: "0.1.0"
+- SPDXID: "SPDXRef-Package-curl"
+  description: "A command line tool and library for transferring data with URL syntax, supporting \
+     HTTP, HTTPS, FTP, FTPS, GOPHER, TFTP, SCP, SFTP, SMB, TELNET, DICT, LDAP, LDAPS, MQTT, FILE, \
+     IMAP, SMTP, POP3, RTSP and RTMP. libcurl offers a myriad of powerful features."
+  copyrightText: "Copyright (c) 1996 - 2020, Daniel Stenberg, <daniel@haxx.se>, and many
+    contributors, see the THANKS file."
+  downloadLocation: "https://github.com/curl/curl/releases/download/curl-7_70_0/curl-7.70.0.tar.gz"
+  filesAnalyzed: false
+  homepage: "https://curl.haxx.se/"
+  licenseConcluded: "NOASSERTION"
+  licenseDeclared: "curl"
+  name: "curl"
+  packageFileName: "./libs/curl"
+  versionInfo: "7.70.0"
+- SPDXID: "SPDXRef-Package-openssl"
+  description: "OpenSSL is a robust, commercial-grade, full-featured Open Source Toolkit for the Transport Layer Security (TLS) protocol formerly known as the Secure Sockets Layer (SSL) protocol. The protocol implementation is based on a full-strength general purpose cryptographic library, which can also be used stand-alone."
+  copyrightText: "copyright 2004-2020 The OpenSSL Project Authors. All Rights Reserved."
+  downloadLocation: "git+ssh://github.com/openssl/openssl.git@e2e09d9fba1187f8d6aafaa34d4172f56f1ffb72"
+  filesAnalyzed: false
+  homepage: "https://www.openssl.org/"
+  licenseConcluded: "NOASSERTION"
+  licenseDeclared: "Apache-2.0"
+  packageFileName: "./libs/openssl"
+  name: "openssl"
+  versionInfo: "1.1.1g"
+relationships:
+- spdxElementId: "SPDXRef-Package-xyz"
+  relatedSpdxElement: "SPDXRef-Package-curl"
+  relationshipType: "CONTAINS"
+- spdxElementId: "SPDXRef-Package-xyz"
+  relatedSpdxElement: "SPDXRef-Package-openssl"
+  relationshipType: "CONTAINS"

--- a/tests/data/parse_anything_test_files/SPDXSBOMExample.spdx.yml.xml
+++ b/tests/data/parse_anything_test_files/SPDXSBOMExample.spdx.yml.xml
@@ -1,0 +1,58 @@
+# example of an SBOM with several packages and filesAnalyzed=False
+# from https://github.com/spdx/spdx-spec/issues/439
+SPDXID: "SPDXRef-DOCUMENT"
+spdxVersion: "SPDX-2.2"
+creationInfo:
+  created: "2020-07-23T18:30:22Z"
+  creators:
+  - "Organization: Example Inc."
+  - "Person: Thomas Steenbergen"
+  licenseListVersion: "3.9"
+name: "xyz-0.1.0"
+dataLicense: "CC0-1.0"
+documentNamespace: "http://spdx.org/spdxdocs/spdx-document-xyz"
+documentDescribes:
+- "SPDXRef-Package-xyz"
+packages:
+- SPDXID: "SPDXRef-Package-xyz"
+  summary: "Awesome product created by Example Inc."
+  copyrightText: "copyright 2004-2020 Example Inc. All Rights Reserved."
+  downloadLocation: "git+ssh://gitlab.example.com:3389/products/xyz.git@b2c358080011af6a366d2512a25a379fbe7b1f78"
+  filesAnalyzed: false
+  homepage: "https://example.com/products/xyz"
+  licenseConcluded:  "NOASSERTION"
+  licenseDeclared: "Apache-2.0 AND curl AND LicenseRef-Proprietary-ExampleInc"
+  name: "xyz"
+  versionInfo: "0.1.0"
+- SPDXID: "SPDXRef-Package-curl"
+  description: "A command line tool and library for transferring data with URL syntax, supporting \
+     HTTP, HTTPS, FTP, FTPS, GOPHER, TFTP, SCP, SFTP, SMB, TELNET, DICT, LDAP, LDAPS, MQTT, FILE, \
+     IMAP, SMTP, POP3, RTSP and RTMP. libcurl offers a myriad of powerful features."
+  copyrightText: "Copyright (c) 1996 - 2020, Daniel Stenberg, <daniel@haxx.se>, and many
+    contributors, see the THANKS file."
+  downloadLocation: "https://github.com/curl/curl/releases/download/curl-7_70_0/curl-7.70.0.tar.gz"
+  filesAnalyzed: false
+  homepage: "https://curl.haxx.se/"
+  licenseConcluded: "NOASSERTION"
+  licenseDeclared: "curl"
+  name: "curl"
+  packageFileName: "./libs/curl"
+  versionInfo: "7.70.0"
+- SPDXID: "SPDXRef-Package-openssl"
+  description: "OpenSSL is a robust, commercial-grade, full-featured Open Source Toolkit for the Transport Layer Security (TLS) protocol formerly known as the Secure Sockets Layer (SSL) protocol. The protocol implementation is based on a full-strength general purpose cryptographic library, which can also be used stand-alone."
+  copyrightText: "copyright 2004-2020 The OpenSSL Project Authors. All Rights Reserved."
+  downloadLocation: "git+ssh://github.com/openssl/openssl.git@e2e09d9fba1187f8d6aafaa34d4172f56f1ffb72"
+  filesAnalyzed: false
+  homepage: "https://www.openssl.org/"
+  licenseConcluded: "NOASSERTION"
+  licenseDeclared: "Apache-2.0"
+  packageFileName: "./libs/openssl"
+  name: "openssl"
+  versionInfo: "1.1.1g"
+relationships:
+- spdxElementId: "SPDXRef-Package-xyz"
+  relatedSpdxElement: "SPDXRef-Package-curl"
+  relationshipType: "CONTAINS"
+- spdxElementId: "SPDXRef-Package-xyz"
+  relatedSpdxElement: "SPDXRef-Package-openssl"
+  relationshipType: "CONTAINS"

--- a/tests/data/parse_anything_test_files/SPDXSBOMExample.spdx.yml.yaml
+++ b/tests/data/parse_anything_test_files/SPDXSBOMExample.spdx.yml.yaml
@@ -1,0 +1,58 @@
+# example of an SBOM with several packages and filesAnalyzed=False
+# from https://github.com/spdx/spdx-spec/issues/439
+SPDXID: "SPDXRef-DOCUMENT"
+spdxVersion: "SPDX-2.2"
+creationInfo:
+  created: "2020-07-23T18:30:22Z"
+  creators:
+  - "Organization: Example Inc."
+  - "Person: Thomas Steenbergen"
+  licenseListVersion: "3.9"
+name: "xyz-0.1.0"
+dataLicense: "CC0-1.0"
+documentNamespace: "http://spdx.org/spdxdocs/spdx-document-xyz"
+documentDescribes:
+- "SPDXRef-Package-xyz"
+packages:
+- SPDXID: "SPDXRef-Package-xyz"
+  summary: "Awesome product created by Example Inc."
+  copyrightText: "copyright 2004-2020 Example Inc. All Rights Reserved."
+  downloadLocation: "git+ssh://gitlab.example.com:3389/products/xyz.git@b2c358080011af6a366d2512a25a379fbe7b1f78"
+  filesAnalyzed: false
+  homepage: "https://example.com/products/xyz"
+  licenseConcluded:  "NOASSERTION"
+  licenseDeclared: "Apache-2.0 AND curl AND LicenseRef-Proprietary-ExampleInc"
+  name: "xyz"
+  versionInfo: "0.1.0"
+- SPDXID: "SPDXRef-Package-curl"
+  description: "A command line tool and library for transferring data with URL syntax, supporting \
+     HTTP, HTTPS, FTP, FTPS, GOPHER, TFTP, SCP, SFTP, SMB, TELNET, DICT, LDAP, LDAPS, MQTT, FILE, \
+     IMAP, SMTP, POP3, RTSP and RTMP. libcurl offers a myriad of powerful features."
+  copyrightText: "Copyright (c) 1996 - 2020, Daniel Stenberg, <daniel@haxx.se>, and many
+    contributors, see the THANKS file."
+  downloadLocation: "https://github.com/curl/curl/releases/download/curl-7_70_0/curl-7.70.0.tar.gz"
+  filesAnalyzed: false
+  homepage: "https://curl.haxx.se/"
+  licenseConcluded: "NOASSERTION"
+  licenseDeclared: "curl"
+  name: "curl"
+  packageFileName: "./libs/curl"
+  versionInfo: "7.70.0"
+- SPDXID: "SPDXRef-Package-openssl"
+  description: "OpenSSL is a robust, commercial-grade, full-featured Open Source Toolkit for the Transport Layer Security (TLS) protocol formerly known as the Secure Sockets Layer (SSL) protocol. The protocol implementation is based on a full-strength general purpose cryptographic library, which can also be used stand-alone."
+  copyrightText: "copyright 2004-2020 The OpenSSL Project Authors. All Rights Reserved."
+  downloadLocation: "git+ssh://github.com/openssl/openssl.git@e2e09d9fba1187f8d6aafaa34d4172f56f1ffb72"
+  filesAnalyzed: false
+  homepage: "https://www.openssl.org/"
+  licenseConcluded: "NOASSERTION"
+  licenseDeclared: "Apache-2.0"
+  packageFileName: "./libs/openssl"
+  name: "openssl"
+  versionInfo: "1.1.1g"
+relationships:
+- spdxElementId: "SPDXRef-Package-xyz"
+  relatedSpdxElement: "SPDXRef-Package-curl"
+  relationshipType: "CONTAINS"
+- spdxElementId: "SPDXRef-Package-xyz"
+  relatedSpdxElement: "SPDXRef-Package-openssl"
+  relationshipType: "CONTAINS"

--- a/tests/data/parse_anything_test_files/SPDXSimpleTag.tag
+++ b/tests/data/parse_anything_test_files/SPDXSimpleTag.tag
@@ -1,0 +1,65 @@
+# Document info
+SPDXVersion: SPDX-2.1
+DataLicense: CC0-1.0
+DocumentName: Sample_Document-V2.1
+SPDXID: SPDXRef-DOCUMENT
+DocumentNamespace: https://spdx.org/spdxdocs/spdx-example-444504E0-4F89-41D3-9A0C-0305E82C3301
+DocumentComment: <text>Sample Comment</text>
+ExternalDocumentRef:DocumentRef-spdx-tool-2.1 https://spdx.org/spdxdocs/spdx-tools-v2.1-3F2504E0-4F89-41D3-9A0C-0305E82C3301 SHA1: d6a770ba38583ed4bb4525bd96e50461655d2759
+
+# Creation info
+Creator: Person: Bob (bob@example.com)
+Creator: Organization: Acme
+Created: 2014-02-03T00:00:00Z
+CreatorComment: <text>Sample Comment</text>
+
+# Review #1
+Reviewer: Person: Bob the Reviewer
+ReviewDate: 2014-02-10T00:00:00Z
+ReviewComment: <text>Bob was Here.</text>
+
+# Review #2
+Reviewer: Person: Alice the Reviewer
+ReviewDate: 2014-04-10T00:00:00Z
+ReviewComment: <text>Alice was also here.</text>
+
+
+# Package info
+PackageName: Test
+SPDXID: SPDXRef-Package
+PackageVersion: Version 0.9.2
+PackageDownloadLocation: http://example.com/test
+PackageSummary: <text>Test package</text>
+PackageSourceInfo: <text>Version 1.0 of test</text>
+PackageFileName: test-1.0.zip
+PackageSupplier: Organization:ACME
+PackageOriginator: Organization:ACME
+PackageAttributionText: <text>The GNU C Library is free software.  See the file COPYING.LIB for copying conditions, and LICENSES for notices about a few contributions that require these additional notices to be distributed.  License copyright years may be listed using range notation, e.g., 1996-2015, indicating that every year in the range, inclusive, is a copyrightable year that would otherwise be listed individually.</text>
+PackageChecksum: SHA1: 2fd4e1c67a2d28fced849ee1bb76e7391b93eb12
+PackageVerificationCode: 4e3211c67a2d28fced849ee1bb76e7391b93feba (something.rdf, something.txt)
+PackageDescription: <text>A package.</text>
+PackageAttributionText: <text>The GNU C Library is free software.  See the file COPYING.LIB for copying conditions, and LICENSES for notices about a few contributions that require these additional notices to be distributed.  License copyright years may be listed using range notation, e.g., 1996-2015, indicating that every year in the range, inclusive, is a copyrightable year that would otherwise be listed individually.</text>
+PackageCopyrightText: <text> Copyright 2010, 2011 Acme Inc.</text>
+PackageLicenseDeclared: Apache-2.0
+PackageLicenseConcluded: (LicenseRef-2.0 and Apache-2.0)
+PackageLicenseInfoFromFiles: Apache-1.0
+PackageLicenseInfoFromFiles: Apache-2.0
+PackageLicenseComments: <text>License Comments</text>
+
+# File Info
+
+FileName: testfile.java
+SPDXID: SPDXRef-File
+FileType: SOURCE
+FileChecksum: SHA1: 2fd4e1c67a2d28fced849ee1bb76e7391b93eb12
+LicenseConcluded: Apache-2.0
+LicenseInfoInFile: Apache-2.0
+FileCopyrightText: <text>Copyright 2014 Acme Inc.</text>
+ArtifactOfProjectName: AcmeTest
+ArtifactOfProjectHomePage: http://www.acme.org/
+ArtifactOfProjectURI: http://www.acme.org/
+FileComment: <text>Very long file</text>
+
+
+
+

--- a/tests/data/parse_anything_test_files/SPDXSimpleTag.tag.json
+++ b/tests/data/parse_anything_test_files/SPDXSimpleTag.tag.json
@@ -1,0 +1,65 @@
+# Document info
+SPDXVersion: SPDX-2.1
+DataLicense: CC0-1.0
+DocumentName: Sample_Document-V2.1
+SPDXID: SPDXRef-DOCUMENT
+DocumentNamespace: https://spdx.org/spdxdocs/spdx-example-444504E0-4F89-41D3-9A0C-0305E82C3301
+DocumentComment: <text>Sample Comment</text>
+ExternalDocumentRef:DocumentRef-spdx-tool-2.1 https://spdx.org/spdxdocs/spdx-tools-v2.1-3F2504E0-4F89-41D3-9A0C-0305E82C3301 SHA1: d6a770ba38583ed4bb4525bd96e50461655d2759
+
+# Creation info
+Creator: Person: Bob (bob@example.com)
+Creator: Organization: Acme
+Created: 2014-02-03T00:00:00Z
+CreatorComment: <text>Sample Comment</text>
+
+# Review #1
+Reviewer: Person: Bob the Reviewer
+ReviewDate: 2014-02-10T00:00:00Z
+ReviewComment: <text>Bob was Here.</text>
+
+# Review #2
+Reviewer: Person: Alice the Reviewer
+ReviewDate: 2014-04-10T00:00:00Z
+ReviewComment: <text>Alice was also here.</text>
+
+
+# Package info
+PackageName: Test
+SPDXID: SPDXRef-Package
+PackageVersion: Version 0.9.2
+PackageDownloadLocation: http://example.com/test
+PackageSummary: <text>Test package</text>
+PackageSourceInfo: <text>Version 1.0 of test</text>
+PackageFileName: test-1.0.zip
+PackageSupplier: Organization:ACME
+PackageOriginator: Organization:ACME
+PackageAttributionText: <text>The GNU C Library is free software.  See the file COPYING.LIB for copying conditions, and LICENSES for notices about a few contributions that require these additional notices to be distributed.  License copyright years may be listed using range notation, e.g., 1996-2015, indicating that every year in the range, inclusive, is a copyrightable year that would otherwise be listed individually.</text>
+PackageChecksum: SHA1: 2fd4e1c67a2d28fced849ee1bb76e7391b93eb12
+PackageVerificationCode: 4e3211c67a2d28fced849ee1bb76e7391b93feba (something.rdf, something.txt)
+PackageDescription: <text>A package.</text>
+PackageAttributionText: <text>The GNU C Library is free software.  See the file COPYING.LIB for copying conditions, and LICENSES for notices about a few contributions that require these additional notices to be distributed.  License copyright years may be listed using range notation, e.g., 1996-2015, indicating that every year in the range, inclusive, is a copyrightable year that would otherwise be listed individually.</text>
+PackageCopyrightText: <text> Copyright 2010, 2011 Acme Inc.</text>
+PackageLicenseDeclared: Apache-2.0
+PackageLicenseConcluded: (LicenseRef-2.0 and Apache-2.0)
+PackageLicenseInfoFromFiles: Apache-1.0
+PackageLicenseInfoFromFiles: Apache-2.0
+PackageLicenseComments: <text>License Comments</text>
+
+# File Info
+
+FileName: testfile.java
+SPDXID: SPDXRef-File
+FileType: SOURCE
+FileChecksum: SHA1: 2fd4e1c67a2d28fced849ee1bb76e7391b93eb12
+LicenseConcluded: Apache-2.0
+LicenseInfoInFile: Apache-2.0
+FileCopyrightText: <text>Copyright 2014 Acme Inc.</text>
+ArtifactOfProjectName: AcmeTest
+ArtifactOfProjectHomePage: http://www.acme.org/
+ArtifactOfProjectURI: http://www.acme.org/
+FileComment: <text>Very long file</text>
+
+
+
+

--- a/tests/data/parse_anything_test_files/SPDXSimpleTag.tag.rdf
+++ b/tests/data/parse_anything_test_files/SPDXSimpleTag.tag.rdf
@@ -1,0 +1,65 @@
+# Document info
+SPDXVersion: SPDX-2.1
+DataLicense: CC0-1.0
+DocumentName: Sample_Document-V2.1
+SPDXID: SPDXRef-DOCUMENT
+DocumentNamespace: https://spdx.org/spdxdocs/spdx-example-444504E0-4F89-41D3-9A0C-0305E82C3301
+DocumentComment: <text>Sample Comment</text>
+ExternalDocumentRef:DocumentRef-spdx-tool-2.1 https://spdx.org/spdxdocs/spdx-tools-v2.1-3F2504E0-4F89-41D3-9A0C-0305E82C3301 SHA1: d6a770ba38583ed4bb4525bd96e50461655d2759
+
+# Creation info
+Creator: Person: Bob (bob@example.com)
+Creator: Organization: Acme
+Created: 2014-02-03T00:00:00Z
+CreatorComment: <text>Sample Comment</text>
+
+# Review #1
+Reviewer: Person: Bob the Reviewer
+ReviewDate: 2014-02-10T00:00:00Z
+ReviewComment: <text>Bob was Here.</text>
+
+# Review #2
+Reviewer: Person: Alice the Reviewer
+ReviewDate: 2014-04-10T00:00:00Z
+ReviewComment: <text>Alice was also here.</text>
+
+
+# Package info
+PackageName: Test
+SPDXID: SPDXRef-Package
+PackageVersion: Version 0.9.2
+PackageDownloadLocation: http://example.com/test
+PackageSummary: <text>Test package</text>
+PackageSourceInfo: <text>Version 1.0 of test</text>
+PackageFileName: test-1.0.zip
+PackageSupplier: Organization:ACME
+PackageOriginator: Organization:ACME
+PackageAttributionText: <text>The GNU C Library is free software.  See the file COPYING.LIB for copying conditions, and LICENSES for notices about a few contributions that require these additional notices to be distributed.  License copyright years may be listed using range notation, e.g., 1996-2015, indicating that every year in the range, inclusive, is a copyrightable year that would otherwise be listed individually.</text>
+PackageChecksum: SHA1: 2fd4e1c67a2d28fced849ee1bb76e7391b93eb12
+PackageVerificationCode: 4e3211c67a2d28fced849ee1bb76e7391b93feba (something.rdf, something.txt)
+PackageDescription: <text>A package.</text>
+PackageAttributionText: <text>The GNU C Library is free software.  See the file COPYING.LIB for copying conditions, and LICENSES for notices about a few contributions that require these additional notices to be distributed.  License copyright years may be listed using range notation, e.g., 1996-2015, indicating that every year in the range, inclusive, is a copyrightable year that would otherwise be listed individually.</text>
+PackageCopyrightText: <text> Copyright 2010, 2011 Acme Inc.</text>
+PackageLicenseDeclared: Apache-2.0
+PackageLicenseConcluded: (LicenseRef-2.0 and Apache-2.0)
+PackageLicenseInfoFromFiles: Apache-1.0
+PackageLicenseInfoFromFiles: Apache-2.0
+PackageLicenseComments: <text>License Comments</text>
+
+# File Info
+
+FileName: testfile.java
+SPDXID: SPDXRef-File
+FileType: SOURCE
+FileChecksum: SHA1: 2fd4e1c67a2d28fced849ee1bb76e7391b93eb12
+LicenseConcluded: Apache-2.0
+LicenseInfoInFile: Apache-2.0
+FileCopyrightText: <text>Copyright 2014 Acme Inc.</text>
+ArtifactOfProjectName: AcmeTest
+ArtifactOfProjectHomePage: http://www.acme.org/
+ArtifactOfProjectURI: http://www.acme.org/
+FileComment: <text>Very long file</text>
+
+
+
+

--- a/tests/data/parse_anything_test_files/SPDXSimpleTag.tag.spdx
+++ b/tests/data/parse_anything_test_files/SPDXSimpleTag.tag.spdx
@@ -1,0 +1,65 @@
+# Document info
+SPDXVersion: SPDX-2.1
+DataLicense: CC0-1.0
+DocumentName: Sample_Document-V2.1
+SPDXID: SPDXRef-DOCUMENT
+DocumentNamespace: https://spdx.org/spdxdocs/spdx-example-444504E0-4F89-41D3-9A0C-0305E82C3301
+DocumentComment: <text>Sample Comment</text>
+ExternalDocumentRef:DocumentRef-spdx-tool-2.1 https://spdx.org/spdxdocs/spdx-tools-v2.1-3F2504E0-4F89-41D3-9A0C-0305E82C3301 SHA1: d6a770ba38583ed4bb4525bd96e50461655d2759
+
+# Creation info
+Creator: Person: Bob (bob@example.com)
+Creator: Organization: Acme
+Created: 2014-02-03T00:00:00Z
+CreatorComment: <text>Sample Comment</text>
+
+# Review #1
+Reviewer: Person: Bob the Reviewer
+ReviewDate: 2014-02-10T00:00:00Z
+ReviewComment: <text>Bob was Here.</text>
+
+# Review #2
+Reviewer: Person: Alice the Reviewer
+ReviewDate: 2014-04-10T00:00:00Z
+ReviewComment: <text>Alice was also here.</text>
+
+
+# Package info
+PackageName: Test
+SPDXID: SPDXRef-Package
+PackageVersion: Version 0.9.2
+PackageDownloadLocation: http://example.com/test
+PackageSummary: <text>Test package</text>
+PackageSourceInfo: <text>Version 1.0 of test</text>
+PackageFileName: test-1.0.zip
+PackageSupplier: Organization:ACME
+PackageOriginator: Organization:ACME
+PackageAttributionText: <text>The GNU C Library is free software.  See the file COPYING.LIB for copying conditions, and LICENSES for notices about a few contributions that require these additional notices to be distributed.  License copyright years may be listed using range notation, e.g., 1996-2015, indicating that every year in the range, inclusive, is a copyrightable year that would otherwise be listed individually.</text>
+PackageChecksum: SHA1: 2fd4e1c67a2d28fced849ee1bb76e7391b93eb12
+PackageVerificationCode: 4e3211c67a2d28fced849ee1bb76e7391b93feba (something.rdf, something.txt)
+PackageDescription: <text>A package.</text>
+PackageAttributionText: <text>The GNU C Library is free software.  See the file COPYING.LIB for copying conditions, and LICENSES for notices about a few contributions that require these additional notices to be distributed.  License copyright years may be listed using range notation, e.g., 1996-2015, indicating that every year in the range, inclusive, is a copyrightable year that would otherwise be listed individually.</text>
+PackageCopyrightText: <text> Copyright 2010, 2011 Acme Inc.</text>
+PackageLicenseDeclared: Apache-2.0
+PackageLicenseConcluded: (LicenseRef-2.0 and Apache-2.0)
+PackageLicenseInfoFromFiles: Apache-1.0
+PackageLicenseInfoFromFiles: Apache-2.0
+PackageLicenseComments: <text>License Comments</text>
+
+# File Info
+
+FileName: testfile.java
+SPDXID: SPDXRef-File
+FileType: SOURCE
+FileChecksum: SHA1: 2fd4e1c67a2d28fced849ee1bb76e7391b93eb12
+LicenseConcluded: Apache-2.0
+LicenseInfoInFile: Apache-2.0
+FileCopyrightText: <text>Copyright 2014 Acme Inc.</text>
+ArtifactOfProjectName: AcmeTest
+ArtifactOfProjectHomePage: http://www.acme.org/
+ArtifactOfProjectURI: http://www.acme.org/
+FileComment: <text>Very long file</text>
+
+
+
+

--- a/tests/data/parse_anything_test_files/SPDXSimpleTag.tag.spdx.yml
+++ b/tests/data/parse_anything_test_files/SPDXSimpleTag.tag.spdx.yml
@@ -1,0 +1,65 @@
+# Document info
+SPDXVersion: SPDX-2.1
+DataLicense: CC0-1.0
+DocumentName: Sample_Document-V2.1
+SPDXID: SPDXRef-DOCUMENT
+DocumentNamespace: https://spdx.org/spdxdocs/spdx-example-444504E0-4F89-41D3-9A0C-0305E82C3301
+DocumentComment: <text>Sample Comment</text>
+ExternalDocumentRef:DocumentRef-spdx-tool-2.1 https://spdx.org/spdxdocs/spdx-tools-v2.1-3F2504E0-4F89-41D3-9A0C-0305E82C3301 SHA1: d6a770ba38583ed4bb4525bd96e50461655d2759
+
+# Creation info
+Creator: Person: Bob (bob@example.com)
+Creator: Organization: Acme
+Created: 2014-02-03T00:00:00Z
+CreatorComment: <text>Sample Comment</text>
+
+# Review #1
+Reviewer: Person: Bob the Reviewer
+ReviewDate: 2014-02-10T00:00:00Z
+ReviewComment: <text>Bob was Here.</text>
+
+# Review #2
+Reviewer: Person: Alice the Reviewer
+ReviewDate: 2014-04-10T00:00:00Z
+ReviewComment: <text>Alice was also here.</text>
+
+
+# Package info
+PackageName: Test
+SPDXID: SPDXRef-Package
+PackageVersion: Version 0.9.2
+PackageDownloadLocation: http://example.com/test
+PackageSummary: <text>Test package</text>
+PackageSourceInfo: <text>Version 1.0 of test</text>
+PackageFileName: test-1.0.zip
+PackageSupplier: Organization:ACME
+PackageOriginator: Organization:ACME
+PackageAttributionText: <text>The GNU C Library is free software.  See the file COPYING.LIB for copying conditions, and LICENSES for notices about a few contributions that require these additional notices to be distributed.  License copyright years may be listed using range notation, e.g., 1996-2015, indicating that every year in the range, inclusive, is a copyrightable year that would otherwise be listed individually.</text>
+PackageChecksum: SHA1: 2fd4e1c67a2d28fced849ee1bb76e7391b93eb12
+PackageVerificationCode: 4e3211c67a2d28fced849ee1bb76e7391b93feba (something.rdf, something.txt)
+PackageDescription: <text>A package.</text>
+PackageAttributionText: <text>The GNU C Library is free software.  See the file COPYING.LIB for copying conditions, and LICENSES for notices about a few contributions that require these additional notices to be distributed.  License copyright years may be listed using range notation, e.g., 1996-2015, indicating that every year in the range, inclusive, is a copyrightable year that would otherwise be listed individually.</text>
+PackageCopyrightText: <text> Copyright 2010, 2011 Acme Inc.</text>
+PackageLicenseDeclared: Apache-2.0
+PackageLicenseConcluded: (LicenseRef-2.0 and Apache-2.0)
+PackageLicenseInfoFromFiles: Apache-1.0
+PackageLicenseInfoFromFiles: Apache-2.0
+PackageLicenseComments: <text>License Comments</text>
+
+# File Info
+
+FileName: testfile.java
+SPDXID: SPDXRef-File
+FileType: SOURCE
+FileChecksum: SHA1: 2fd4e1c67a2d28fced849ee1bb76e7391b93eb12
+LicenseConcluded: Apache-2.0
+LicenseInfoInFile: Apache-2.0
+FileCopyrightText: <text>Copyright 2014 Acme Inc.</text>
+ArtifactOfProjectName: AcmeTest
+ArtifactOfProjectHomePage: http://www.acme.org/
+ArtifactOfProjectURI: http://www.acme.org/
+FileComment: <text>Very long file</text>
+
+
+
+

--- a/tests/data/parse_anything_test_files/SPDXSimpleTag.tag.xml
+++ b/tests/data/parse_anything_test_files/SPDXSimpleTag.tag.xml
@@ -1,0 +1,65 @@
+# Document info
+SPDXVersion: SPDX-2.1
+DataLicense: CC0-1.0
+DocumentName: Sample_Document-V2.1
+SPDXID: SPDXRef-DOCUMENT
+DocumentNamespace: https://spdx.org/spdxdocs/spdx-example-444504E0-4F89-41D3-9A0C-0305E82C3301
+DocumentComment: <text>Sample Comment</text>
+ExternalDocumentRef:DocumentRef-spdx-tool-2.1 https://spdx.org/spdxdocs/spdx-tools-v2.1-3F2504E0-4F89-41D3-9A0C-0305E82C3301 SHA1: d6a770ba38583ed4bb4525bd96e50461655d2759
+
+# Creation info
+Creator: Person: Bob (bob@example.com)
+Creator: Organization: Acme
+Created: 2014-02-03T00:00:00Z
+CreatorComment: <text>Sample Comment</text>
+
+# Review #1
+Reviewer: Person: Bob the Reviewer
+ReviewDate: 2014-02-10T00:00:00Z
+ReviewComment: <text>Bob was Here.</text>
+
+# Review #2
+Reviewer: Person: Alice the Reviewer
+ReviewDate: 2014-04-10T00:00:00Z
+ReviewComment: <text>Alice was also here.</text>
+
+
+# Package info
+PackageName: Test
+SPDXID: SPDXRef-Package
+PackageVersion: Version 0.9.2
+PackageDownloadLocation: http://example.com/test
+PackageSummary: <text>Test package</text>
+PackageSourceInfo: <text>Version 1.0 of test</text>
+PackageFileName: test-1.0.zip
+PackageSupplier: Organization:ACME
+PackageOriginator: Organization:ACME
+PackageAttributionText: <text>The GNU C Library is free software.  See the file COPYING.LIB for copying conditions, and LICENSES for notices about a few contributions that require these additional notices to be distributed.  License copyright years may be listed using range notation, e.g., 1996-2015, indicating that every year in the range, inclusive, is a copyrightable year that would otherwise be listed individually.</text>
+PackageChecksum: SHA1: 2fd4e1c67a2d28fced849ee1bb76e7391b93eb12
+PackageVerificationCode: 4e3211c67a2d28fced849ee1bb76e7391b93feba (something.rdf, something.txt)
+PackageDescription: <text>A package.</text>
+PackageAttributionText: <text>The GNU C Library is free software.  See the file COPYING.LIB for copying conditions, and LICENSES for notices about a few contributions that require these additional notices to be distributed.  License copyright years may be listed using range notation, e.g., 1996-2015, indicating that every year in the range, inclusive, is a copyrightable year that would otherwise be listed individually.</text>
+PackageCopyrightText: <text> Copyright 2010, 2011 Acme Inc.</text>
+PackageLicenseDeclared: Apache-2.0
+PackageLicenseConcluded: (LicenseRef-2.0 and Apache-2.0)
+PackageLicenseInfoFromFiles: Apache-1.0
+PackageLicenseInfoFromFiles: Apache-2.0
+PackageLicenseComments: <text>License Comments</text>
+
+# File Info
+
+FileName: testfile.java
+SPDXID: SPDXRef-File
+FileType: SOURCE
+FileChecksum: SHA1: 2fd4e1c67a2d28fced849ee1bb76e7391b93eb12
+LicenseConcluded: Apache-2.0
+LicenseInfoInFile: Apache-2.0
+FileCopyrightText: <text>Copyright 2014 Acme Inc.</text>
+ArtifactOfProjectName: AcmeTest
+ArtifactOfProjectHomePage: http://www.acme.org/
+ArtifactOfProjectURI: http://www.acme.org/
+FileComment: <text>Very long file</text>
+
+
+
+

--- a/tests/data/parse_anything_test_files/SPDXSimpleTag.tag.yaml
+++ b/tests/data/parse_anything_test_files/SPDXSimpleTag.tag.yaml
@@ -1,0 +1,65 @@
+# Document info
+SPDXVersion: SPDX-2.1
+DataLicense: CC0-1.0
+DocumentName: Sample_Document-V2.1
+SPDXID: SPDXRef-DOCUMENT
+DocumentNamespace: https://spdx.org/spdxdocs/spdx-example-444504E0-4F89-41D3-9A0C-0305E82C3301
+DocumentComment: <text>Sample Comment</text>
+ExternalDocumentRef:DocumentRef-spdx-tool-2.1 https://spdx.org/spdxdocs/spdx-tools-v2.1-3F2504E0-4F89-41D3-9A0C-0305E82C3301 SHA1: d6a770ba38583ed4bb4525bd96e50461655d2759
+
+# Creation info
+Creator: Person: Bob (bob@example.com)
+Creator: Organization: Acme
+Created: 2014-02-03T00:00:00Z
+CreatorComment: <text>Sample Comment</text>
+
+# Review #1
+Reviewer: Person: Bob the Reviewer
+ReviewDate: 2014-02-10T00:00:00Z
+ReviewComment: <text>Bob was Here.</text>
+
+# Review #2
+Reviewer: Person: Alice the Reviewer
+ReviewDate: 2014-04-10T00:00:00Z
+ReviewComment: <text>Alice was also here.</text>
+
+
+# Package info
+PackageName: Test
+SPDXID: SPDXRef-Package
+PackageVersion: Version 0.9.2
+PackageDownloadLocation: http://example.com/test
+PackageSummary: <text>Test package</text>
+PackageSourceInfo: <text>Version 1.0 of test</text>
+PackageFileName: test-1.0.zip
+PackageSupplier: Organization:ACME
+PackageOriginator: Organization:ACME
+PackageAttributionText: <text>The GNU C Library is free software.  See the file COPYING.LIB for copying conditions, and LICENSES for notices about a few contributions that require these additional notices to be distributed.  License copyright years may be listed using range notation, e.g., 1996-2015, indicating that every year in the range, inclusive, is a copyrightable year that would otherwise be listed individually.</text>
+PackageChecksum: SHA1: 2fd4e1c67a2d28fced849ee1bb76e7391b93eb12
+PackageVerificationCode: 4e3211c67a2d28fced849ee1bb76e7391b93feba (something.rdf, something.txt)
+PackageDescription: <text>A package.</text>
+PackageAttributionText: <text>The GNU C Library is free software.  See the file COPYING.LIB for copying conditions, and LICENSES for notices about a few contributions that require these additional notices to be distributed.  License copyright years may be listed using range notation, e.g., 1996-2015, indicating that every year in the range, inclusive, is a copyrightable year that would otherwise be listed individually.</text>
+PackageCopyrightText: <text> Copyright 2010, 2011 Acme Inc.</text>
+PackageLicenseDeclared: Apache-2.0
+PackageLicenseConcluded: (LicenseRef-2.0 and Apache-2.0)
+PackageLicenseInfoFromFiles: Apache-1.0
+PackageLicenseInfoFromFiles: Apache-2.0
+PackageLicenseComments: <text>License Comments</text>
+
+# File Info
+
+FileName: testfile.java
+SPDXID: SPDXRef-File
+FileType: SOURCE
+FileChecksum: SHA1: 2fd4e1c67a2d28fced849ee1bb76e7391b93eb12
+LicenseConcluded: Apache-2.0
+LicenseInfoInFile: Apache-2.0
+FileCopyrightText: <text>Copyright 2014 Acme Inc.</text>
+ArtifactOfProjectName: AcmeTest
+ArtifactOfProjectHomePage: http://www.acme.org/
+ArtifactOfProjectURI: http://www.acme.org/
+FileComment: <text>Very long file</text>
+
+
+
+

--- a/tests/data/parse_anything_test_files/SPDXTagExample.tag
+++ b/tests/data/parse_anything_test_files/SPDXTagExample.tag
@@ -1,0 +1,219 @@
+SPDXVersion: SPDX-2.1
+DataLicense: CC0-1.0
+DocumentName: Sample_Document-V2.1
+SPDXID: SPDXRef-DOCUMENT
+DocumentNamespace: https://spdx.org/spdxdocs/spdx-example-444504E0-4F89-41D3-9A0C-0305E82C3301
+DocumentComment: <text>This is a sample spreadsheet</text>
+
+## Creation Information
+Creator: Person: Gary O'Neall
+Creator: Organization: Source Auditor Inc.
+Creator: Tool: SourceAuditor-V1.2
+Created: 2010-02-03T00:00:00Z
+CreatorComment: <text>This is an example of an SPDX spreadsheet format</text>
+
+## Review Information
+Reviewer: Person: Joe Reviewer
+ReviewDate: 2010-02-10T00:00:00Z
+ReviewComment: <text>This is just an example.  Some of the non-standard licenses look like they are actually BSD 3 clause licenses</text>
+
+Reviewer: Person: Suzanne Reviewer
+ReviewDate: 2011-03-13T00:00:00Z
+ReviewComment: <text>Another example reviewer.</text>
+
+## Annotation Information
+Annotator: Person: Jim Annotator
+AnnotationType: REVIEW
+AnnotationDate: 2012-03-11T00:00:00Z
+AnnotationComment: <text>An example annotation comment.</text>
+SPDXREF: SPDXRef-45
+
+## Relationships
+Relationship: SPDXRef-DOCUMENT DESCRIBES SPDXRef-File
+Relationship: SPDXRef-DOCUMENT DESCRIBES SPDXRef-Package
+Relationship: SPDXRef-DOCUMENT COPY_OF DocumentRef-spdx-tool-1.2:SPDXRef-ToolsElement
+Relationship: SPDXRef-DOCUMENT CONTAINS SPDXRef-Package
+
+## Package Information
+PackageName: SPDX Translator
+SPDXID: SPDXRef-Package
+PackageVersion: Version 0.9.2
+PackageDownloadLocation: http://www.spdx.org/tools
+PackageSummary: <text>SPDX Translator utility</text>
+PackageSourceInfo: <text>Version 1.0 of the SPDX Translator application</text>
+PackageFileName: spdxtranslator-1.0.zip
+PackageAttributionText: <text>The GNU C Library is free software.  See the file COPYING.LIB for copying conditions, and LICENSES for notices about a few contributions that require these additional notices to be distributed.  License copyright years may be listed using range notation, e.g., 1996-2015, indicating that every year in the range, inclusive, is a copyrightable year that would otherwise be listed individually.</text>
+PackageSupplier: Organization:Linux Foundation
+PackageOriginator: Organization:SPDX
+PackageChecksum: SHA1: 2fd4e1c67a2d28fced849ee1bb76e7391b93eb12
+PackageVerificationCode: 4e3211c67a2d28fced849ee1bb76e7391b93feba (SpdxTranslatorSpdx.rdf, SpdxTranslatorSpdx.txt)
+PackageDescription: <text>This utility translates and SPDX RDF XML document to a spreadsheet, translates a spreadsheet to an SPDX RDF XML document and translates an SPDX RDFa document to an SPDX RDF XML document.</text>
+PackageAttributionText: <text>The GNU C Library is free software.  See the file COPYING.LIB for copying conditions, and LICENSES for notices about a few contributions that require these additional notices to be distributed.  License copyright years may be listed using range notation, e.g., 1996-2015, indicating that every year in the range, inclusive, is a copyrightable year that would otherwise be listed individually.</text>
+PackageComment: <text>This package includes several sub-packages.</text>
+
+PackageCopyrightText: <text> Copyright 2010, 2011 Source Auditor Inc.</text>
+
+PackageLicenseDeclared: (LicenseRef-3 AND LicenseRef-4 AND Apache-2.0 AND MPL-1.1 AND LicenseRef-1 AND LicenseRef-2)
+PackageLicenseConcluded: (LicenseRef-3 AND LicenseRef-4 AND Apache-1.0 AND Apache-2.0 AND MPL-1.1 AND LicenseRef-1 AND LicenseRef-2)
+
+PackageLicenseInfoFromFiles: Apache-1.0
+PackageLicenseInfoFromFiles: LicenseRef-3
+PackageLicenseInfoFromFiles: Apache-2.0
+PackageLicenseInfoFromFiles: LicenseRef-4
+PackageLicenseInfoFromFiles: LicenseRef-2
+PackageLicenseInfoFromFiles: LicenseRef-1
+PackageLicenseInfoFromFiles: MPL-1.1
+PackageLicenseComments: <text>The declared license information can be found in the NOTICE file at the root of the archive file</text>
+
+ExternalRef: SECURITY cpe23Type cpe:2.3:a:pivotal_software:spring_framework:4.1.0:*:*:*:*:*:*:
+ExternalRefComment: <text>NIST National Vulnerability Database (NVD) describes security vulnerabilities (CVEs) which affect Vendor Product Version acmecorp:acmenator:6.6.6.</text>
+
+## File Information
+FileName: src/org/spdx/parser/DOAPProject.java
+SPDXID: SPDXRef-File1
+FileType: SOURCE
+FileChecksum: SHA1: 2fd4e1c67a2d28fced849ee1bb76e7391b93eb12
+LicenseConcluded: Apache-2.0
+LicenseInfoInFile: Apache-2.0
+FileCopyrightText: <text>Copyright 2010, 2011 Source Auditor Inc.</text>
+
+FileName: Jenna-2.6.3/jena-2.6.3-sources.jar
+SPDXID: SPDXRef-File2
+FileType: ARCHIVE
+FileChecksum: SHA1: 3ab4e1c67a2d28fced849ee1bb76e7391b93f125
+LicenseConcluded: LicenseRef-1
+LicenseInfoInFile: LicenseRef-1
+LicenseComments: <text>This license is used by Jena</text>
+FileCopyrightText: <text>(c) Copyright 2000, 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009 Hewlett-Packard Development Company, LP</text>
+ArtifactOfProjectName: Jena
+ArtifactOfProjectHomePage: http://www.openjena.org/
+ArtifactOfProjectURI: UNKNOWN
+FileComment: <text>This file belongs to Jena</text>
+
+## Snippet Information
+SnippetSPDXID: SPDXRef-Snippet
+SnippetFromFileSPDXID: SPDXRef-DoapSource
+SnippetLicenseComments: <text>The concluded license was taken from package xyz, from which the snippet was copied into the current file. The concluded license information was found in the COPYING.txt file in package xyz.</text>
+SnippetCopyrightText: <text> Copyright 2008-2010 John Smith </text>
+SnippetComment: <text>This snippet was identified as significant and highlighted in this Apache-2.0 file, when a commercial scanner identified it as being derived from file foo.c in package xyz which is licensed under GPL-2.0-or-later.</text>
+SnippetName: from linux kernel
+SnippetLicenseConcluded: Apache-2.0
+LicenseInfoInSnippet: Apache-2.0
+
+## License Information
+LicenseID: LicenseRef-3
+ExtractedText: <text>The CyberNeko Software License, Version 1.0
+
+ 
+(C) Copyright 2002-2005, Andy Clark.  All rights reserved.
+ 
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer. 
+
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in
+   the documentation and/or other materials provided with the
+   distribution.
+
+3. The end-user documentation included with the redistribution,
+   if any, must include the following acknowledgment:  
+     "This product includes software developed by Andy Clark."
+   Alternately, this acknowledgment may appear in the software itself,
+   if and wherever such third-party acknowledgments normally appear.
+
+4. The names "CyberNeko" and "NekoHTML" must not be used to endorse
+   or promote products derived from this software without prior 
+   written permission. For written permission, please contact 
+   andyc@cyberneko.net.
+
+5. Products derived from this software may not be called "CyberNeko",
+   nor may "CyberNeko" appear in their name, without prior written
+   permission of the author.
+
+THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESSED OR IMPLIED
+WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR OTHER CONTRIBUTORS
+BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, 
+OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT 
+OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR 
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE 
+OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, 
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.</text>
+LicenseName: CyberNeko License
+LicenseCrossReference: http://people.apache.org/~andyc/neko/LICENSE
+LicenseCrossReference: http://justasample.url.com
+LicenseComment: <text>This is tye CyperNeko License</text>
+
+LicenseID: LicenseRef-1
+ExtractedText: <text>/*
+ * (c) Copyright 2000, 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009 Hewlett-Packard Development Company, LP
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. The name of the author may not be used to endorse or promote products
+ *    derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */</text>
+
+LicenseID: LicenseRef-2
+ExtractedText: <text>This package includes the GRDDL parser developed by Hewlett Packard under the following license:
+© Copyright 2007 Hewlett-Packard Development Company, LP
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met: 
+
+Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer. 
+Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution. 
+The name of the author may not be used to endorse or promote products derived from this software without specific prior written permission. 
+THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. </text>
+
+LicenseID: LicenseRef-4
+ExtractedText: <text>/*
+ * (c) Copyright 2009 University of Bristol
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. The name of the author may not be used to endorse or promote products
+ *    derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */  </text>
+

--- a/tests/data/parse_anything_test_files/SPDXXmlExample.xml
+++ b/tests/data/parse_anything_test_files/SPDXXmlExample.xml
@@ -1,0 +1,263 @@
+<?xml version="1.0" encoding="utf-8"?>
+<SpdxDocument>
+	<Document>
+		<comment>This is a sample spreadsheet</comment>
+		<name>Sample_Document-V2.1</name>
+		<documentDescribes>
+			<Package>
+				<SPDXID>SPDXRef-Package</SPDXID>
+                <originator>Organization: SPDX</originator>
+                                 <attributionTexts>The GNU C Library is free software.  See the file COPYING.LIB for copying conditions, and LICENSES for notices about a few contributions that require these additional notices to be distributed.  License copyright years may be listed using range notation, e.g., 1996-2015, indicating that every year in the range, inclusive, is a copyrightable year that would otherwise be listed individually.</attributionTexts>
+				<files>
+					<File>
+						<licenseInfoFromFiles>Apache-2.0</licenseInfoFromFiles>
+						<sha1>2fd4e1c67a2d28fced849ee1bb76e7391b93eb12</sha1>
+						<name>src/org/spdx/parser/DOAPProject.java</name>
+						<copyrightText>Copyright 2010, 2011 Source Auditor Inc.</copyrightText>
+						<licenseConcluded>Apache-2.0</licenseConcluded>
+						<licenseComments></licenseComments>
+						<checksums>
+							<checksumValue>2fd4e1c67a2d28fced849ee1bb76e7391b93eb12</checksumValue>
+							<algorithm>checksumAlgorithm_sha1</algorithm>
+						</checksums>
+						<fileTypes>fileType_source</fileTypes>
+						<SPDXID>SPDXRef-File2</SPDXID>
+					</File>
+				</files>
+				<files>
+					<File>
+						<comment>This file belongs to Jena</comment>
+						<licenseInfoFromFiles>LicenseRef-1</licenseInfoFromFiles>
+						<sha1>3ab4e1c67a2d28fced849ee1bb76e7391b93f125</sha1>
+						<name>Jenna-2.6.3/jena-2.6.3-sources.jar</name>
+						<copyrightText>(c) Copyright 2000, 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009 Hewlett-Packard Development Company, LP</copyrightText>
+						<artifactOf>
+							<name>Jena</name>
+							<homePage>http://www.openjena.org/</homePage>
+							<projectUri>http://subversion.apache.org/doap.rdf</projectUri>
+						</artifactOf>
+						<licenseConcluded>LicenseRef-1</licenseConcluded>
+						<licenseComments>This license is used by Jena</licenseComments>
+						<checksums>
+							<checksumValue>3ab4e1c67a2d28fced849ee1bb76e7391b93f125</checksumValue>
+							<algorithm>checksumAlgorithm_sha1</algorithm>
+						</checksums>
+						<fileTypes>fileType_archive</fileTypes>
+						<SPDXID>SPDXRef-File1</SPDXID>
+					</File>
+				</files>
+				<licenseInfoFromFiles>LicenseRef-3</licenseInfoFromFiles>
+				<licenseInfoFromFiles>LicenseRef-1</licenseInfoFromFiles>
+				<licenseInfoFromFiles>Apache-1.0</licenseInfoFromFiles>
+				<licenseInfoFromFiles>LicenseRef-4</licenseInfoFromFiles>
+				<licenseInfoFromFiles>Apache-2.0</licenseInfoFromFiles>
+				<licenseInfoFromFiles>LicenseRef-2</licenseInfoFromFiles>
+				<licenseInfoFromFiles>MPL-1.1</licenseInfoFromFiles>
+				<sha1>2fd4e1c67a2d28fced849ee1bb76e7391b93eb12</sha1>
+				<name>SPDX Translator</name>
+				<packageFileName>spdxtranslator-1.0.zip</packageFileName>
+				<licenseComments>The declared license information can be found in the NOTICE file at the root of the archive file</licenseComments>
+				<summary>SPDX Translator utility</summary>
+				<sourceInfo>Version 1.0 of the SPDX Translator application</sourceInfo>
+				<copyrightText> Copyright 2010, 2011 Source Auditor Inc.</copyrightText>
+				<packageVerificationCode>
+					<packageVerificationCodeValue>4e3211c67a2d28fced849ee1bb76e7391b93feba</packageVerificationCodeValue>
+					<packageVerificationCodeExcludedFiles>SpdxTranslatorSpdx.rdf</packageVerificationCodeExcludedFiles>
+					<packageVerificationCodeExcludedFiles>SpdxTranslatorSpdx.txt</packageVerificationCodeExcludedFiles>
+				</packageVerificationCode>
+				<licenseConcluded>(LicenseRef-1 AND MPL-1.1 AND LicenseRef-2 AND LicenseRef-3 AND Apache-2.0 AND LicenseRef-4 AND Apache-1.0)</licenseConcluded>
+				<supplier>Organization: Linux Foundation</supplier>
+				<checksums>
+					<checksumValue>2fd4e1c67a2d28fced849ee1bb76e7391b93eb12</checksumValue>
+					<algorithm>checksumAlgorithm_sha1</algorithm>
+				</checksums>
+				<versionInfo>Version 0.9.2</versionInfo>
+				<licenseDeclared>(LicenseRef-3 AND LicenseRef-2 AND Apache-2.0 AND MPL-1.1 AND LicenseRef-1 AND LicenseRef-4)</licenseDeclared>
+				<downloadLocation>http://www.spdx.org/tools</downloadLocation>
+				<description>This utility translates and SPDX RDF XML document to a spreadsheet, translates a spreadsheet to an SPDX RDF XML document and translates an SPDX RDFa document to an SPDX RDF XML document.</description>
+			</Package>
+		</documentDescribes>
+		<creationInfo>
+			<comment>This is an example of an SPDX spreadsheet format</comment>
+			<creators>Tool: SourceAuditor-V1.2</creators>
+			<creators>Person: Gary O'Neall</creators>
+			<creators>Organization: Source Auditor Inc.</creators>
+			<licenseListVersion>3.6</licenseListVersion>
+			<created>2010-02-03T00:00:00Z</created>
+		</creationInfo>
+		<externalDocumentRefs>
+			<checksum>
+				<checksumValue>d6a770ba38583ed4bb4525bd96e50461655d2759</checksumValue>
+				<algorithm>checksumAlgorithm_sha1</algorithm>
+			</checksum>
+			<spdxDocument>https://spdx.org/spdxdocs/spdx-tools-v2.1-3F2504E0-4F89-41D3-9A0C-0305E82C3301</spdxDocument>
+			<externalDocumentId>DocumentRef-spdx-tool-2.1</externalDocumentId>
+		</externalDocumentRefs>
+		<documentNamespace>https://spdx.org/spdxdocs/spdx-example-444504E0-4F89-41D3-9A0C-0305E82C3301</documentNamespace>
+		<annotations>
+			<comment>This is just an example. Some of the non-standard licenses look like they are actually BSD 3 clause licenses</comment>
+			<annotationType>REVIEW</annotationType>
+			<SPDXID>SPDXRef-45</SPDXID>
+			<annotationDate>2012-06-13T00:00:00Z</annotationDate>
+			<annotator>Person: Jim Reviewer</annotator>
+		</annotations>
+		<dataLicense>CC0-1.0</dataLicense>
+		<reviewers>
+			<comment>This is just an example.  Some of the non-standard licenses look like they are actually BSD 3 clause licenses</comment>
+			<reviewer>Person: Joe Reviewer</reviewer>
+			<reviewDate>2010-02-10T00:00:00Z</reviewDate>
+		</reviewers>
+		<reviewers>
+			<comment>Another example reviewer.</comment>
+			<reviewer>Person: Suzanne Reviewer</reviewer>
+			<reviewDate>2011-03-13T00:00:00Z</reviewDate>
+		</reviewers>
+		<hasExtractedLicensingInfos>
+			<extractedText>/*
+ * (c) Copyright 2000, 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009 Hewlett-Packard Development Company, LP
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. The name of the author may not be used to endorse or promote products
+ *    derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */</extractedText>
+			<licenseId>LicenseRef-1</licenseId>
+		</hasExtractedLicensingInfos>
+		<hasExtractedLicensingInfos>
+			<extractedText>This package includes the GRDDL parser developed by Hewlett Packard under the following license:
+© Copyright 2007 Hewlett-Packard Development Company, LP
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met: 
+
+Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer. 
+Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution. 
+The name of the author may not be used to endorse or promote products derived from this software without specific prior written permission. 
+THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. </extractedText>
+			<licenseId>LicenseRef-2</licenseId>
+		</hasExtractedLicensingInfos>
+		<hasExtractedLicensingInfos>
+			<extractedText>The CyberNeko Software License, Version 1.0
+
+ 
+(C) Copyright 2002-2005, Andy Clark.  All rights reserved.
+ 
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer. 
+
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in
+   the documentation and/or other materials provided with the
+   distribution.
+
+3. The end-user documentation included with the redistribution,
+   if any, must include the following acknowledgment:  
+     "This product includes software developed by Andy Clark."
+   Alternately, this acknowledgment may appear in the software itself,
+   if and wherever such third-party acknowledgments normally appear.
+
+4. The names "CyberNeko" and "NekoHTML" must not be used to endorse
+   or promote products derived from this software without prior 
+   written permission. For written permission, please contact 
+   andyc@cyberneko.net.
+
+5. Products derived from this software may not be called "CyberNeko",
+   nor may "CyberNeko" appear in their name, without prior written
+   permission of the author.
+
+THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESSED OR IMPLIED
+WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR OTHER CONTRIBUTORS
+BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, 
+OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT 
+OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR 
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE 
+OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, 
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.</extractedText>
+			<comment>This is tye CyperNeko License</comment>
+			<licenseId>LicenseRef-3</licenseId>
+			<name>CyberNeko License</name>
+			<seeAlso>http://justasample.url.com</seeAlso>
+			<seeAlso>http://people.apache.org/~andyc/neko/LICENSE</seeAlso>
+		</hasExtractedLicensingInfos>
+		<hasExtractedLicensingInfos>
+			<extractedText>/*
+ * (c) Copyright 2009 University of Bristol
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. The name of the author may not be used to endorse or promote products
+ *    derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */  </extractedText>
+			<licenseId>LicenseRef-4</licenseId>
+		</hasExtractedLicensingInfos>
+		<spdxVersion>SPDX-2.1</spdxVersion>
+		<SPDXID>SPDXRef-DOCUMENT</SPDXID>
+		<snippets>
+			<comment>This snippet was identified as significant and highlighted in this Apache-2.0 file, when a commercial scanner identified it as being derived from file foo.c in package xyz which is licensed under GPL-2.0-or-later.</comment>
+			<name>from linux kernel</name>
+			<copyrightText>Copyright 2008-2010 John Smith</copyrightText>
+			<licenseConcluded>Apache-2.0</licenseConcluded>
+			<licenseInfoFromSnippet>Apache-2.0</licenseInfoFromSnippet>
+			<licenseComments>The concluded license was taken from package xyz, from which the snippet was copied into the current file. The concluded license information was found in the COPYING.txt file in package xyz.</licenseComments>
+			<SPDXID>SPDXRef-Snippet</SPDXID>
+			<fileId>SPDXRef-DoapSource</fileId>
+		</snippets>
+        <relationships>
+            <spdxElementId>SPDXRef-DOCUMENT</spdxElementId>
+            <relatedSpdxElement>SPDXRef-File</relatedSpdxElement>
+            <relationshipType>DESCRIBES</relationshipType>
+        </relationships>
+        <relationships>
+            <spdxElementId>SPDXRef-DOCUMENT</spdxElementId>
+            <relatedSpdxElement>SPDXRef-Package</relatedSpdxElement>
+            <relationshipType>DESCRIBES</relationshipType>
+        </relationships>
+        <relationships>
+            <spdxElementId>SPDXRef-DOCUMENT</spdxElementId>
+            <relatedSpdxElement>SPDXRef-Package</relatedSpdxElement>
+            <relationshipType>CONTAINS</relationshipType>
+        </relationships>
+	</Document>
+</SpdxDocument>

--- a/tests/data/parse_anything_test_files/SPDXXmlExample.xml.json
+++ b/tests/data/parse_anything_test_files/SPDXXmlExample.xml.json
@@ -1,0 +1,263 @@
+<?xml version="1.0" encoding="utf-8"?>
+<SpdxDocument>
+	<Document>
+		<comment>This is a sample spreadsheet</comment>
+		<name>Sample_Document-V2.1</name>
+		<documentDescribes>
+			<Package>
+				<SPDXID>SPDXRef-Package</SPDXID>
+                <originator>Organization: SPDX</originator>
+                                 <attributionTexts>The GNU C Library is free software.  See the file COPYING.LIB for copying conditions, and LICENSES for notices about a few contributions that require these additional notices to be distributed.  License copyright years may be listed using range notation, e.g., 1996-2015, indicating that every year in the range, inclusive, is a copyrightable year that would otherwise be listed individually.</attributionTexts>
+				<files>
+					<File>
+						<licenseInfoFromFiles>Apache-2.0</licenseInfoFromFiles>
+						<sha1>2fd4e1c67a2d28fced849ee1bb76e7391b93eb12</sha1>
+						<name>src/org/spdx/parser/DOAPProject.java</name>
+						<copyrightText>Copyright 2010, 2011 Source Auditor Inc.</copyrightText>
+						<licenseConcluded>Apache-2.0</licenseConcluded>
+						<licenseComments></licenseComments>
+						<checksums>
+							<checksumValue>2fd4e1c67a2d28fced849ee1bb76e7391b93eb12</checksumValue>
+							<algorithm>checksumAlgorithm_sha1</algorithm>
+						</checksums>
+						<fileTypes>fileType_source</fileTypes>
+						<SPDXID>SPDXRef-File2</SPDXID>
+					</File>
+				</files>
+				<files>
+					<File>
+						<comment>This file belongs to Jena</comment>
+						<licenseInfoFromFiles>LicenseRef-1</licenseInfoFromFiles>
+						<sha1>3ab4e1c67a2d28fced849ee1bb76e7391b93f125</sha1>
+						<name>Jenna-2.6.3/jena-2.6.3-sources.jar</name>
+						<copyrightText>(c) Copyright 2000, 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009 Hewlett-Packard Development Company, LP</copyrightText>
+						<artifactOf>
+							<name>Jena</name>
+							<homePage>http://www.openjena.org/</homePage>
+							<projectUri>http://subversion.apache.org/doap.rdf</projectUri>
+						</artifactOf>
+						<licenseConcluded>LicenseRef-1</licenseConcluded>
+						<licenseComments>This license is used by Jena</licenseComments>
+						<checksums>
+							<checksumValue>3ab4e1c67a2d28fced849ee1bb76e7391b93f125</checksumValue>
+							<algorithm>checksumAlgorithm_sha1</algorithm>
+						</checksums>
+						<fileTypes>fileType_archive</fileTypes>
+						<SPDXID>SPDXRef-File1</SPDXID>
+					</File>
+				</files>
+				<licenseInfoFromFiles>LicenseRef-3</licenseInfoFromFiles>
+				<licenseInfoFromFiles>LicenseRef-1</licenseInfoFromFiles>
+				<licenseInfoFromFiles>Apache-1.0</licenseInfoFromFiles>
+				<licenseInfoFromFiles>LicenseRef-4</licenseInfoFromFiles>
+				<licenseInfoFromFiles>Apache-2.0</licenseInfoFromFiles>
+				<licenseInfoFromFiles>LicenseRef-2</licenseInfoFromFiles>
+				<licenseInfoFromFiles>MPL-1.1</licenseInfoFromFiles>
+				<sha1>2fd4e1c67a2d28fced849ee1bb76e7391b93eb12</sha1>
+				<name>SPDX Translator</name>
+				<packageFileName>spdxtranslator-1.0.zip</packageFileName>
+				<licenseComments>The declared license information can be found in the NOTICE file at the root of the archive file</licenseComments>
+				<summary>SPDX Translator utility</summary>
+				<sourceInfo>Version 1.0 of the SPDX Translator application</sourceInfo>
+				<copyrightText> Copyright 2010, 2011 Source Auditor Inc.</copyrightText>
+				<packageVerificationCode>
+					<packageVerificationCodeValue>4e3211c67a2d28fced849ee1bb76e7391b93feba</packageVerificationCodeValue>
+					<packageVerificationCodeExcludedFiles>SpdxTranslatorSpdx.rdf</packageVerificationCodeExcludedFiles>
+					<packageVerificationCodeExcludedFiles>SpdxTranslatorSpdx.txt</packageVerificationCodeExcludedFiles>
+				</packageVerificationCode>
+				<licenseConcluded>(LicenseRef-1 AND MPL-1.1 AND LicenseRef-2 AND LicenseRef-3 AND Apache-2.0 AND LicenseRef-4 AND Apache-1.0)</licenseConcluded>
+				<supplier>Organization: Linux Foundation</supplier>
+				<checksums>
+					<checksumValue>2fd4e1c67a2d28fced849ee1bb76e7391b93eb12</checksumValue>
+					<algorithm>checksumAlgorithm_sha1</algorithm>
+				</checksums>
+				<versionInfo>Version 0.9.2</versionInfo>
+				<licenseDeclared>(LicenseRef-3 AND LicenseRef-2 AND Apache-2.0 AND MPL-1.1 AND LicenseRef-1 AND LicenseRef-4)</licenseDeclared>
+				<downloadLocation>http://www.spdx.org/tools</downloadLocation>
+				<description>This utility translates and SPDX RDF XML document to a spreadsheet, translates a spreadsheet to an SPDX RDF XML document and translates an SPDX RDFa document to an SPDX RDF XML document.</description>
+			</Package>
+		</documentDescribes>
+		<creationInfo>
+			<comment>This is an example of an SPDX spreadsheet format</comment>
+			<creators>Tool: SourceAuditor-V1.2</creators>
+			<creators>Person: Gary O'Neall</creators>
+			<creators>Organization: Source Auditor Inc.</creators>
+			<licenseListVersion>3.6</licenseListVersion>
+			<created>2010-02-03T00:00:00Z</created>
+		</creationInfo>
+		<externalDocumentRefs>
+			<checksum>
+				<checksumValue>d6a770ba38583ed4bb4525bd96e50461655d2759</checksumValue>
+				<algorithm>checksumAlgorithm_sha1</algorithm>
+			</checksum>
+			<spdxDocument>https://spdx.org/spdxdocs/spdx-tools-v2.1-3F2504E0-4F89-41D3-9A0C-0305E82C3301</spdxDocument>
+			<externalDocumentId>DocumentRef-spdx-tool-2.1</externalDocumentId>
+		</externalDocumentRefs>
+		<documentNamespace>https://spdx.org/spdxdocs/spdx-example-444504E0-4F89-41D3-9A0C-0305E82C3301</documentNamespace>
+		<annotations>
+			<comment>This is just an example. Some of the non-standard licenses look like they are actually BSD 3 clause licenses</comment>
+			<annotationType>REVIEW</annotationType>
+			<SPDXID>SPDXRef-45</SPDXID>
+			<annotationDate>2012-06-13T00:00:00Z</annotationDate>
+			<annotator>Person: Jim Reviewer</annotator>
+		</annotations>
+		<dataLicense>CC0-1.0</dataLicense>
+		<reviewers>
+			<comment>This is just an example.  Some of the non-standard licenses look like they are actually BSD 3 clause licenses</comment>
+			<reviewer>Person: Joe Reviewer</reviewer>
+			<reviewDate>2010-02-10T00:00:00Z</reviewDate>
+		</reviewers>
+		<reviewers>
+			<comment>Another example reviewer.</comment>
+			<reviewer>Person: Suzanne Reviewer</reviewer>
+			<reviewDate>2011-03-13T00:00:00Z</reviewDate>
+		</reviewers>
+		<hasExtractedLicensingInfos>
+			<extractedText>/*
+ * (c) Copyright 2000, 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009 Hewlett-Packard Development Company, LP
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. The name of the author may not be used to endorse or promote products
+ *    derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */</extractedText>
+			<licenseId>LicenseRef-1</licenseId>
+		</hasExtractedLicensingInfos>
+		<hasExtractedLicensingInfos>
+			<extractedText>This package includes the GRDDL parser developed by Hewlett Packard under the following license:
+© Copyright 2007 Hewlett-Packard Development Company, LP
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met: 
+
+Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer. 
+Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution. 
+The name of the author may not be used to endorse or promote products derived from this software without specific prior written permission. 
+THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. </extractedText>
+			<licenseId>LicenseRef-2</licenseId>
+		</hasExtractedLicensingInfos>
+		<hasExtractedLicensingInfos>
+			<extractedText>The CyberNeko Software License, Version 1.0
+
+ 
+(C) Copyright 2002-2005, Andy Clark.  All rights reserved.
+ 
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer. 
+
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in
+   the documentation and/or other materials provided with the
+   distribution.
+
+3. The end-user documentation included with the redistribution,
+   if any, must include the following acknowledgment:  
+     "This product includes software developed by Andy Clark."
+   Alternately, this acknowledgment may appear in the software itself,
+   if and wherever such third-party acknowledgments normally appear.
+
+4. The names "CyberNeko" and "NekoHTML" must not be used to endorse
+   or promote products derived from this software without prior 
+   written permission. For written permission, please contact 
+   andyc@cyberneko.net.
+
+5. Products derived from this software may not be called "CyberNeko",
+   nor may "CyberNeko" appear in their name, without prior written
+   permission of the author.
+
+THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESSED OR IMPLIED
+WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR OTHER CONTRIBUTORS
+BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, 
+OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT 
+OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR 
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE 
+OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, 
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.</extractedText>
+			<comment>This is tye CyperNeko License</comment>
+			<licenseId>LicenseRef-3</licenseId>
+			<name>CyberNeko License</name>
+			<seeAlso>http://justasample.url.com</seeAlso>
+			<seeAlso>http://people.apache.org/~andyc/neko/LICENSE</seeAlso>
+		</hasExtractedLicensingInfos>
+		<hasExtractedLicensingInfos>
+			<extractedText>/*
+ * (c) Copyright 2009 University of Bristol
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. The name of the author may not be used to endorse or promote products
+ *    derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */  </extractedText>
+			<licenseId>LicenseRef-4</licenseId>
+		</hasExtractedLicensingInfos>
+		<spdxVersion>SPDX-2.1</spdxVersion>
+		<SPDXID>SPDXRef-DOCUMENT</SPDXID>
+		<snippets>
+			<comment>This snippet was identified as significant and highlighted in this Apache-2.0 file, when a commercial scanner identified it as being derived from file foo.c in package xyz which is licensed under GPL-2.0-or-later.</comment>
+			<name>from linux kernel</name>
+			<copyrightText>Copyright 2008-2010 John Smith</copyrightText>
+			<licenseConcluded>Apache-2.0</licenseConcluded>
+			<licenseInfoFromSnippet>Apache-2.0</licenseInfoFromSnippet>
+			<licenseComments>The concluded license was taken from package xyz, from which the snippet was copied into the current file. The concluded license information was found in the COPYING.txt file in package xyz.</licenseComments>
+			<SPDXID>SPDXRef-Snippet</SPDXID>
+			<fileId>SPDXRef-DoapSource</fileId>
+		</snippets>
+        <relationships>
+            <spdxElementId>SPDXRef-DOCUMENT</spdxElementId>
+            <relatedSpdxElement>SPDXRef-File</relatedSpdxElement>
+            <relationshipType>DESCRIBES</relationshipType>
+        </relationships>
+        <relationships>
+            <spdxElementId>SPDXRef-DOCUMENT</spdxElementId>
+            <relatedSpdxElement>SPDXRef-Package</relatedSpdxElement>
+            <relationshipType>DESCRIBES</relationshipType>
+        </relationships>
+        <relationships>
+            <spdxElementId>SPDXRef-DOCUMENT</spdxElementId>
+            <relatedSpdxElement>SPDXRef-Package</relatedSpdxElement>
+            <relationshipType>CONTAINS</relationshipType>
+        </relationships>
+	</Document>
+</SpdxDocument>

--- a/tests/data/parse_anything_test_files/SPDXXmlExample.xml.rdf
+++ b/tests/data/parse_anything_test_files/SPDXXmlExample.xml.rdf
@@ -1,0 +1,263 @@
+<?xml version="1.0" encoding="utf-8"?>
+<SpdxDocument>
+	<Document>
+		<comment>This is a sample spreadsheet</comment>
+		<name>Sample_Document-V2.1</name>
+		<documentDescribes>
+			<Package>
+				<SPDXID>SPDXRef-Package</SPDXID>
+                <originator>Organization: SPDX</originator>
+                                 <attributionTexts>The GNU C Library is free software.  See the file COPYING.LIB for copying conditions, and LICENSES for notices about a few contributions that require these additional notices to be distributed.  License copyright years may be listed using range notation, e.g., 1996-2015, indicating that every year in the range, inclusive, is a copyrightable year that would otherwise be listed individually.</attributionTexts>
+				<files>
+					<File>
+						<licenseInfoFromFiles>Apache-2.0</licenseInfoFromFiles>
+						<sha1>2fd4e1c67a2d28fced849ee1bb76e7391b93eb12</sha1>
+						<name>src/org/spdx/parser/DOAPProject.java</name>
+						<copyrightText>Copyright 2010, 2011 Source Auditor Inc.</copyrightText>
+						<licenseConcluded>Apache-2.0</licenseConcluded>
+						<licenseComments></licenseComments>
+						<checksums>
+							<checksumValue>2fd4e1c67a2d28fced849ee1bb76e7391b93eb12</checksumValue>
+							<algorithm>checksumAlgorithm_sha1</algorithm>
+						</checksums>
+						<fileTypes>fileType_source</fileTypes>
+						<SPDXID>SPDXRef-File2</SPDXID>
+					</File>
+				</files>
+				<files>
+					<File>
+						<comment>This file belongs to Jena</comment>
+						<licenseInfoFromFiles>LicenseRef-1</licenseInfoFromFiles>
+						<sha1>3ab4e1c67a2d28fced849ee1bb76e7391b93f125</sha1>
+						<name>Jenna-2.6.3/jena-2.6.3-sources.jar</name>
+						<copyrightText>(c) Copyright 2000, 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009 Hewlett-Packard Development Company, LP</copyrightText>
+						<artifactOf>
+							<name>Jena</name>
+							<homePage>http://www.openjena.org/</homePage>
+							<projectUri>http://subversion.apache.org/doap.rdf</projectUri>
+						</artifactOf>
+						<licenseConcluded>LicenseRef-1</licenseConcluded>
+						<licenseComments>This license is used by Jena</licenseComments>
+						<checksums>
+							<checksumValue>3ab4e1c67a2d28fced849ee1bb76e7391b93f125</checksumValue>
+							<algorithm>checksumAlgorithm_sha1</algorithm>
+						</checksums>
+						<fileTypes>fileType_archive</fileTypes>
+						<SPDXID>SPDXRef-File1</SPDXID>
+					</File>
+				</files>
+				<licenseInfoFromFiles>LicenseRef-3</licenseInfoFromFiles>
+				<licenseInfoFromFiles>LicenseRef-1</licenseInfoFromFiles>
+				<licenseInfoFromFiles>Apache-1.0</licenseInfoFromFiles>
+				<licenseInfoFromFiles>LicenseRef-4</licenseInfoFromFiles>
+				<licenseInfoFromFiles>Apache-2.0</licenseInfoFromFiles>
+				<licenseInfoFromFiles>LicenseRef-2</licenseInfoFromFiles>
+				<licenseInfoFromFiles>MPL-1.1</licenseInfoFromFiles>
+				<sha1>2fd4e1c67a2d28fced849ee1bb76e7391b93eb12</sha1>
+				<name>SPDX Translator</name>
+				<packageFileName>spdxtranslator-1.0.zip</packageFileName>
+				<licenseComments>The declared license information can be found in the NOTICE file at the root of the archive file</licenseComments>
+				<summary>SPDX Translator utility</summary>
+				<sourceInfo>Version 1.0 of the SPDX Translator application</sourceInfo>
+				<copyrightText> Copyright 2010, 2011 Source Auditor Inc.</copyrightText>
+				<packageVerificationCode>
+					<packageVerificationCodeValue>4e3211c67a2d28fced849ee1bb76e7391b93feba</packageVerificationCodeValue>
+					<packageVerificationCodeExcludedFiles>SpdxTranslatorSpdx.rdf</packageVerificationCodeExcludedFiles>
+					<packageVerificationCodeExcludedFiles>SpdxTranslatorSpdx.txt</packageVerificationCodeExcludedFiles>
+				</packageVerificationCode>
+				<licenseConcluded>(LicenseRef-1 AND MPL-1.1 AND LicenseRef-2 AND LicenseRef-3 AND Apache-2.0 AND LicenseRef-4 AND Apache-1.0)</licenseConcluded>
+				<supplier>Organization: Linux Foundation</supplier>
+				<checksums>
+					<checksumValue>2fd4e1c67a2d28fced849ee1bb76e7391b93eb12</checksumValue>
+					<algorithm>checksumAlgorithm_sha1</algorithm>
+				</checksums>
+				<versionInfo>Version 0.9.2</versionInfo>
+				<licenseDeclared>(LicenseRef-3 AND LicenseRef-2 AND Apache-2.0 AND MPL-1.1 AND LicenseRef-1 AND LicenseRef-4)</licenseDeclared>
+				<downloadLocation>http://www.spdx.org/tools</downloadLocation>
+				<description>This utility translates and SPDX RDF XML document to a spreadsheet, translates a spreadsheet to an SPDX RDF XML document and translates an SPDX RDFa document to an SPDX RDF XML document.</description>
+			</Package>
+		</documentDescribes>
+		<creationInfo>
+			<comment>This is an example of an SPDX spreadsheet format</comment>
+			<creators>Tool: SourceAuditor-V1.2</creators>
+			<creators>Person: Gary O'Neall</creators>
+			<creators>Organization: Source Auditor Inc.</creators>
+			<licenseListVersion>3.6</licenseListVersion>
+			<created>2010-02-03T00:00:00Z</created>
+		</creationInfo>
+		<externalDocumentRefs>
+			<checksum>
+				<checksumValue>d6a770ba38583ed4bb4525bd96e50461655d2759</checksumValue>
+				<algorithm>checksumAlgorithm_sha1</algorithm>
+			</checksum>
+			<spdxDocument>https://spdx.org/spdxdocs/spdx-tools-v2.1-3F2504E0-4F89-41D3-9A0C-0305E82C3301</spdxDocument>
+			<externalDocumentId>DocumentRef-spdx-tool-2.1</externalDocumentId>
+		</externalDocumentRefs>
+		<documentNamespace>https://spdx.org/spdxdocs/spdx-example-444504E0-4F89-41D3-9A0C-0305E82C3301</documentNamespace>
+		<annotations>
+			<comment>This is just an example. Some of the non-standard licenses look like they are actually BSD 3 clause licenses</comment>
+			<annotationType>REVIEW</annotationType>
+			<SPDXID>SPDXRef-45</SPDXID>
+			<annotationDate>2012-06-13T00:00:00Z</annotationDate>
+			<annotator>Person: Jim Reviewer</annotator>
+		</annotations>
+		<dataLicense>CC0-1.0</dataLicense>
+		<reviewers>
+			<comment>This is just an example.  Some of the non-standard licenses look like they are actually BSD 3 clause licenses</comment>
+			<reviewer>Person: Joe Reviewer</reviewer>
+			<reviewDate>2010-02-10T00:00:00Z</reviewDate>
+		</reviewers>
+		<reviewers>
+			<comment>Another example reviewer.</comment>
+			<reviewer>Person: Suzanne Reviewer</reviewer>
+			<reviewDate>2011-03-13T00:00:00Z</reviewDate>
+		</reviewers>
+		<hasExtractedLicensingInfos>
+			<extractedText>/*
+ * (c) Copyright 2000, 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009 Hewlett-Packard Development Company, LP
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. The name of the author may not be used to endorse or promote products
+ *    derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */</extractedText>
+			<licenseId>LicenseRef-1</licenseId>
+		</hasExtractedLicensingInfos>
+		<hasExtractedLicensingInfos>
+			<extractedText>This package includes the GRDDL parser developed by Hewlett Packard under the following license:
+© Copyright 2007 Hewlett-Packard Development Company, LP
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met: 
+
+Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer. 
+Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution. 
+The name of the author may not be used to endorse or promote products derived from this software without specific prior written permission. 
+THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. </extractedText>
+			<licenseId>LicenseRef-2</licenseId>
+		</hasExtractedLicensingInfos>
+		<hasExtractedLicensingInfos>
+			<extractedText>The CyberNeko Software License, Version 1.0
+
+ 
+(C) Copyright 2002-2005, Andy Clark.  All rights reserved.
+ 
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer. 
+
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in
+   the documentation and/or other materials provided with the
+   distribution.
+
+3. The end-user documentation included with the redistribution,
+   if any, must include the following acknowledgment:  
+     "This product includes software developed by Andy Clark."
+   Alternately, this acknowledgment may appear in the software itself,
+   if and wherever such third-party acknowledgments normally appear.
+
+4. The names "CyberNeko" and "NekoHTML" must not be used to endorse
+   or promote products derived from this software without prior 
+   written permission. For written permission, please contact 
+   andyc@cyberneko.net.
+
+5. Products derived from this software may not be called "CyberNeko",
+   nor may "CyberNeko" appear in their name, without prior written
+   permission of the author.
+
+THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESSED OR IMPLIED
+WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR OTHER CONTRIBUTORS
+BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, 
+OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT 
+OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR 
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE 
+OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, 
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.</extractedText>
+			<comment>This is tye CyperNeko License</comment>
+			<licenseId>LicenseRef-3</licenseId>
+			<name>CyberNeko License</name>
+			<seeAlso>http://justasample.url.com</seeAlso>
+			<seeAlso>http://people.apache.org/~andyc/neko/LICENSE</seeAlso>
+		</hasExtractedLicensingInfos>
+		<hasExtractedLicensingInfos>
+			<extractedText>/*
+ * (c) Copyright 2009 University of Bristol
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. The name of the author may not be used to endorse or promote products
+ *    derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */  </extractedText>
+			<licenseId>LicenseRef-4</licenseId>
+		</hasExtractedLicensingInfos>
+		<spdxVersion>SPDX-2.1</spdxVersion>
+		<SPDXID>SPDXRef-DOCUMENT</SPDXID>
+		<snippets>
+			<comment>This snippet was identified as significant and highlighted in this Apache-2.0 file, when a commercial scanner identified it as being derived from file foo.c in package xyz which is licensed under GPL-2.0-or-later.</comment>
+			<name>from linux kernel</name>
+			<copyrightText>Copyright 2008-2010 John Smith</copyrightText>
+			<licenseConcluded>Apache-2.0</licenseConcluded>
+			<licenseInfoFromSnippet>Apache-2.0</licenseInfoFromSnippet>
+			<licenseComments>The concluded license was taken from package xyz, from which the snippet was copied into the current file. The concluded license information was found in the COPYING.txt file in package xyz.</licenseComments>
+			<SPDXID>SPDXRef-Snippet</SPDXID>
+			<fileId>SPDXRef-DoapSource</fileId>
+		</snippets>
+        <relationships>
+            <spdxElementId>SPDXRef-DOCUMENT</spdxElementId>
+            <relatedSpdxElement>SPDXRef-File</relatedSpdxElement>
+            <relationshipType>DESCRIBES</relationshipType>
+        </relationships>
+        <relationships>
+            <spdxElementId>SPDXRef-DOCUMENT</spdxElementId>
+            <relatedSpdxElement>SPDXRef-Package</relatedSpdxElement>
+            <relationshipType>DESCRIBES</relationshipType>
+        </relationships>
+        <relationships>
+            <spdxElementId>SPDXRef-DOCUMENT</spdxElementId>
+            <relatedSpdxElement>SPDXRef-Package</relatedSpdxElement>
+            <relationshipType>CONTAINS</relationshipType>
+        </relationships>
+	</Document>
+</SpdxDocument>

--- a/tests/data/parse_anything_test_files/SPDXXmlExample.xml.spdx
+++ b/tests/data/parse_anything_test_files/SPDXXmlExample.xml.spdx
@@ -1,0 +1,263 @@
+<?xml version="1.0" encoding="utf-8"?>
+<SpdxDocument>
+	<Document>
+		<comment>This is a sample spreadsheet</comment>
+		<name>Sample_Document-V2.1</name>
+		<documentDescribes>
+			<Package>
+				<SPDXID>SPDXRef-Package</SPDXID>
+                <originator>Organization: SPDX</originator>
+                                 <attributionTexts>The GNU C Library is free software.  See the file COPYING.LIB for copying conditions, and LICENSES for notices about a few contributions that require these additional notices to be distributed.  License copyright years may be listed using range notation, e.g., 1996-2015, indicating that every year in the range, inclusive, is a copyrightable year that would otherwise be listed individually.</attributionTexts>
+				<files>
+					<File>
+						<licenseInfoFromFiles>Apache-2.0</licenseInfoFromFiles>
+						<sha1>2fd4e1c67a2d28fced849ee1bb76e7391b93eb12</sha1>
+						<name>src/org/spdx/parser/DOAPProject.java</name>
+						<copyrightText>Copyright 2010, 2011 Source Auditor Inc.</copyrightText>
+						<licenseConcluded>Apache-2.0</licenseConcluded>
+						<licenseComments></licenseComments>
+						<checksums>
+							<checksumValue>2fd4e1c67a2d28fced849ee1bb76e7391b93eb12</checksumValue>
+							<algorithm>checksumAlgorithm_sha1</algorithm>
+						</checksums>
+						<fileTypes>fileType_source</fileTypes>
+						<SPDXID>SPDXRef-File2</SPDXID>
+					</File>
+				</files>
+				<files>
+					<File>
+						<comment>This file belongs to Jena</comment>
+						<licenseInfoFromFiles>LicenseRef-1</licenseInfoFromFiles>
+						<sha1>3ab4e1c67a2d28fced849ee1bb76e7391b93f125</sha1>
+						<name>Jenna-2.6.3/jena-2.6.3-sources.jar</name>
+						<copyrightText>(c) Copyright 2000, 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009 Hewlett-Packard Development Company, LP</copyrightText>
+						<artifactOf>
+							<name>Jena</name>
+							<homePage>http://www.openjena.org/</homePage>
+							<projectUri>http://subversion.apache.org/doap.rdf</projectUri>
+						</artifactOf>
+						<licenseConcluded>LicenseRef-1</licenseConcluded>
+						<licenseComments>This license is used by Jena</licenseComments>
+						<checksums>
+							<checksumValue>3ab4e1c67a2d28fced849ee1bb76e7391b93f125</checksumValue>
+							<algorithm>checksumAlgorithm_sha1</algorithm>
+						</checksums>
+						<fileTypes>fileType_archive</fileTypes>
+						<SPDXID>SPDXRef-File1</SPDXID>
+					</File>
+				</files>
+				<licenseInfoFromFiles>LicenseRef-3</licenseInfoFromFiles>
+				<licenseInfoFromFiles>LicenseRef-1</licenseInfoFromFiles>
+				<licenseInfoFromFiles>Apache-1.0</licenseInfoFromFiles>
+				<licenseInfoFromFiles>LicenseRef-4</licenseInfoFromFiles>
+				<licenseInfoFromFiles>Apache-2.0</licenseInfoFromFiles>
+				<licenseInfoFromFiles>LicenseRef-2</licenseInfoFromFiles>
+				<licenseInfoFromFiles>MPL-1.1</licenseInfoFromFiles>
+				<sha1>2fd4e1c67a2d28fced849ee1bb76e7391b93eb12</sha1>
+				<name>SPDX Translator</name>
+				<packageFileName>spdxtranslator-1.0.zip</packageFileName>
+				<licenseComments>The declared license information can be found in the NOTICE file at the root of the archive file</licenseComments>
+				<summary>SPDX Translator utility</summary>
+				<sourceInfo>Version 1.0 of the SPDX Translator application</sourceInfo>
+				<copyrightText> Copyright 2010, 2011 Source Auditor Inc.</copyrightText>
+				<packageVerificationCode>
+					<packageVerificationCodeValue>4e3211c67a2d28fced849ee1bb76e7391b93feba</packageVerificationCodeValue>
+					<packageVerificationCodeExcludedFiles>SpdxTranslatorSpdx.rdf</packageVerificationCodeExcludedFiles>
+					<packageVerificationCodeExcludedFiles>SpdxTranslatorSpdx.txt</packageVerificationCodeExcludedFiles>
+				</packageVerificationCode>
+				<licenseConcluded>(LicenseRef-1 AND MPL-1.1 AND LicenseRef-2 AND LicenseRef-3 AND Apache-2.0 AND LicenseRef-4 AND Apache-1.0)</licenseConcluded>
+				<supplier>Organization: Linux Foundation</supplier>
+				<checksums>
+					<checksumValue>2fd4e1c67a2d28fced849ee1bb76e7391b93eb12</checksumValue>
+					<algorithm>checksumAlgorithm_sha1</algorithm>
+				</checksums>
+				<versionInfo>Version 0.9.2</versionInfo>
+				<licenseDeclared>(LicenseRef-3 AND LicenseRef-2 AND Apache-2.0 AND MPL-1.1 AND LicenseRef-1 AND LicenseRef-4)</licenseDeclared>
+				<downloadLocation>http://www.spdx.org/tools</downloadLocation>
+				<description>This utility translates and SPDX RDF XML document to a spreadsheet, translates a spreadsheet to an SPDX RDF XML document and translates an SPDX RDFa document to an SPDX RDF XML document.</description>
+			</Package>
+		</documentDescribes>
+		<creationInfo>
+			<comment>This is an example of an SPDX spreadsheet format</comment>
+			<creators>Tool: SourceAuditor-V1.2</creators>
+			<creators>Person: Gary O'Neall</creators>
+			<creators>Organization: Source Auditor Inc.</creators>
+			<licenseListVersion>3.6</licenseListVersion>
+			<created>2010-02-03T00:00:00Z</created>
+		</creationInfo>
+		<externalDocumentRefs>
+			<checksum>
+				<checksumValue>d6a770ba38583ed4bb4525bd96e50461655d2759</checksumValue>
+				<algorithm>checksumAlgorithm_sha1</algorithm>
+			</checksum>
+			<spdxDocument>https://spdx.org/spdxdocs/spdx-tools-v2.1-3F2504E0-4F89-41D3-9A0C-0305E82C3301</spdxDocument>
+			<externalDocumentId>DocumentRef-spdx-tool-2.1</externalDocumentId>
+		</externalDocumentRefs>
+		<documentNamespace>https://spdx.org/spdxdocs/spdx-example-444504E0-4F89-41D3-9A0C-0305E82C3301</documentNamespace>
+		<annotations>
+			<comment>This is just an example. Some of the non-standard licenses look like they are actually BSD 3 clause licenses</comment>
+			<annotationType>REVIEW</annotationType>
+			<SPDXID>SPDXRef-45</SPDXID>
+			<annotationDate>2012-06-13T00:00:00Z</annotationDate>
+			<annotator>Person: Jim Reviewer</annotator>
+		</annotations>
+		<dataLicense>CC0-1.0</dataLicense>
+		<reviewers>
+			<comment>This is just an example.  Some of the non-standard licenses look like they are actually BSD 3 clause licenses</comment>
+			<reviewer>Person: Joe Reviewer</reviewer>
+			<reviewDate>2010-02-10T00:00:00Z</reviewDate>
+		</reviewers>
+		<reviewers>
+			<comment>Another example reviewer.</comment>
+			<reviewer>Person: Suzanne Reviewer</reviewer>
+			<reviewDate>2011-03-13T00:00:00Z</reviewDate>
+		</reviewers>
+		<hasExtractedLicensingInfos>
+			<extractedText>/*
+ * (c) Copyright 2000, 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009 Hewlett-Packard Development Company, LP
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. The name of the author may not be used to endorse or promote products
+ *    derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */</extractedText>
+			<licenseId>LicenseRef-1</licenseId>
+		</hasExtractedLicensingInfos>
+		<hasExtractedLicensingInfos>
+			<extractedText>This package includes the GRDDL parser developed by Hewlett Packard under the following license:
+© Copyright 2007 Hewlett-Packard Development Company, LP
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met: 
+
+Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer. 
+Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution. 
+The name of the author may not be used to endorse or promote products derived from this software without specific prior written permission. 
+THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. </extractedText>
+			<licenseId>LicenseRef-2</licenseId>
+		</hasExtractedLicensingInfos>
+		<hasExtractedLicensingInfos>
+			<extractedText>The CyberNeko Software License, Version 1.0
+
+ 
+(C) Copyright 2002-2005, Andy Clark.  All rights reserved.
+ 
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer. 
+
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in
+   the documentation and/or other materials provided with the
+   distribution.
+
+3. The end-user documentation included with the redistribution,
+   if any, must include the following acknowledgment:  
+     "This product includes software developed by Andy Clark."
+   Alternately, this acknowledgment may appear in the software itself,
+   if and wherever such third-party acknowledgments normally appear.
+
+4. The names "CyberNeko" and "NekoHTML" must not be used to endorse
+   or promote products derived from this software without prior 
+   written permission. For written permission, please contact 
+   andyc@cyberneko.net.
+
+5. Products derived from this software may not be called "CyberNeko",
+   nor may "CyberNeko" appear in their name, without prior written
+   permission of the author.
+
+THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESSED OR IMPLIED
+WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR OTHER CONTRIBUTORS
+BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, 
+OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT 
+OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR 
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE 
+OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, 
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.</extractedText>
+			<comment>This is tye CyperNeko License</comment>
+			<licenseId>LicenseRef-3</licenseId>
+			<name>CyberNeko License</name>
+			<seeAlso>http://justasample.url.com</seeAlso>
+			<seeAlso>http://people.apache.org/~andyc/neko/LICENSE</seeAlso>
+		</hasExtractedLicensingInfos>
+		<hasExtractedLicensingInfos>
+			<extractedText>/*
+ * (c) Copyright 2009 University of Bristol
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. The name of the author may not be used to endorse or promote products
+ *    derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */  </extractedText>
+			<licenseId>LicenseRef-4</licenseId>
+		</hasExtractedLicensingInfos>
+		<spdxVersion>SPDX-2.1</spdxVersion>
+		<SPDXID>SPDXRef-DOCUMENT</SPDXID>
+		<snippets>
+			<comment>This snippet was identified as significant and highlighted in this Apache-2.0 file, when a commercial scanner identified it as being derived from file foo.c in package xyz which is licensed under GPL-2.0-or-later.</comment>
+			<name>from linux kernel</name>
+			<copyrightText>Copyright 2008-2010 John Smith</copyrightText>
+			<licenseConcluded>Apache-2.0</licenseConcluded>
+			<licenseInfoFromSnippet>Apache-2.0</licenseInfoFromSnippet>
+			<licenseComments>The concluded license was taken from package xyz, from which the snippet was copied into the current file. The concluded license information was found in the COPYING.txt file in package xyz.</licenseComments>
+			<SPDXID>SPDXRef-Snippet</SPDXID>
+			<fileId>SPDXRef-DoapSource</fileId>
+		</snippets>
+        <relationships>
+            <spdxElementId>SPDXRef-DOCUMENT</spdxElementId>
+            <relatedSpdxElement>SPDXRef-File</relatedSpdxElement>
+            <relationshipType>DESCRIBES</relationshipType>
+        </relationships>
+        <relationships>
+            <spdxElementId>SPDXRef-DOCUMENT</spdxElementId>
+            <relatedSpdxElement>SPDXRef-Package</relatedSpdxElement>
+            <relationshipType>DESCRIBES</relationshipType>
+        </relationships>
+        <relationships>
+            <spdxElementId>SPDXRef-DOCUMENT</spdxElementId>
+            <relatedSpdxElement>SPDXRef-Package</relatedSpdxElement>
+            <relationshipType>CONTAINS</relationshipType>
+        </relationships>
+	</Document>
+</SpdxDocument>

--- a/tests/data/parse_anything_test_files/SPDXXmlExample.xml.spdx.yml
+++ b/tests/data/parse_anything_test_files/SPDXXmlExample.xml.spdx.yml
@@ -1,0 +1,263 @@
+<?xml version="1.0" encoding="utf-8"?>
+<SpdxDocument>
+	<Document>
+		<comment>This is a sample spreadsheet</comment>
+		<name>Sample_Document-V2.1</name>
+		<documentDescribes>
+			<Package>
+				<SPDXID>SPDXRef-Package</SPDXID>
+                <originator>Organization: SPDX</originator>
+                                 <attributionTexts>The GNU C Library is free software.  See the file COPYING.LIB for copying conditions, and LICENSES for notices about a few contributions that require these additional notices to be distributed.  License copyright years may be listed using range notation, e.g., 1996-2015, indicating that every year in the range, inclusive, is a copyrightable year that would otherwise be listed individually.</attributionTexts>
+				<files>
+					<File>
+						<licenseInfoFromFiles>Apache-2.0</licenseInfoFromFiles>
+						<sha1>2fd4e1c67a2d28fced849ee1bb76e7391b93eb12</sha1>
+						<name>src/org/spdx/parser/DOAPProject.java</name>
+						<copyrightText>Copyright 2010, 2011 Source Auditor Inc.</copyrightText>
+						<licenseConcluded>Apache-2.0</licenseConcluded>
+						<licenseComments></licenseComments>
+						<checksums>
+							<checksumValue>2fd4e1c67a2d28fced849ee1bb76e7391b93eb12</checksumValue>
+							<algorithm>checksumAlgorithm_sha1</algorithm>
+						</checksums>
+						<fileTypes>fileType_source</fileTypes>
+						<SPDXID>SPDXRef-File2</SPDXID>
+					</File>
+				</files>
+				<files>
+					<File>
+						<comment>This file belongs to Jena</comment>
+						<licenseInfoFromFiles>LicenseRef-1</licenseInfoFromFiles>
+						<sha1>3ab4e1c67a2d28fced849ee1bb76e7391b93f125</sha1>
+						<name>Jenna-2.6.3/jena-2.6.3-sources.jar</name>
+						<copyrightText>(c) Copyright 2000, 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009 Hewlett-Packard Development Company, LP</copyrightText>
+						<artifactOf>
+							<name>Jena</name>
+							<homePage>http://www.openjena.org/</homePage>
+							<projectUri>http://subversion.apache.org/doap.rdf</projectUri>
+						</artifactOf>
+						<licenseConcluded>LicenseRef-1</licenseConcluded>
+						<licenseComments>This license is used by Jena</licenseComments>
+						<checksums>
+							<checksumValue>3ab4e1c67a2d28fced849ee1bb76e7391b93f125</checksumValue>
+							<algorithm>checksumAlgorithm_sha1</algorithm>
+						</checksums>
+						<fileTypes>fileType_archive</fileTypes>
+						<SPDXID>SPDXRef-File1</SPDXID>
+					</File>
+				</files>
+				<licenseInfoFromFiles>LicenseRef-3</licenseInfoFromFiles>
+				<licenseInfoFromFiles>LicenseRef-1</licenseInfoFromFiles>
+				<licenseInfoFromFiles>Apache-1.0</licenseInfoFromFiles>
+				<licenseInfoFromFiles>LicenseRef-4</licenseInfoFromFiles>
+				<licenseInfoFromFiles>Apache-2.0</licenseInfoFromFiles>
+				<licenseInfoFromFiles>LicenseRef-2</licenseInfoFromFiles>
+				<licenseInfoFromFiles>MPL-1.1</licenseInfoFromFiles>
+				<sha1>2fd4e1c67a2d28fced849ee1bb76e7391b93eb12</sha1>
+				<name>SPDX Translator</name>
+				<packageFileName>spdxtranslator-1.0.zip</packageFileName>
+				<licenseComments>The declared license information can be found in the NOTICE file at the root of the archive file</licenseComments>
+				<summary>SPDX Translator utility</summary>
+				<sourceInfo>Version 1.0 of the SPDX Translator application</sourceInfo>
+				<copyrightText> Copyright 2010, 2011 Source Auditor Inc.</copyrightText>
+				<packageVerificationCode>
+					<packageVerificationCodeValue>4e3211c67a2d28fced849ee1bb76e7391b93feba</packageVerificationCodeValue>
+					<packageVerificationCodeExcludedFiles>SpdxTranslatorSpdx.rdf</packageVerificationCodeExcludedFiles>
+					<packageVerificationCodeExcludedFiles>SpdxTranslatorSpdx.txt</packageVerificationCodeExcludedFiles>
+				</packageVerificationCode>
+				<licenseConcluded>(LicenseRef-1 AND MPL-1.1 AND LicenseRef-2 AND LicenseRef-3 AND Apache-2.0 AND LicenseRef-4 AND Apache-1.0)</licenseConcluded>
+				<supplier>Organization: Linux Foundation</supplier>
+				<checksums>
+					<checksumValue>2fd4e1c67a2d28fced849ee1bb76e7391b93eb12</checksumValue>
+					<algorithm>checksumAlgorithm_sha1</algorithm>
+				</checksums>
+				<versionInfo>Version 0.9.2</versionInfo>
+				<licenseDeclared>(LicenseRef-3 AND LicenseRef-2 AND Apache-2.0 AND MPL-1.1 AND LicenseRef-1 AND LicenseRef-4)</licenseDeclared>
+				<downloadLocation>http://www.spdx.org/tools</downloadLocation>
+				<description>This utility translates and SPDX RDF XML document to a spreadsheet, translates a spreadsheet to an SPDX RDF XML document and translates an SPDX RDFa document to an SPDX RDF XML document.</description>
+			</Package>
+		</documentDescribes>
+		<creationInfo>
+			<comment>This is an example of an SPDX spreadsheet format</comment>
+			<creators>Tool: SourceAuditor-V1.2</creators>
+			<creators>Person: Gary O'Neall</creators>
+			<creators>Organization: Source Auditor Inc.</creators>
+			<licenseListVersion>3.6</licenseListVersion>
+			<created>2010-02-03T00:00:00Z</created>
+		</creationInfo>
+		<externalDocumentRefs>
+			<checksum>
+				<checksumValue>d6a770ba38583ed4bb4525bd96e50461655d2759</checksumValue>
+				<algorithm>checksumAlgorithm_sha1</algorithm>
+			</checksum>
+			<spdxDocument>https://spdx.org/spdxdocs/spdx-tools-v2.1-3F2504E0-4F89-41D3-9A0C-0305E82C3301</spdxDocument>
+			<externalDocumentId>DocumentRef-spdx-tool-2.1</externalDocumentId>
+		</externalDocumentRefs>
+		<documentNamespace>https://spdx.org/spdxdocs/spdx-example-444504E0-4F89-41D3-9A0C-0305E82C3301</documentNamespace>
+		<annotations>
+			<comment>This is just an example. Some of the non-standard licenses look like they are actually BSD 3 clause licenses</comment>
+			<annotationType>REVIEW</annotationType>
+			<SPDXID>SPDXRef-45</SPDXID>
+			<annotationDate>2012-06-13T00:00:00Z</annotationDate>
+			<annotator>Person: Jim Reviewer</annotator>
+		</annotations>
+		<dataLicense>CC0-1.0</dataLicense>
+		<reviewers>
+			<comment>This is just an example.  Some of the non-standard licenses look like they are actually BSD 3 clause licenses</comment>
+			<reviewer>Person: Joe Reviewer</reviewer>
+			<reviewDate>2010-02-10T00:00:00Z</reviewDate>
+		</reviewers>
+		<reviewers>
+			<comment>Another example reviewer.</comment>
+			<reviewer>Person: Suzanne Reviewer</reviewer>
+			<reviewDate>2011-03-13T00:00:00Z</reviewDate>
+		</reviewers>
+		<hasExtractedLicensingInfos>
+			<extractedText>/*
+ * (c) Copyright 2000, 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009 Hewlett-Packard Development Company, LP
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. The name of the author may not be used to endorse or promote products
+ *    derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */</extractedText>
+			<licenseId>LicenseRef-1</licenseId>
+		</hasExtractedLicensingInfos>
+		<hasExtractedLicensingInfos>
+			<extractedText>This package includes the GRDDL parser developed by Hewlett Packard under the following license:
+© Copyright 2007 Hewlett-Packard Development Company, LP
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met: 
+
+Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer. 
+Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution. 
+The name of the author may not be used to endorse or promote products derived from this software without specific prior written permission. 
+THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. </extractedText>
+			<licenseId>LicenseRef-2</licenseId>
+		</hasExtractedLicensingInfos>
+		<hasExtractedLicensingInfos>
+			<extractedText>The CyberNeko Software License, Version 1.0
+
+ 
+(C) Copyright 2002-2005, Andy Clark.  All rights reserved.
+ 
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer. 
+
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in
+   the documentation and/or other materials provided with the
+   distribution.
+
+3. The end-user documentation included with the redistribution,
+   if any, must include the following acknowledgment:  
+     "This product includes software developed by Andy Clark."
+   Alternately, this acknowledgment may appear in the software itself,
+   if and wherever such third-party acknowledgments normally appear.
+
+4. The names "CyberNeko" and "NekoHTML" must not be used to endorse
+   or promote products derived from this software without prior 
+   written permission. For written permission, please contact 
+   andyc@cyberneko.net.
+
+5. Products derived from this software may not be called "CyberNeko",
+   nor may "CyberNeko" appear in their name, without prior written
+   permission of the author.
+
+THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESSED OR IMPLIED
+WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR OTHER CONTRIBUTORS
+BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, 
+OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT 
+OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR 
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE 
+OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, 
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.</extractedText>
+			<comment>This is tye CyperNeko License</comment>
+			<licenseId>LicenseRef-3</licenseId>
+			<name>CyberNeko License</name>
+			<seeAlso>http://justasample.url.com</seeAlso>
+			<seeAlso>http://people.apache.org/~andyc/neko/LICENSE</seeAlso>
+		</hasExtractedLicensingInfos>
+		<hasExtractedLicensingInfos>
+			<extractedText>/*
+ * (c) Copyright 2009 University of Bristol
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. The name of the author may not be used to endorse or promote products
+ *    derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */  </extractedText>
+			<licenseId>LicenseRef-4</licenseId>
+		</hasExtractedLicensingInfos>
+		<spdxVersion>SPDX-2.1</spdxVersion>
+		<SPDXID>SPDXRef-DOCUMENT</SPDXID>
+		<snippets>
+			<comment>This snippet was identified as significant and highlighted in this Apache-2.0 file, when a commercial scanner identified it as being derived from file foo.c in package xyz which is licensed under GPL-2.0-or-later.</comment>
+			<name>from linux kernel</name>
+			<copyrightText>Copyright 2008-2010 John Smith</copyrightText>
+			<licenseConcluded>Apache-2.0</licenseConcluded>
+			<licenseInfoFromSnippet>Apache-2.0</licenseInfoFromSnippet>
+			<licenseComments>The concluded license was taken from package xyz, from which the snippet was copied into the current file. The concluded license information was found in the COPYING.txt file in package xyz.</licenseComments>
+			<SPDXID>SPDXRef-Snippet</SPDXID>
+			<fileId>SPDXRef-DoapSource</fileId>
+		</snippets>
+        <relationships>
+            <spdxElementId>SPDXRef-DOCUMENT</spdxElementId>
+            <relatedSpdxElement>SPDXRef-File</relatedSpdxElement>
+            <relationshipType>DESCRIBES</relationshipType>
+        </relationships>
+        <relationships>
+            <spdxElementId>SPDXRef-DOCUMENT</spdxElementId>
+            <relatedSpdxElement>SPDXRef-Package</relatedSpdxElement>
+            <relationshipType>DESCRIBES</relationshipType>
+        </relationships>
+        <relationships>
+            <spdxElementId>SPDXRef-DOCUMENT</spdxElementId>
+            <relatedSpdxElement>SPDXRef-Package</relatedSpdxElement>
+            <relationshipType>CONTAINS</relationshipType>
+        </relationships>
+	</Document>
+</SpdxDocument>

--- a/tests/data/parse_anything_test_files/SPDXXmlExample.xml.tag
+++ b/tests/data/parse_anything_test_files/SPDXXmlExample.xml.tag
@@ -1,0 +1,263 @@
+<?xml version="1.0" encoding="utf-8"?>
+<SpdxDocument>
+	<Document>
+		<comment>This is a sample spreadsheet</comment>
+		<name>Sample_Document-V2.1</name>
+		<documentDescribes>
+			<Package>
+				<SPDXID>SPDXRef-Package</SPDXID>
+                <originator>Organization: SPDX</originator>
+                                 <attributionTexts>The GNU C Library is free software.  See the file COPYING.LIB for copying conditions, and LICENSES for notices about a few contributions that require these additional notices to be distributed.  License copyright years may be listed using range notation, e.g., 1996-2015, indicating that every year in the range, inclusive, is a copyrightable year that would otherwise be listed individually.</attributionTexts>
+				<files>
+					<File>
+						<licenseInfoFromFiles>Apache-2.0</licenseInfoFromFiles>
+						<sha1>2fd4e1c67a2d28fced849ee1bb76e7391b93eb12</sha1>
+						<name>src/org/spdx/parser/DOAPProject.java</name>
+						<copyrightText>Copyright 2010, 2011 Source Auditor Inc.</copyrightText>
+						<licenseConcluded>Apache-2.0</licenseConcluded>
+						<licenseComments></licenseComments>
+						<checksums>
+							<checksumValue>2fd4e1c67a2d28fced849ee1bb76e7391b93eb12</checksumValue>
+							<algorithm>checksumAlgorithm_sha1</algorithm>
+						</checksums>
+						<fileTypes>fileType_source</fileTypes>
+						<SPDXID>SPDXRef-File2</SPDXID>
+					</File>
+				</files>
+				<files>
+					<File>
+						<comment>This file belongs to Jena</comment>
+						<licenseInfoFromFiles>LicenseRef-1</licenseInfoFromFiles>
+						<sha1>3ab4e1c67a2d28fced849ee1bb76e7391b93f125</sha1>
+						<name>Jenna-2.6.3/jena-2.6.3-sources.jar</name>
+						<copyrightText>(c) Copyright 2000, 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009 Hewlett-Packard Development Company, LP</copyrightText>
+						<artifactOf>
+							<name>Jena</name>
+							<homePage>http://www.openjena.org/</homePage>
+							<projectUri>http://subversion.apache.org/doap.rdf</projectUri>
+						</artifactOf>
+						<licenseConcluded>LicenseRef-1</licenseConcluded>
+						<licenseComments>This license is used by Jena</licenseComments>
+						<checksums>
+							<checksumValue>3ab4e1c67a2d28fced849ee1bb76e7391b93f125</checksumValue>
+							<algorithm>checksumAlgorithm_sha1</algorithm>
+						</checksums>
+						<fileTypes>fileType_archive</fileTypes>
+						<SPDXID>SPDXRef-File1</SPDXID>
+					</File>
+				</files>
+				<licenseInfoFromFiles>LicenseRef-3</licenseInfoFromFiles>
+				<licenseInfoFromFiles>LicenseRef-1</licenseInfoFromFiles>
+				<licenseInfoFromFiles>Apache-1.0</licenseInfoFromFiles>
+				<licenseInfoFromFiles>LicenseRef-4</licenseInfoFromFiles>
+				<licenseInfoFromFiles>Apache-2.0</licenseInfoFromFiles>
+				<licenseInfoFromFiles>LicenseRef-2</licenseInfoFromFiles>
+				<licenseInfoFromFiles>MPL-1.1</licenseInfoFromFiles>
+				<sha1>2fd4e1c67a2d28fced849ee1bb76e7391b93eb12</sha1>
+				<name>SPDX Translator</name>
+				<packageFileName>spdxtranslator-1.0.zip</packageFileName>
+				<licenseComments>The declared license information can be found in the NOTICE file at the root of the archive file</licenseComments>
+				<summary>SPDX Translator utility</summary>
+				<sourceInfo>Version 1.0 of the SPDX Translator application</sourceInfo>
+				<copyrightText> Copyright 2010, 2011 Source Auditor Inc.</copyrightText>
+				<packageVerificationCode>
+					<packageVerificationCodeValue>4e3211c67a2d28fced849ee1bb76e7391b93feba</packageVerificationCodeValue>
+					<packageVerificationCodeExcludedFiles>SpdxTranslatorSpdx.rdf</packageVerificationCodeExcludedFiles>
+					<packageVerificationCodeExcludedFiles>SpdxTranslatorSpdx.txt</packageVerificationCodeExcludedFiles>
+				</packageVerificationCode>
+				<licenseConcluded>(LicenseRef-1 AND MPL-1.1 AND LicenseRef-2 AND LicenseRef-3 AND Apache-2.0 AND LicenseRef-4 AND Apache-1.0)</licenseConcluded>
+				<supplier>Organization: Linux Foundation</supplier>
+				<checksums>
+					<checksumValue>2fd4e1c67a2d28fced849ee1bb76e7391b93eb12</checksumValue>
+					<algorithm>checksumAlgorithm_sha1</algorithm>
+				</checksums>
+				<versionInfo>Version 0.9.2</versionInfo>
+				<licenseDeclared>(LicenseRef-3 AND LicenseRef-2 AND Apache-2.0 AND MPL-1.1 AND LicenseRef-1 AND LicenseRef-4)</licenseDeclared>
+				<downloadLocation>http://www.spdx.org/tools</downloadLocation>
+				<description>This utility translates and SPDX RDF XML document to a spreadsheet, translates a spreadsheet to an SPDX RDF XML document and translates an SPDX RDFa document to an SPDX RDF XML document.</description>
+			</Package>
+		</documentDescribes>
+		<creationInfo>
+			<comment>This is an example of an SPDX spreadsheet format</comment>
+			<creators>Tool: SourceAuditor-V1.2</creators>
+			<creators>Person: Gary O'Neall</creators>
+			<creators>Organization: Source Auditor Inc.</creators>
+			<licenseListVersion>3.6</licenseListVersion>
+			<created>2010-02-03T00:00:00Z</created>
+		</creationInfo>
+		<externalDocumentRefs>
+			<checksum>
+				<checksumValue>d6a770ba38583ed4bb4525bd96e50461655d2759</checksumValue>
+				<algorithm>checksumAlgorithm_sha1</algorithm>
+			</checksum>
+			<spdxDocument>https://spdx.org/spdxdocs/spdx-tools-v2.1-3F2504E0-4F89-41D3-9A0C-0305E82C3301</spdxDocument>
+			<externalDocumentId>DocumentRef-spdx-tool-2.1</externalDocumentId>
+		</externalDocumentRefs>
+		<documentNamespace>https://spdx.org/spdxdocs/spdx-example-444504E0-4F89-41D3-9A0C-0305E82C3301</documentNamespace>
+		<annotations>
+			<comment>This is just an example. Some of the non-standard licenses look like they are actually BSD 3 clause licenses</comment>
+			<annotationType>REVIEW</annotationType>
+			<SPDXID>SPDXRef-45</SPDXID>
+			<annotationDate>2012-06-13T00:00:00Z</annotationDate>
+			<annotator>Person: Jim Reviewer</annotator>
+		</annotations>
+		<dataLicense>CC0-1.0</dataLicense>
+		<reviewers>
+			<comment>This is just an example.  Some of the non-standard licenses look like they are actually BSD 3 clause licenses</comment>
+			<reviewer>Person: Joe Reviewer</reviewer>
+			<reviewDate>2010-02-10T00:00:00Z</reviewDate>
+		</reviewers>
+		<reviewers>
+			<comment>Another example reviewer.</comment>
+			<reviewer>Person: Suzanne Reviewer</reviewer>
+			<reviewDate>2011-03-13T00:00:00Z</reviewDate>
+		</reviewers>
+		<hasExtractedLicensingInfos>
+			<extractedText>/*
+ * (c) Copyright 2000, 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009 Hewlett-Packard Development Company, LP
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. The name of the author may not be used to endorse or promote products
+ *    derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */</extractedText>
+			<licenseId>LicenseRef-1</licenseId>
+		</hasExtractedLicensingInfos>
+		<hasExtractedLicensingInfos>
+			<extractedText>This package includes the GRDDL parser developed by Hewlett Packard under the following license:
+© Copyright 2007 Hewlett-Packard Development Company, LP
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met: 
+
+Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer. 
+Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution. 
+The name of the author may not be used to endorse or promote products derived from this software without specific prior written permission. 
+THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. </extractedText>
+			<licenseId>LicenseRef-2</licenseId>
+		</hasExtractedLicensingInfos>
+		<hasExtractedLicensingInfos>
+			<extractedText>The CyberNeko Software License, Version 1.0
+
+ 
+(C) Copyright 2002-2005, Andy Clark.  All rights reserved.
+ 
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer. 
+
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in
+   the documentation and/or other materials provided with the
+   distribution.
+
+3. The end-user documentation included with the redistribution,
+   if any, must include the following acknowledgment:  
+     "This product includes software developed by Andy Clark."
+   Alternately, this acknowledgment may appear in the software itself,
+   if and wherever such third-party acknowledgments normally appear.
+
+4. The names "CyberNeko" and "NekoHTML" must not be used to endorse
+   or promote products derived from this software without prior 
+   written permission. For written permission, please contact 
+   andyc@cyberneko.net.
+
+5. Products derived from this software may not be called "CyberNeko",
+   nor may "CyberNeko" appear in their name, without prior written
+   permission of the author.
+
+THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESSED OR IMPLIED
+WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR OTHER CONTRIBUTORS
+BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, 
+OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT 
+OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR 
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE 
+OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, 
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.</extractedText>
+			<comment>This is tye CyperNeko License</comment>
+			<licenseId>LicenseRef-3</licenseId>
+			<name>CyberNeko License</name>
+			<seeAlso>http://justasample.url.com</seeAlso>
+			<seeAlso>http://people.apache.org/~andyc/neko/LICENSE</seeAlso>
+		</hasExtractedLicensingInfos>
+		<hasExtractedLicensingInfos>
+			<extractedText>/*
+ * (c) Copyright 2009 University of Bristol
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. The name of the author may not be used to endorse or promote products
+ *    derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */  </extractedText>
+			<licenseId>LicenseRef-4</licenseId>
+		</hasExtractedLicensingInfos>
+		<spdxVersion>SPDX-2.1</spdxVersion>
+		<SPDXID>SPDXRef-DOCUMENT</SPDXID>
+		<snippets>
+			<comment>This snippet was identified as significant and highlighted in this Apache-2.0 file, when a commercial scanner identified it as being derived from file foo.c in package xyz which is licensed under GPL-2.0-or-later.</comment>
+			<name>from linux kernel</name>
+			<copyrightText>Copyright 2008-2010 John Smith</copyrightText>
+			<licenseConcluded>Apache-2.0</licenseConcluded>
+			<licenseInfoFromSnippet>Apache-2.0</licenseInfoFromSnippet>
+			<licenseComments>The concluded license was taken from package xyz, from which the snippet was copied into the current file. The concluded license information was found in the COPYING.txt file in package xyz.</licenseComments>
+			<SPDXID>SPDXRef-Snippet</SPDXID>
+			<fileId>SPDXRef-DoapSource</fileId>
+		</snippets>
+        <relationships>
+            <spdxElementId>SPDXRef-DOCUMENT</spdxElementId>
+            <relatedSpdxElement>SPDXRef-File</relatedSpdxElement>
+            <relationshipType>DESCRIBES</relationshipType>
+        </relationships>
+        <relationships>
+            <spdxElementId>SPDXRef-DOCUMENT</spdxElementId>
+            <relatedSpdxElement>SPDXRef-Package</relatedSpdxElement>
+            <relationshipType>DESCRIBES</relationshipType>
+        </relationships>
+        <relationships>
+            <spdxElementId>SPDXRef-DOCUMENT</spdxElementId>
+            <relatedSpdxElement>SPDXRef-Package</relatedSpdxElement>
+            <relationshipType>CONTAINS</relationshipType>
+        </relationships>
+	</Document>
+</SpdxDocument>

--- a/tests/data/parse_anything_test_files/SPDXXmlExample.xml.yaml
+++ b/tests/data/parse_anything_test_files/SPDXXmlExample.xml.yaml
@@ -1,0 +1,263 @@
+<?xml version="1.0" encoding="utf-8"?>
+<SpdxDocument>
+	<Document>
+		<comment>This is a sample spreadsheet</comment>
+		<name>Sample_Document-V2.1</name>
+		<documentDescribes>
+			<Package>
+				<SPDXID>SPDXRef-Package</SPDXID>
+                <originator>Organization: SPDX</originator>
+                                 <attributionTexts>The GNU C Library is free software.  See the file COPYING.LIB for copying conditions, and LICENSES for notices about a few contributions that require these additional notices to be distributed.  License copyright years may be listed using range notation, e.g., 1996-2015, indicating that every year in the range, inclusive, is a copyrightable year that would otherwise be listed individually.</attributionTexts>
+				<files>
+					<File>
+						<licenseInfoFromFiles>Apache-2.0</licenseInfoFromFiles>
+						<sha1>2fd4e1c67a2d28fced849ee1bb76e7391b93eb12</sha1>
+						<name>src/org/spdx/parser/DOAPProject.java</name>
+						<copyrightText>Copyright 2010, 2011 Source Auditor Inc.</copyrightText>
+						<licenseConcluded>Apache-2.0</licenseConcluded>
+						<licenseComments></licenseComments>
+						<checksums>
+							<checksumValue>2fd4e1c67a2d28fced849ee1bb76e7391b93eb12</checksumValue>
+							<algorithm>checksumAlgorithm_sha1</algorithm>
+						</checksums>
+						<fileTypes>fileType_source</fileTypes>
+						<SPDXID>SPDXRef-File2</SPDXID>
+					</File>
+				</files>
+				<files>
+					<File>
+						<comment>This file belongs to Jena</comment>
+						<licenseInfoFromFiles>LicenseRef-1</licenseInfoFromFiles>
+						<sha1>3ab4e1c67a2d28fced849ee1bb76e7391b93f125</sha1>
+						<name>Jenna-2.6.3/jena-2.6.3-sources.jar</name>
+						<copyrightText>(c) Copyright 2000, 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009 Hewlett-Packard Development Company, LP</copyrightText>
+						<artifactOf>
+							<name>Jena</name>
+							<homePage>http://www.openjena.org/</homePage>
+							<projectUri>http://subversion.apache.org/doap.rdf</projectUri>
+						</artifactOf>
+						<licenseConcluded>LicenseRef-1</licenseConcluded>
+						<licenseComments>This license is used by Jena</licenseComments>
+						<checksums>
+							<checksumValue>3ab4e1c67a2d28fced849ee1bb76e7391b93f125</checksumValue>
+							<algorithm>checksumAlgorithm_sha1</algorithm>
+						</checksums>
+						<fileTypes>fileType_archive</fileTypes>
+						<SPDXID>SPDXRef-File1</SPDXID>
+					</File>
+				</files>
+				<licenseInfoFromFiles>LicenseRef-3</licenseInfoFromFiles>
+				<licenseInfoFromFiles>LicenseRef-1</licenseInfoFromFiles>
+				<licenseInfoFromFiles>Apache-1.0</licenseInfoFromFiles>
+				<licenseInfoFromFiles>LicenseRef-4</licenseInfoFromFiles>
+				<licenseInfoFromFiles>Apache-2.0</licenseInfoFromFiles>
+				<licenseInfoFromFiles>LicenseRef-2</licenseInfoFromFiles>
+				<licenseInfoFromFiles>MPL-1.1</licenseInfoFromFiles>
+				<sha1>2fd4e1c67a2d28fced849ee1bb76e7391b93eb12</sha1>
+				<name>SPDX Translator</name>
+				<packageFileName>spdxtranslator-1.0.zip</packageFileName>
+				<licenseComments>The declared license information can be found in the NOTICE file at the root of the archive file</licenseComments>
+				<summary>SPDX Translator utility</summary>
+				<sourceInfo>Version 1.0 of the SPDX Translator application</sourceInfo>
+				<copyrightText> Copyright 2010, 2011 Source Auditor Inc.</copyrightText>
+				<packageVerificationCode>
+					<packageVerificationCodeValue>4e3211c67a2d28fced849ee1bb76e7391b93feba</packageVerificationCodeValue>
+					<packageVerificationCodeExcludedFiles>SpdxTranslatorSpdx.rdf</packageVerificationCodeExcludedFiles>
+					<packageVerificationCodeExcludedFiles>SpdxTranslatorSpdx.txt</packageVerificationCodeExcludedFiles>
+				</packageVerificationCode>
+				<licenseConcluded>(LicenseRef-1 AND MPL-1.1 AND LicenseRef-2 AND LicenseRef-3 AND Apache-2.0 AND LicenseRef-4 AND Apache-1.0)</licenseConcluded>
+				<supplier>Organization: Linux Foundation</supplier>
+				<checksums>
+					<checksumValue>2fd4e1c67a2d28fced849ee1bb76e7391b93eb12</checksumValue>
+					<algorithm>checksumAlgorithm_sha1</algorithm>
+				</checksums>
+				<versionInfo>Version 0.9.2</versionInfo>
+				<licenseDeclared>(LicenseRef-3 AND LicenseRef-2 AND Apache-2.0 AND MPL-1.1 AND LicenseRef-1 AND LicenseRef-4)</licenseDeclared>
+				<downloadLocation>http://www.spdx.org/tools</downloadLocation>
+				<description>This utility translates and SPDX RDF XML document to a spreadsheet, translates a spreadsheet to an SPDX RDF XML document and translates an SPDX RDFa document to an SPDX RDF XML document.</description>
+			</Package>
+		</documentDescribes>
+		<creationInfo>
+			<comment>This is an example of an SPDX spreadsheet format</comment>
+			<creators>Tool: SourceAuditor-V1.2</creators>
+			<creators>Person: Gary O'Neall</creators>
+			<creators>Organization: Source Auditor Inc.</creators>
+			<licenseListVersion>3.6</licenseListVersion>
+			<created>2010-02-03T00:00:00Z</created>
+		</creationInfo>
+		<externalDocumentRefs>
+			<checksum>
+				<checksumValue>d6a770ba38583ed4bb4525bd96e50461655d2759</checksumValue>
+				<algorithm>checksumAlgorithm_sha1</algorithm>
+			</checksum>
+			<spdxDocument>https://spdx.org/spdxdocs/spdx-tools-v2.1-3F2504E0-4F89-41D3-9A0C-0305E82C3301</spdxDocument>
+			<externalDocumentId>DocumentRef-spdx-tool-2.1</externalDocumentId>
+		</externalDocumentRefs>
+		<documentNamespace>https://spdx.org/spdxdocs/spdx-example-444504E0-4F89-41D3-9A0C-0305E82C3301</documentNamespace>
+		<annotations>
+			<comment>This is just an example. Some of the non-standard licenses look like they are actually BSD 3 clause licenses</comment>
+			<annotationType>REVIEW</annotationType>
+			<SPDXID>SPDXRef-45</SPDXID>
+			<annotationDate>2012-06-13T00:00:00Z</annotationDate>
+			<annotator>Person: Jim Reviewer</annotator>
+		</annotations>
+		<dataLicense>CC0-1.0</dataLicense>
+		<reviewers>
+			<comment>This is just an example.  Some of the non-standard licenses look like they are actually BSD 3 clause licenses</comment>
+			<reviewer>Person: Joe Reviewer</reviewer>
+			<reviewDate>2010-02-10T00:00:00Z</reviewDate>
+		</reviewers>
+		<reviewers>
+			<comment>Another example reviewer.</comment>
+			<reviewer>Person: Suzanne Reviewer</reviewer>
+			<reviewDate>2011-03-13T00:00:00Z</reviewDate>
+		</reviewers>
+		<hasExtractedLicensingInfos>
+			<extractedText>/*
+ * (c) Copyright 2000, 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009 Hewlett-Packard Development Company, LP
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. The name of the author may not be used to endorse or promote products
+ *    derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */</extractedText>
+			<licenseId>LicenseRef-1</licenseId>
+		</hasExtractedLicensingInfos>
+		<hasExtractedLicensingInfos>
+			<extractedText>This package includes the GRDDL parser developed by Hewlett Packard under the following license:
+© Copyright 2007 Hewlett-Packard Development Company, LP
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met: 
+
+Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer. 
+Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution. 
+The name of the author may not be used to endorse or promote products derived from this software without specific prior written permission. 
+THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. </extractedText>
+			<licenseId>LicenseRef-2</licenseId>
+		</hasExtractedLicensingInfos>
+		<hasExtractedLicensingInfos>
+			<extractedText>The CyberNeko Software License, Version 1.0
+
+ 
+(C) Copyright 2002-2005, Andy Clark.  All rights reserved.
+ 
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer. 
+
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in
+   the documentation and/or other materials provided with the
+   distribution.
+
+3. The end-user documentation included with the redistribution,
+   if any, must include the following acknowledgment:  
+     "This product includes software developed by Andy Clark."
+   Alternately, this acknowledgment may appear in the software itself,
+   if and wherever such third-party acknowledgments normally appear.
+
+4. The names "CyberNeko" and "NekoHTML" must not be used to endorse
+   or promote products derived from this software without prior 
+   written permission. For written permission, please contact 
+   andyc@cyberneko.net.
+
+5. Products derived from this software may not be called "CyberNeko",
+   nor may "CyberNeko" appear in their name, without prior written
+   permission of the author.
+
+THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESSED OR IMPLIED
+WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR OTHER CONTRIBUTORS
+BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, 
+OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT 
+OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR 
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE 
+OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, 
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.</extractedText>
+			<comment>This is tye CyperNeko License</comment>
+			<licenseId>LicenseRef-3</licenseId>
+			<name>CyberNeko License</name>
+			<seeAlso>http://justasample.url.com</seeAlso>
+			<seeAlso>http://people.apache.org/~andyc/neko/LICENSE</seeAlso>
+		</hasExtractedLicensingInfos>
+		<hasExtractedLicensingInfos>
+			<extractedText>/*
+ * (c) Copyright 2009 University of Bristol
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. The name of the author may not be used to endorse or promote products
+ *    derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */  </extractedText>
+			<licenseId>LicenseRef-4</licenseId>
+		</hasExtractedLicensingInfos>
+		<spdxVersion>SPDX-2.1</spdxVersion>
+		<SPDXID>SPDXRef-DOCUMENT</SPDXID>
+		<snippets>
+			<comment>This snippet was identified as significant and highlighted in this Apache-2.0 file, when a commercial scanner identified it as being derived from file foo.c in package xyz which is licensed under GPL-2.0-or-later.</comment>
+			<name>from linux kernel</name>
+			<copyrightText>Copyright 2008-2010 John Smith</copyrightText>
+			<licenseConcluded>Apache-2.0</licenseConcluded>
+			<licenseInfoFromSnippet>Apache-2.0</licenseInfoFromSnippet>
+			<licenseComments>The concluded license was taken from package xyz, from which the snippet was copied into the current file. The concluded license information was found in the COPYING.txt file in package xyz.</licenseComments>
+			<SPDXID>SPDXRef-Snippet</SPDXID>
+			<fileId>SPDXRef-DoapSource</fileId>
+		</snippets>
+        <relationships>
+            <spdxElementId>SPDXRef-DOCUMENT</spdxElementId>
+            <relatedSpdxElement>SPDXRef-File</relatedSpdxElement>
+            <relationshipType>DESCRIBES</relationshipType>
+        </relationships>
+        <relationships>
+            <spdxElementId>SPDXRef-DOCUMENT</spdxElementId>
+            <relatedSpdxElement>SPDXRef-Package</relatedSpdxElement>
+            <relationshipType>DESCRIBES</relationshipType>
+        </relationships>
+        <relationships>
+            <spdxElementId>SPDXRef-DOCUMENT</spdxElementId>
+            <relatedSpdxElement>SPDXRef-Package</relatedSpdxElement>
+            <relationshipType>CONTAINS</relationshipType>
+        </relationships>
+	</Document>
+</SpdxDocument>

--- a/tests/data/parse_anything_test_files/SPDXYamlExample.yaml
+++ b/tests/data/parse_anything_test_files/SPDXYamlExample.yaml
@@ -1,0 +1,237 @@
+---
+Document:
+  annotations:
+  - annotationDate: '2012-06-13T00:00:00Z'
+    annotationType: REVIEW
+    annotator: 'Person: Jim Reviewer'
+    comment: This is just an example. Some of the non-standard licenses look like
+      they are actually BSD 3 clause licenses
+    SPDXID: SPDXRef-45
+  comment: This is a sample spreadsheet
+  creationInfo:
+    comment: This is an example of an SPDX spreadsheet format
+    created: '2010-02-03T00:00:00Z'
+    creators:
+    - 'Tool: SourceAuditor-V1.2'
+    - 'Organization: Source Auditor Inc.'
+    - 'Person: Gary O''Neall'
+    licenseListVersion: '3.6'
+  dataLicense: CC0-1.0
+  documentDescribes:
+  - Package:
+      SPDXID: SPDXRef-Package
+      checksums:
+      - algorithm: checksumAlgorithm_sha1
+        checksumValue: 2fd4e1c67a2d28fced849ee1bb76e7391b93eb12
+      copyrightText: ' Copyright 2010, 2011 Source Auditor Inc.'
+      description: This utility translates and SPDX RDF XML document to a spreadsheet,
+        translates a spreadsheet to an SPDX RDF XML document and translates an SPDX
+        RDFa document to an SPDX RDF XML document.
+      downloadLocation: http://www.spdx.org/tools
+      attributionTexts:
+      - "The GNU C Library is free software.  See the file COPYING.LIB for copying conditions,\
+        \ and LICENSES for notices about a few contributions that require these additional\
+        \ notices to be distributed.  License copyright years may be listed using range\
+        \ notation, e.g., 1996-2015, indicating that every year in the range, inclusive,\
+        \ is a copyrightable year that would otherwise be listed individually."
+      files:
+      - File:
+          checksums:
+          - algorithm: checksumAlgorithm_sha1
+            checksumValue: 3ab4e1c67a2d28fced849ee1bb76e7391b93f125
+          comment: This file belongs to Jena
+          copyrightText: (c) Copyright 2000, 2001, 2002, 2003, 2004, 2005, 2006, 2007,
+            2008, 2009 Hewlett-Packard Development Company, LP
+          artifactOf:
+            - name: "Jena"
+              homePage: "http://www.openjena.org/"
+              projectUri: "http://subversion.apache.org/doap.rdf"
+          fileTypes:
+          - fileType_archive
+          SPDXID: SPDXRef-File1
+          licenseComments: This license is used by Jena
+          licenseConcluded: LicenseRef-1
+          licenseInfoFromFiles:
+          - LicenseRef-1
+          name: Jenna-2.6.3/jena-2.6.3-sources.jar
+          sha1: 3ab4e1c67a2d28fced849ee1bb76e7391b93f125
+      - File:
+          checksums:
+          - algorithm: checksumAlgorithm_sha1
+            checksumValue: 2fd4e1c67a2d28fced849ee1bb76e7391b93eb12
+          copyrightText: Copyright 2010, 2011 Source Auditor Inc.
+          fileTypes:
+          - fileType_source
+          SPDXID: SPDXRef-File2
+          licenseConcluded: Apache-2.0
+          licenseInfoFromFiles:
+          - Apache-2.0
+          name: src/org/spdx/parser/DOAPProject.java
+          sha1: 2fd4e1c67a2d28fced849ee1bb76e7391b93eb12
+      licenseComments: The declared license information can be found in the NOTICE
+        file at the root of the archive file
+      licenseConcluded: (LicenseRef-3 AND LicenseRef-1 AND MPL-1.1 AND Apache-2.0
+        AND LicenseRef-2 AND Apache-1.0 AND LicenseRef-4)
+      licenseDeclared: (MPL-1.1 AND LicenseRef-4 AND LicenseRef-2 AND LicenseRef-1
+        AND Apache-2.0 AND LicenseRef-3)
+      licenseInfoFromFiles:
+      - Apache-2.0
+      - MPL-1.1
+      - LicenseRef-3
+      - LicenseRef-1
+      - LicenseRef-4
+      - Apache-1.0
+      - LicenseRef-2
+      name: SPDX Translator
+      originator: 'Organization: SPDX'
+      packageFileName: spdxtranslator-1.0.zip
+      packageVerificationCode:
+        packageVerificationCodeExcludedFiles:
+        - SpdxTranslatorSpdx.txt
+        - SpdxTranslatorSpdx.rdf
+        packageVerificationCodeValue: 4e3211c67a2d28fced849ee1bb76e7391b93feba
+      sha1: 2fd4e1c67a2d28fced849ee1bb76e7391b93eb12
+      sourceInfo: Version 1.0 of the SPDX Translator application
+      summary: SPDX Translator utility
+      supplier: 'Organization: Linux Foundation'
+      versionInfo: Version 0.9.2
+  externalDocumentRefs:
+  - checksum:
+      algorithm: checksumAlgorithm_sha1
+      checksumValue: d6a770ba38583ed4bb4525bd96e50461655d2759
+    externalDocumentId: DocumentRef-spdx-tool-2.1
+    spdxDocument: https://spdx.org/spdxdocs/spdx-tools-v2.1-3F2504E0-4F89-41D3-9A0C-0305E82C3301
+  hasExtractedLicensingInfos:
+  - comment: This is tye CyperNeko License
+    extractedText: "The CyberNeko Software License, Version 1.0\n\n \n(C) Copyright\
+      \ 2002-2005, Andy Clark.  All rights reserved.\n \nRedistribution and use in\
+      \ source and binary forms, with or without\nmodification, are permitted provided\
+      \ that the following conditions\nare met:\n\n1. Redistributions of source code\
+      \ must retain the above copyright\n   notice, this list of conditions and the\
+      \ following disclaimer. \n\n2. Redistributions in binary form must reproduce\
+      \ the above copyright\n   notice, this list of conditions and the following\
+      \ disclaimer in\n   the documentation and/or other materials provided with the\n\
+      \   distribution.\n\n3. The end-user documentation included with the redistribution,\n\
+      \   if any, must include the following acknowledgment:  \n     \"This product\
+      \ includes software developed by Andy Clark.\"\n   Alternately, this acknowledgment\
+      \ may appear in the software itself,\n   if and wherever such third-party acknowledgments\
+      \ normally appear.\n\n4. The names \"CyberNeko\" and \"NekoHTML\" must not be\
+      \ used to endorse\n   or promote products derived from this software without\
+      \ prior \n   written permission. For written permission, please contact \n \
+      \  andyc@cyberneko.net.\n\n5. Products derived from this software may not be\
+      \ called \"CyberNeko\",\n   nor may \"CyberNeko\" appear in their name, without\
+      \ prior written\n   permission of the author.\n\nTHIS SOFTWARE IS PROVIDED ``AS\
+      \ IS'' AND ANY EXPRESSED OR IMPLIED\nWARRANTIES, INCLUDING, BUT NOT LIMITED\
+      \ TO, THE IMPLIED WARRANTIES\nOF MERCHANTABILITY AND FITNESS FOR A PARTICULAR\
+      \ PURPOSE ARE\nDISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR OTHER CONTRIBUTORS\n\
+      BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, \nOR CONSEQUENTIAL\
+      \ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT \nOF SUBSTITUTE GOODS\
+      \ OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR \nBUSINESS INTERRUPTION) HOWEVER\
+      \ CAUSED AND ON ANY THEORY OF LIABILITY, \nWHETHER IN CONTRACT, STRICT LIABILITY,\
+      \ OR TORT (INCLUDING NEGLIGENCE \nOR OTHERWISE) ARISING IN ANY WAY OUT OF THE\
+      \ USE OF THIS SOFTWARE, \nEVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE."
+    licenseId: LicenseRef-3
+    name: CyberNeko License
+    seeAlso:
+    - http://justasample.url.com
+    - http://people.apache.org/~andyc/neko/LICENSE
+  - extractedText: "/*\n * (c) Copyright 2000, 2001, 2002, 2003, 2004, 2005, 2006,\
+      \ 2007, 2008, 2009 Hewlett-Packard Development Company, LP\n * All rights reserved.\n\
+      \ *\n * Redistribution and use in source and binary forms, with or without\n\
+      \ * modification, are permitted provided that the following conditions\n * are\
+      \ met:\n * 1. Redistributions of source code must retain the above copyright\n\
+      \ *    notice, this list of conditions and the following disclaimer.\n * 2.\
+      \ Redistributions in binary form must reproduce the above copyright\n *    notice,\
+      \ this list of conditions and the following disclaimer in the\n *    documentation\
+      \ and/or other materials provided with the distribution.\n * 3. The name of\
+      \ the author may not be used to endorse or promote products\n *    derived from\
+      \ this software without specific prior written permission.\n *\n * THIS SOFTWARE\
+      \ IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR\n * IMPLIED WARRANTIES,\
+      \ INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES\n * OF MERCHANTABILITY\
+      \ AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.\n * IN NO EVENT SHALL\
+      \ THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,\n * INCIDENTAL, SPECIAL, EXEMPLARY,\
+      \ OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT\n * NOT LIMITED TO, PROCUREMENT OF\
+      \ SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,\n * DATA, OR PROFITS; OR BUSINESS\
+      \ INTERRUPTION) HOWEVER CAUSED AND ON ANY\n * THEORY OF LIABILITY, WHETHER IN\
+      \ CONTRACT, STRICT LIABILITY, OR TORT\n * (INCLUDING NEGLIGENCE OR OTHERWISE)\
+      \ ARISING IN ANY WAY OUT OF THE USE OF\n * THIS SOFTWARE, EVEN IF ADVISED OF\
+      \ THE POSSIBILITY OF SUCH DAMAGE.\n */"
+    licenseId: LicenseRef-1
+  - extractedText: "This package includes the GRDDL parser developed by Hewlett Packard\
+      \ under the following license:\n\xA9 Copyright 2007 Hewlett-Packard Development\
+      \ Company, LP\n\nRedistribution and use in source and binary forms, with or\
+      \ without modification, are permitted provided that the following conditions\
+      \ are met: \n\nRedistributions of source code must retain the above copyright\
+      \ notice, this list of conditions and the following disclaimer. \nRedistributions\
+      \ in binary form must reproduce the above copyright notice, this list of conditions\
+      \ and the following disclaimer in the documentation and/or other materials provided\
+      \ with the distribution. \nThe name of the author may not be used to endorse\
+      \ or promote products derived from this software without specific prior written\
+      \ permission. \nTHIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS\
+      \ OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES\
+      \ OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN\
+      \ NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,\
+      \ SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,\
+      \ PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;\
+      \ OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER\
+      \ IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)\
+      \ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE\
+      \ POSSIBILITY OF SUCH DAMAGE. "
+    licenseId: LicenseRef-2
+  - extractedText: "/*\n * (c) Copyright 2009 University of Bristol\n * All rights\
+      \ reserved.\n *\n * Redistribution and use in source and binary forms, with\
+      \ or without\n * modification, are permitted provided that the following conditions\n\
+      \ * are met:\n * 1. Redistributions of source code must retain the above copyright\n\
+      \ *    notice, this list of conditions and the following disclaimer.\n * 2.\
+      \ Redistributions in binary form must reproduce the above copyright\n *    notice,\
+      \ this list of conditions and the following disclaimer in the\n *    documentation\
+      \ and/or other materials provided with the distribution.\n * 3. The name of\
+      \ the author may not be used to endorse or promote products\n *    derived from\
+      \ this software without specific prior written permission.\n *\n * THIS SOFTWARE\
+      \ IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR\n * IMPLIED WARRANTIES,\
+      \ INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES\n * OF MERCHANTABILITY\
+      \ AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.\n * IN NO EVENT SHALL\
+      \ THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,\n * INCIDENTAL, SPECIAL, EXEMPLARY,\
+      \ OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT\n * NOT LIMITED TO, PROCUREMENT OF\
+      \ SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,\n * DATA, OR PROFITS; OR BUSINESS\
+      \ INTERRUPTION) HOWEVER CAUSED AND ON ANY\n * THEORY OF LIABILITY, WHETHER IN\
+      \ CONTRACT, STRICT LIABILITY, OR TORT\n * (INCLUDING NEGLIGENCE OR OTHERWISE)\
+      \ ARISING IN ANY WAY OUT OF THE USE OF\n * THIS SOFTWARE, EVEN IF ADVISED OF\
+      \ THE POSSIBILITY OF SUCH DAMAGE.\n */  "
+    licenseId: LicenseRef-4
+  SPDXID: SPDXRef-DOCUMENT
+  name: Sample_Document-V2.1
+  documentNamespace: https://spdx.org/spdxdocs/spdx-example-444504E0-4F89-41D3-9A0C-0305E82C3301
+  relationships:
+  - spdxElementId: "SPDXRef-DOCUMENT"
+    relatedSpdxElement: "SPDXRef-Package"
+    relationshipType: "DESCRIBES"
+  - spdxElementId: "SPDXRef-DOCUMENT"
+    relatedSpdxElement: "SPDXRef-Package"
+    relationshipType: "CONTAINS"
+  - spdxElementId: "SPDXRef-DOCUMENT"
+    relatedSpdxElement: "SPDXRef-File"
+    relationshipType: "DESCRIBES"
+  reviewers:
+  - comment: Another example reviewer.
+    reviewDate: '2011-03-13T00:00:00Z'
+    reviewer: 'Person: Suzanne Reviewer'
+  - comment: This is just an example.  Some of the non-standard licenses look like
+      they are actually BSD 3 clause licenses
+    reviewDate: '2010-02-10T00:00:00Z'
+    reviewer: 'Person: Joe Reviewer'
+  snippets:
+  - comment: This snippet was identified as significant and highlighted in this Apache-2.0
+      file, when a commercial scanner identified it as being derived from file foo.c
+      in package xyz which is licensed under GPL-2.0-or-later.
+    copyrightText: Copyright 2008-2010 John Smith
+    fileId: SPDXRef-DoapSource
+    SPDXID: SPDXRef-Snippet
+    licenseComments: The concluded license was taken from package xyz, from which
+      the snippet was copied into the current file. The concluded license information
+      was found in the COPYING.txt file in package xyz.
+    licenseConcluded: Apache-2.0
+    licenseInfoFromSnippet:
+    - Apache-2.0
+    name: from linux kernel
+  spdxVersion: SPDX-2.1

--- a/tests/data/parse_anything_test_files/SPDXYamlExample.yaml.json
+++ b/tests/data/parse_anything_test_files/SPDXYamlExample.yaml.json
@@ -1,0 +1,237 @@
+---
+Document:
+  annotations:
+  - annotationDate: '2012-06-13T00:00:00Z'
+    annotationType: REVIEW
+    annotator: 'Person: Jim Reviewer'
+    comment: This is just an example. Some of the non-standard licenses look like
+      they are actually BSD 3 clause licenses
+    SPDXID: SPDXRef-45
+  comment: This is a sample spreadsheet
+  creationInfo:
+    comment: This is an example of an SPDX spreadsheet format
+    created: '2010-02-03T00:00:00Z'
+    creators:
+    - 'Tool: SourceAuditor-V1.2'
+    - 'Organization: Source Auditor Inc.'
+    - 'Person: Gary O''Neall'
+    licenseListVersion: '3.6'
+  dataLicense: CC0-1.0
+  documentDescribes:
+  - Package:
+      SPDXID: SPDXRef-Package
+      checksums:
+      - algorithm: checksumAlgorithm_sha1
+        checksumValue: 2fd4e1c67a2d28fced849ee1bb76e7391b93eb12
+      copyrightText: ' Copyright 2010, 2011 Source Auditor Inc.'
+      description: This utility translates and SPDX RDF XML document to a spreadsheet,
+        translates a spreadsheet to an SPDX RDF XML document and translates an SPDX
+        RDFa document to an SPDX RDF XML document.
+      downloadLocation: http://www.spdx.org/tools
+      attributionTexts:
+      - "The GNU C Library is free software.  See the file COPYING.LIB for copying conditions,\
+        \ and LICENSES for notices about a few contributions that require these additional\
+        \ notices to be distributed.  License copyright years may be listed using range\
+        \ notation, e.g., 1996-2015, indicating that every year in the range, inclusive,\
+        \ is a copyrightable year that would otherwise be listed individually."
+      files:
+      - File:
+          checksums:
+          - algorithm: checksumAlgorithm_sha1
+            checksumValue: 3ab4e1c67a2d28fced849ee1bb76e7391b93f125
+          comment: This file belongs to Jena
+          copyrightText: (c) Copyright 2000, 2001, 2002, 2003, 2004, 2005, 2006, 2007,
+            2008, 2009 Hewlett-Packard Development Company, LP
+          artifactOf:
+            - name: "Jena"
+              homePage: "http://www.openjena.org/"
+              projectUri: "http://subversion.apache.org/doap.rdf"
+          fileTypes:
+          - fileType_archive
+          SPDXID: SPDXRef-File1
+          licenseComments: This license is used by Jena
+          licenseConcluded: LicenseRef-1
+          licenseInfoFromFiles:
+          - LicenseRef-1
+          name: Jenna-2.6.3/jena-2.6.3-sources.jar
+          sha1: 3ab4e1c67a2d28fced849ee1bb76e7391b93f125
+      - File:
+          checksums:
+          - algorithm: checksumAlgorithm_sha1
+            checksumValue: 2fd4e1c67a2d28fced849ee1bb76e7391b93eb12
+          copyrightText: Copyright 2010, 2011 Source Auditor Inc.
+          fileTypes:
+          - fileType_source
+          SPDXID: SPDXRef-File2
+          licenseConcluded: Apache-2.0
+          licenseInfoFromFiles:
+          - Apache-2.0
+          name: src/org/spdx/parser/DOAPProject.java
+          sha1: 2fd4e1c67a2d28fced849ee1bb76e7391b93eb12
+      licenseComments: The declared license information can be found in the NOTICE
+        file at the root of the archive file
+      licenseConcluded: (LicenseRef-3 AND LicenseRef-1 AND MPL-1.1 AND Apache-2.0
+        AND LicenseRef-2 AND Apache-1.0 AND LicenseRef-4)
+      licenseDeclared: (MPL-1.1 AND LicenseRef-4 AND LicenseRef-2 AND LicenseRef-1
+        AND Apache-2.0 AND LicenseRef-3)
+      licenseInfoFromFiles:
+      - Apache-2.0
+      - MPL-1.1
+      - LicenseRef-3
+      - LicenseRef-1
+      - LicenseRef-4
+      - Apache-1.0
+      - LicenseRef-2
+      name: SPDX Translator
+      originator: 'Organization: SPDX'
+      packageFileName: spdxtranslator-1.0.zip
+      packageVerificationCode:
+        packageVerificationCodeExcludedFiles:
+        - SpdxTranslatorSpdx.txt
+        - SpdxTranslatorSpdx.rdf
+        packageVerificationCodeValue: 4e3211c67a2d28fced849ee1bb76e7391b93feba
+      sha1: 2fd4e1c67a2d28fced849ee1bb76e7391b93eb12
+      sourceInfo: Version 1.0 of the SPDX Translator application
+      summary: SPDX Translator utility
+      supplier: 'Organization: Linux Foundation'
+      versionInfo: Version 0.9.2
+  externalDocumentRefs:
+  - checksum:
+      algorithm: checksumAlgorithm_sha1
+      checksumValue: d6a770ba38583ed4bb4525bd96e50461655d2759
+    externalDocumentId: DocumentRef-spdx-tool-2.1
+    spdxDocument: https://spdx.org/spdxdocs/spdx-tools-v2.1-3F2504E0-4F89-41D3-9A0C-0305E82C3301
+  hasExtractedLicensingInfos:
+  - comment: This is tye CyperNeko License
+    extractedText: "The CyberNeko Software License, Version 1.0\n\n \n(C) Copyright\
+      \ 2002-2005, Andy Clark.  All rights reserved.\n \nRedistribution and use in\
+      \ source and binary forms, with or without\nmodification, are permitted provided\
+      \ that the following conditions\nare met:\n\n1. Redistributions of source code\
+      \ must retain the above copyright\n   notice, this list of conditions and the\
+      \ following disclaimer. \n\n2. Redistributions in binary form must reproduce\
+      \ the above copyright\n   notice, this list of conditions and the following\
+      \ disclaimer in\n   the documentation and/or other materials provided with the\n\
+      \   distribution.\n\n3. The end-user documentation included with the redistribution,\n\
+      \   if any, must include the following acknowledgment:  \n     \"This product\
+      \ includes software developed by Andy Clark.\"\n   Alternately, this acknowledgment\
+      \ may appear in the software itself,\n   if and wherever such third-party acknowledgments\
+      \ normally appear.\n\n4. The names \"CyberNeko\" and \"NekoHTML\" must not be\
+      \ used to endorse\n   or promote products derived from this software without\
+      \ prior \n   written permission. For written permission, please contact \n \
+      \  andyc@cyberneko.net.\n\n5. Products derived from this software may not be\
+      \ called \"CyberNeko\",\n   nor may \"CyberNeko\" appear in their name, without\
+      \ prior written\n   permission of the author.\n\nTHIS SOFTWARE IS PROVIDED ``AS\
+      \ IS'' AND ANY EXPRESSED OR IMPLIED\nWARRANTIES, INCLUDING, BUT NOT LIMITED\
+      \ TO, THE IMPLIED WARRANTIES\nOF MERCHANTABILITY AND FITNESS FOR A PARTICULAR\
+      \ PURPOSE ARE\nDISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR OTHER CONTRIBUTORS\n\
+      BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, \nOR CONSEQUENTIAL\
+      \ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT \nOF SUBSTITUTE GOODS\
+      \ OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR \nBUSINESS INTERRUPTION) HOWEVER\
+      \ CAUSED AND ON ANY THEORY OF LIABILITY, \nWHETHER IN CONTRACT, STRICT LIABILITY,\
+      \ OR TORT (INCLUDING NEGLIGENCE \nOR OTHERWISE) ARISING IN ANY WAY OUT OF THE\
+      \ USE OF THIS SOFTWARE, \nEVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE."
+    licenseId: LicenseRef-3
+    name: CyberNeko License
+    seeAlso:
+    - http://justasample.url.com
+    - http://people.apache.org/~andyc/neko/LICENSE
+  - extractedText: "/*\n * (c) Copyright 2000, 2001, 2002, 2003, 2004, 2005, 2006,\
+      \ 2007, 2008, 2009 Hewlett-Packard Development Company, LP\n * All rights reserved.\n\
+      \ *\n * Redistribution and use in source and binary forms, with or without\n\
+      \ * modification, are permitted provided that the following conditions\n * are\
+      \ met:\n * 1. Redistributions of source code must retain the above copyright\n\
+      \ *    notice, this list of conditions and the following disclaimer.\n * 2.\
+      \ Redistributions in binary form must reproduce the above copyright\n *    notice,\
+      \ this list of conditions and the following disclaimer in the\n *    documentation\
+      \ and/or other materials provided with the distribution.\n * 3. The name of\
+      \ the author may not be used to endorse or promote products\n *    derived from\
+      \ this software without specific prior written permission.\n *\n * THIS SOFTWARE\
+      \ IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR\n * IMPLIED WARRANTIES,\
+      \ INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES\n * OF MERCHANTABILITY\
+      \ AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.\n * IN NO EVENT SHALL\
+      \ THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,\n * INCIDENTAL, SPECIAL, EXEMPLARY,\
+      \ OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT\n * NOT LIMITED TO, PROCUREMENT OF\
+      \ SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,\n * DATA, OR PROFITS; OR BUSINESS\
+      \ INTERRUPTION) HOWEVER CAUSED AND ON ANY\n * THEORY OF LIABILITY, WHETHER IN\
+      \ CONTRACT, STRICT LIABILITY, OR TORT\n * (INCLUDING NEGLIGENCE OR OTHERWISE)\
+      \ ARISING IN ANY WAY OUT OF THE USE OF\n * THIS SOFTWARE, EVEN IF ADVISED OF\
+      \ THE POSSIBILITY OF SUCH DAMAGE.\n */"
+    licenseId: LicenseRef-1
+  - extractedText: "This package includes the GRDDL parser developed by Hewlett Packard\
+      \ under the following license:\n\xA9 Copyright 2007 Hewlett-Packard Development\
+      \ Company, LP\n\nRedistribution and use in source and binary forms, with or\
+      \ without modification, are permitted provided that the following conditions\
+      \ are met: \n\nRedistributions of source code must retain the above copyright\
+      \ notice, this list of conditions and the following disclaimer. \nRedistributions\
+      \ in binary form must reproduce the above copyright notice, this list of conditions\
+      \ and the following disclaimer in the documentation and/or other materials provided\
+      \ with the distribution. \nThe name of the author may not be used to endorse\
+      \ or promote products derived from this software without specific prior written\
+      \ permission. \nTHIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS\
+      \ OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES\
+      \ OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN\
+      \ NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,\
+      \ SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,\
+      \ PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;\
+      \ OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER\
+      \ IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)\
+      \ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE\
+      \ POSSIBILITY OF SUCH DAMAGE. "
+    licenseId: LicenseRef-2
+  - extractedText: "/*\n * (c) Copyright 2009 University of Bristol\n * All rights\
+      \ reserved.\n *\n * Redistribution and use in source and binary forms, with\
+      \ or without\n * modification, are permitted provided that the following conditions\n\
+      \ * are met:\n * 1. Redistributions of source code must retain the above copyright\n\
+      \ *    notice, this list of conditions and the following disclaimer.\n * 2.\
+      \ Redistributions in binary form must reproduce the above copyright\n *    notice,\
+      \ this list of conditions and the following disclaimer in the\n *    documentation\
+      \ and/or other materials provided with the distribution.\n * 3. The name of\
+      \ the author may not be used to endorse or promote products\n *    derived from\
+      \ this software without specific prior written permission.\n *\n * THIS SOFTWARE\
+      \ IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR\n * IMPLIED WARRANTIES,\
+      \ INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES\n * OF MERCHANTABILITY\
+      \ AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.\n * IN NO EVENT SHALL\
+      \ THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,\n * INCIDENTAL, SPECIAL, EXEMPLARY,\
+      \ OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT\n * NOT LIMITED TO, PROCUREMENT OF\
+      \ SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,\n * DATA, OR PROFITS; OR BUSINESS\
+      \ INTERRUPTION) HOWEVER CAUSED AND ON ANY\n * THEORY OF LIABILITY, WHETHER IN\
+      \ CONTRACT, STRICT LIABILITY, OR TORT\n * (INCLUDING NEGLIGENCE OR OTHERWISE)\
+      \ ARISING IN ANY WAY OUT OF THE USE OF\n * THIS SOFTWARE, EVEN IF ADVISED OF\
+      \ THE POSSIBILITY OF SUCH DAMAGE.\n */  "
+    licenseId: LicenseRef-4
+  SPDXID: SPDXRef-DOCUMENT
+  name: Sample_Document-V2.1
+  documentNamespace: https://spdx.org/spdxdocs/spdx-example-444504E0-4F89-41D3-9A0C-0305E82C3301
+  relationships:
+  - spdxElementId: "SPDXRef-DOCUMENT"
+    relatedSpdxElement: "SPDXRef-Package"
+    relationshipType: "DESCRIBES"
+  - spdxElementId: "SPDXRef-DOCUMENT"
+    relatedSpdxElement: "SPDXRef-Package"
+    relationshipType: "CONTAINS"
+  - spdxElementId: "SPDXRef-DOCUMENT"
+    relatedSpdxElement: "SPDXRef-File"
+    relationshipType: "DESCRIBES"
+  reviewers:
+  - comment: Another example reviewer.
+    reviewDate: '2011-03-13T00:00:00Z'
+    reviewer: 'Person: Suzanne Reviewer'
+  - comment: This is just an example.  Some of the non-standard licenses look like
+      they are actually BSD 3 clause licenses
+    reviewDate: '2010-02-10T00:00:00Z'
+    reviewer: 'Person: Joe Reviewer'
+  snippets:
+  - comment: This snippet was identified as significant and highlighted in this Apache-2.0
+      file, when a commercial scanner identified it as being derived from file foo.c
+      in package xyz which is licensed under GPL-2.0-or-later.
+    copyrightText: Copyright 2008-2010 John Smith
+    fileId: SPDXRef-DoapSource
+    SPDXID: SPDXRef-Snippet
+    licenseComments: The concluded license was taken from package xyz, from which
+      the snippet was copied into the current file. The concluded license information
+      was found in the COPYING.txt file in package xyz.
+    licenseConcluded: Apache-2.0
+    licenseInfoFromSnippet:
+    - Apache-2.0
+    name: from linux kernel
+  spdxVersion: SPDX-2.1

--- a/tests/data/parse_anything_test_files/SPDXYamlExample.yaml.rdf
+++ b/tests/data/parse_anything_test_files/SPDXYamlExample.yaml.rdf
@@ -1,0 +1,237 @@
+---
+Document:
+  annotations:
+  - annotationDate: '2012-06-13T00:00:00Z'
+    annotationType: REVIEW
+    annotator: 'Person: Jim Reviewer'
+    comment: This is just an example. Some of the non-standard licenses look like
+      they are actually BSD 3 clause licenses
+    SPDXID: SPDXRef-45
+  comment: This is a sample spreadsheet
+  creationInfo:
+    comment: This is an example of an SPDX spreadsheet format
+    created: '2010-02-03T00:00:00Z'
+    creators:
+    - 'Tool: SourceAuditor-V1.2'
+    - 'Organization: Source Auditor Inc.'
+    - 'Person: Gary O''Neall'
+    licenseListVersion: '3.6'
+  dataLicense: CC0-1.0
+  documentDescribes:
+  - Package:
+      SPDXID: SPDXRef-Package
+      checksums:
+      - algorithm: checksumAlgorithm_sha1
+        checksumValue: 2fd4e1c67a2d28fced849ee1bb76e7391b93eb12
+      copyrightText: ' Copyright 2010, 2011 Source Auditor Inc.'
+      description: This utility translates and SPDX RDF XML document to a spreadsheet,
+        translates a spreadsheet to an SPDX RDF XML document and translates an SPDX
+        RDFa document to an SPDX RDF XML document.
+      downloadLocation: http://www.spdx.org/tools
+      attributionTexts:
+      - "The GNU C Library is free software.  See the file COPYING.LIB for copying conditions,\
+        \ and LICENSES for notices about a few contributions that require these additional\
+        \ notices to be distributed.  License copyright years may be listed using range\
+        \ notation, e.g., 1996-2015, indicating that every year in the range, inclusive,\
+        \ is a copyrightable year that would otherwise be listed individually."
+      files:
+      - File:
+          checksums:
+          - algorithm: checksumAlgorithm_sha1
+            checksumValue: 3ab4e1c67a2d28fced849ee1bb76e7391b93f125
+          comment: This file belongs to Jena
+          copyrightText: (c) Copyright 2000, 2001, 2002, 2003, 2004, 2005, 2006, 2007,
+            2008, 2009 Hewlett-Packard Development Company, LP
+          artifactOf:
+            - name: "Jena"
+              homePage: "http://www.openjena.org/"
+              projectUri: "http://subversion.apache.org/doap.rdf"
+          fileTypes:
+          - fileType_archive
+          SPDXID: SPDXRef-File1
+          licenseComments: This license is used by Jena
+          licenseConcluded: LicenseRef-1
+          licenseInfoFromFiles:
+          - LicenseRef-1
+          name: Jenna-2.6.3/jena-2.6.3-sources.jar
+          sha1: 3ab4e1c67a2d28fced849ee1bb76e7391b93f125
+      - File:
+          checksums:
+          - algorithm: checksumAlgorithm_sha1
+            checksumValue: 2fd4e1c67a2d28fced849ee1bb76e7391b93eb12
+          copyrightText: Copyright 2010, 2011 Source Auditor Inc.
+          fileTypes:
+          - fileType_source
+          SPDXID: SPDXRef-File2
+          licenseConcluded: Apache-2.0
+          licenseInfoFromFiles:
+          - Apache-2.0
+          name: src/org/spdx/parser/DOAPProject.java
+          sha1: 2fd4e1c67a2d28fced849ee1bb76e7391b93eb12
+      licenseComments: The declared license information can be found in the NOTICE
+        file at the root of the archive file
+      licenseConcluded: (LicenseRef-3 AND LicenseRef-1 AND MPL-1.1 AND Apache-2.0
+        AND LicenseRef-2 AND Apache-1.0 AND LicenseRef-4)
+      licenseDeclared: (MPL-1.1 AND LicenseRef-4 AND LicenseRef-2 AND LicenseRef-1
+        AND Apache-2.0 AND LicenseRef-3)
+      licenseInfoFromFiles:
+      - Apache-2.0
+      - MPL-1.1
+      - LicenseRef-3
+      - LicenseRef-1
+      - LicenseRef-4
+      - Apache-1.0
+      - LicenseRef-2
+      name: SPDX Translator
+      originator: 'Organization: SPDX'
+      packageFileName: spdxtranslator-1.0.zip
+      packageVerificationCode:
+        packageVerificationCodeExcludedFiles:
+        - SpdxTranslatorSpdx.txt
+        - SpdxTranslatorSpdx.rdf
+        packageVerificationCodeValue: 4e3211c67a2d28fced849ee1bb76e7391b93feba
+      sha1: 2fd4e1c67a2d28fced849ee1bb76e7391b93eb12
+      sourceInfo: Version 1.0 of the SPDX Translator application
+      summary: SPDX Translator utility
+      supplier: 'Organization: Linux Foundation'
+      versionInfo: Version 0.9.2
+  externalDocumentRefs:
+  - checksum:
+      algorithm: checksumAlgorithm_sha1
+      checksumValue: d6a770ba38583ed4bb4525bd96e50461655d2759
+    externalDocumentId: DocumentRef-spdx-tool-2.1
+    spdxDocument: https://spdx.org/spdxdocs/spdx-tools-v2.1-3F2504E0-4F89-41D3-9A0C-0305E82C3301
+  hasExtractedLicensingInfos:
+  - comment: This is tye CyperNeko License
+    extractedText: "The CyberNeko Software License, Version 1.0\n\n \n(C) Copyright\
+      \ 2002-2005, Andy Clark.  All rights reserved.\n \nRedistribution and use in\
+      \ source and binary forms, with or without\nmodification, are permitted provided\
+      \ that the following conditions\nare met:\n\n1. Redistributions of source code\
+      \ must retain the above copyright\n   notice, this list of conditions and the\
+      \ following disclaimer. \n\n2. Redistributions in binary form must reproduce\
+      \ the above copyright\n   notice, this list of conditions and the following\
+      \ disclaimer in\n   the documentation and/or other materials provided with the\n\
+      \   distribution.\n\n3. The end-user documentation included with the redistribution,\n\
+      \   if any, must include the following acknowledgment:  \n     \"This product\
+      \ includes software developed by Andy Clark.\"\n   Alternately, this acknowledgment\
+      \ may appear in the software itself,\n   if and wherever such third-party acknowledgments\
+      \ normally appear.\n\n4. The names \"CyberNeko\" and \"NekoHTML\" must not be\
+      \ used to endorse\n   or promote products derived from this software without\
+      \ prior \n   written permission. For written permission, please contact \n \
+      \  andyc@cyberneko.net.\n\n5. Products derived from this software may not be\
+      \ called \"CyberNeko\",\n   nor may \"CyberNeko\" appear in their name, without\
+      \ prior written\n   permission of the author.\n\nTHIS SOFTWARE IS PROVIDED ``AS\
+      \ IS'' AND ANY EXPRESSED OR IMPLIED\nWARRANTIES, INCLUDING, BUT NOT LIMITED\
+      \ TO, THE IMPLIED WARRANTIES\nOF MERCHANTABILITY AND FITNESS FOR A PARTICULAR\
+      \ PURPOSE ARE\nDISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR OTHER CONTRIBUTORS\n\
+      BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, \nOR CONSEQUENTIAL\
+      \ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT \nOF SUBSTITUTE GOODS\
+      \ OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR \nBUSINESS INTERRUPTION) HOWEVER\
+      \ CAUSED AND ON ANY THEORY OF LIABILITY, \nWHETHER IN CONTRACT, STRICT LIABILITY,\
+      \ OR TORT (INCLUDING NEGLIGENCE \nOR OTHERWISE) ARISING IN ANY WAY OUT OF THE\
+      \ USE OF THIS SOFTWARE, \nEVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE."
+    licenseId: LicenseRef-3
+    name: CyberNeko License
+    seeAlso:
+    - http://justasample.url.com
+    - http://people.apache.org/~andyc/neko/LICENSE
+  - extractedText: "/*\n * (c) Copyright 2000, 2001, 2002, 2003, 2004, 2005, 2006,\
+      \ 2007, 2008, 2009 Hewlett-Packard Development Company, LP\n * All rights reserved.\n\
+      \ *\n * Redistribution and use in source and binary forms, with or without\n\
+      \ * modification, are permitted provided that the following conditions\n * are\
+      \ met:\n * 1. Redistributions of source code must retain the above copyright\n\
+      \ *    notice, this list of conditions and the following disclaimer.\n * 2.\
+      \ Redistributions in binary form must reproduce the above copyright\n *    notice,\
+      \ this list of conditions and the following disclaimer in the\n *    documentation\
+      \ and/or other materials provided with the distribution.\n * 3. The name of\
+      \ the author may not be used to endorse or promote products\n *    derived from\
+      \ this software without specific prior written permission.\n *\n * THIS SOFTWARE\
+      \ IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR\n * IMPLIED WARRANTIES,\
+      \ INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES\n * OF MERCHANTABILITY\
+      \ AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.\n * IN NO EVENT SHALL\
+      \ THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,\n * INCIDENTAL, SPECIAL, EXEMPLARY,\
+      \ OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT\n * NOT LIMITED TO, PROCUREMENT OF\
+      \ SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,\n * DATA, OR PROFITS; OR BUSINESS\
+      \ INTERRUPTION) HOWEVER CAUSED AND ON ANY\n * THEORY OF LIABILITY, WHETHER IN\
+      \ CONTRACT, STRICT LIABILITY, OR TORT\n * (INCLUDING NEGLIGENCE OR OTHERWISE)\
+      \ ARISING IN ANY WAY OUT OF THE USE OF\n * THIS SOFTWARE, EVEN IF ADVISED OF\
+      \ THE POSSIBILITY OF SUCH DAMAGE.\n */"
+    licenseId: LicenseRef-1
+  - extractedText: "This package includes the GRDDL parser developed by Hewlett Packard\
+      \ under the following license:\n\xA9 Copyright 2007 Hewlett-Packard Development\
+      \ Company, LP\n\nRedistribution and use in source and binary forms, with or\
+      \ without modification, are permitted provided that the following conditions\
+      \ are met: \n\nRedistributions of source code must retain the above copyright\
+      \ notice, this list of conditions and the following disclaimer. \nRedistributions\
+      \ in binary form must reproduce the above copyright notice, this list of conditions\
+      \ and the following disclaimer in the documentation and/or other materials provided\
+      \ with the distribution. \nThe name of the author may not be used to endorse\
+      \ or promote products derived from this software without specific prior written\
+      \ permission. \nTHIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS\
+      \ OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES\
+      \ OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN\
+      \ NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,\
+      \ SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,\
+      \ PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;\
+      \ OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER\
+      \ IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)\
+      \ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE\
+      \ POSSIBILITY OF SUCH DAMAGE. "
+    licenseId: LicenseRef-2
+  - extractedText: "/*\n * (c) Copyright 2009 University of Bristol\n * All rights\
+      \ reserved.\n *\n * Redistribution and use in source and binary forms, with\
+      \ or without\n * modification, are permitted provided that the following conditions\n\
+      \ * are met:\n * 1. Redistributions of source code must retain the above copyright\n\
+      \ *    notice, this list of conditions and the following disclaimer.\n * 2.\
+      \ Redistributions in binary form must reproduce the above copyright\n *    notice,\
+      \ this list of conditions and the following disclaimer in the\n *    documentation\
+      \ and/or other materials provided with the distribution.\n * 3. The name of\
+      \ the author may not be used to endorse or promote products\n *    derived from\
+      \ this software without specific prior written permission.\n *\n * THIS SOFTWARE\
+      \ IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR\n * IMPLIED WARRANTIES,\
+      \ INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES\n * OF MERCHANTABILITY\
+      \ AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.\n * IN NO EVENT SHALL\
+      \ THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,\n * INCIDENTAL, SPECIAL, EXEMPLARY,\
+      \ OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT\n * NOT LIMITED TO, PROCUREMENT OF\
+      \ SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,\n * DATA, OR PROFITS; OR BUSINESS\
+      \ INTERRUPTION) HOWEVER CAUSED AND ON ANY\n * THEORY OF LIABILITY, WHETHER IN\
+      \ CONTRACT, STRICT LIABILITY, OR TORT\n * (INCLUDING NEGLIGENCE OR OTHERWISE)\
+      \ ARISING IN ANY WAY OUT OF THE USE OF\n * THIS SOFTWARE, EVEN IF ADVISED OF\
+      \ THE POSSIBILITY OF SUCH DAMAGE.\n */  "
+    licenseId: LicenseRef-4
+  SPDXID: SPDXRef-DOCUMENT
+  name: Sample_Document-V2.1
+  documentNamespace: https://spdx.org/spdxdocs/spdx-example-444504E0-4F89-41D3-9A0C-0305E82C3301
+  relationships:
+  - spdxElementId: "SPDXRef-DOCUMENT"
+    relatedSpdxElement: "SPDXRef-Package"
+    relationshipType: "DESCRIBES"
+  - spdxElementId: "SPDXRef-DOCUMENT"
+    relatedSpdxElement: "SPDXRef-Package"
+    relationshipType: "CONTAINS"
+  - spdxElementId: "SPDXRef-DOCUMENT"
+    relatedSpdxElement: "SPDXRef-File"
+    relationshipType: "DESCRIBES"
+  reviewers:
+  - comment: Another example reviewer.
+    reviewDate: '2011-03-13T00:00:00Z'
+    reviewer: 'Person: Suzanne Reviewer'
+  - comment: This is just an example.  Some of the non-standard licenses look like
+      they are actually BSD 3 clause licenses
+    reviewDate: '2010-02-10T00:00:00Z'
+    reviewer: 'Person: Joe Reviewer'
+  snippets:
+  - comment: This snippet was identified as significant and highlighted in this Apache-2.0
+      file, when a commercial scanner identified it as being derived from file foo.c
+      in package xyz which is licensed under GPL-2.0-or-later.
+    copyrightText: Copyright 2008-2010 John Smith
+    fileId: SPDXRef-DoapSource
+    SPDXID: SPDXRef-Snippet
+    licenseComments: The concluded license was taken from package xyz, from which
+      the snippet was copied into the current file. The concluded license information
+      was found in the COPYING.txt file in package xyz.
+    licenseConcluded: Apache-2.0
+    licenseInfoFromSnippet:
+    - Apache-2.0
+    name: from linux kernel
+  spdxVersion: SPDX-2.1

--- a/tests/data/parse_anything_test_files/SPDXYamlExample.yaml.spdx
+++ b/tests/data/parse_anything_test_files/SPDXYamlExample.yaml.spdx
@@ -1,0 +1,237 @@
+---
+Document:
+  annotations:
+  - annotationDate: '2012-06-13T00:00:00Z'
+    annotationType: REVIEW
+    annotator: 'Person: Jim Reviewer'
+    comment: This is just an example. Some of the non-standard licenses look like
+      they are actually BSD 3 clause licenses
+    SPDXID: SPDXRef-45
+  comment: This is a sample spreadsheet
+  creationInfo:
+    comment: This is an example of an SPDX spreadsheet format
+    created: '2010-02-03T00:00:00Z'
+    creators:
+    - 'Tool: SourceAuditor-V1.2'
+    - 'Organization: Source Auditor Inc.'
+    - 'Person: Gary O''Neall'
+    licenseListVersion: '3.6'
+  dataLicense: CC0-1.0
+  documentDescribes:
+  - Package:
+      SPDXID: SPDXRef-Package
+      checksums:
+      - algorithm: checksumAlgorithm_sha1
+        checksumValue: 2fd4e1c67a2d28fced849ee1bb76e7391b93eb12
+      copyrightText: ' Copyright 2010, 2011 Source Auditor Inc.'
+      description: This utility translates and SPDX RDF XML document to a spreadsheet,
+        translates a spreadsheet to an SPDX RDF XML document and translates an SPDX
+        RDFa document to an SPDX RDF XML document.
+      downloadLocation: http://www.spdx.org/tools
+      attributionTexts:
+      - "The GNU C Library is free software.  See the file COPYING.LIB for copying conditions,\
+        \ and LICENSES for notices about a few contributions that require these additional\
+        \ notices to be distributed.  License copyright years may be listed using range\
+        \ notation, e.g., 1996-2015, indicating that every year in the range, inclusive,\
+        \ is a copyrightable year that would otherwise be listed individually."
+      files:
+      - File:
+          checksums:
+          - algorithm: checksumAlgorithm_sha1
+            checksumValue: 3ab4e1c67a2d28fced849ee1bb76e7391b93f125
+          comment: This file belongs to Jena
+          copyrightText: (c) Copyright 2000, 2001, 2002, 2003, 2004, 2005, 2006, 2007,
+            2008, 2009 Hewlett-Packard Development Company, LP
+          artifactOf:
+            - name: "Jena"
+              homePage: "http://www.openjena.org/"
+              projectUri: "http://subversion.apache.org/doap.rdf"
+          fileTypes:
+          - fileType_archive
+          SPDXID: SPDXRef-File1
+          licenseComments: This license is used by Jena
+          licenseConcluded: LicenseRef-1
+          licenseInfoFromFiles:
+          - LicenseRef-1
+          name: Jenna-2.6.3/jena-2.6.3-sources.jar
+          sha1: 3ab4e1c67a2d28fced849ee1bb76e7391b93f125
+      - File:
+          checksums:
+          - algorithm: checksumAlgorithm_sha1
+            checksumValue: 2fd4e1c67a2d28fced849ee1bb76e7391b93eb12
+          copyrightText: Copyright 2010, 2011 Source Auditor Inc.
+          fileTypes:
+          - fileType_source
+          SPDXID: SPDXRef-File2
+          licenseConcluded: Apache-2.0
+          licenseInfoFromFiles:
+          - Apache-2.0
+          name: src/org/spdx/parser/DOAPProject.java
+          sha1: 2fd4e1c67a2d28fced849ee1bb76e7391b93eb12
+      licenseComments: The declared license information can be found in the NOTICE
+        file at the root of the archive file
+      licenseConcluded: (LicenseRef-3 AND LicenseRef-1 AND MPL-1.1 AND Apache-2.0
+        AND LicenseRef-2 AND Apache-1.0 AND LicenseRef-4)
+      licenseDeclared: (MPL-1.1 AND LicenseRef-4 AND LicenseRef-2 AND LicenseRef-1
+        AND Apache-2.0 AND LicenseRef-3)
+      licenseInfoFromFiles:
+      - Apache-2.0
+      - MPL-1.1
+      - LicenseRef-3
+      - LicenseRef-1
+      - LicenseRef-4
+      - Apache-1.0
+      - LicenseRef-2
+      name: SPDX Translator
+      originator: 'Organization: SPDX'
+      packageFileName: spdxtranslator-1.0.zip
+      packageVerificationCode:
+        packageVerificationCodeExcludedFiles:
+        - SpdxTranslatorSpdx.txt
+        - SpdxTranslatorSpdx.rdf
+        packageVerificationCodeValue: 4e3211c67a2d28fced849ee1bb76e7391b93feba
+      sha1: 2fd4e1c67a2d28fced849ee1bb76e7391b93eb12
+      sourceInfo: Version 1.0 of the SPDX Translator application
+      summary: SPDX Translator utility
+      supplier: 'Organization: Linux Foundation'
+      versionInfo: Version 0.9.2
+  externalDocumentRefs:
+  - checksum:
+      algorithm: checksumAlgorithm_sha1
+      checksumValue: d6a770ba38583ed4bb4525bd96e50461655d2759
+    externalDocumentId: DocumentRef-spdx-tool-2.1
+    spdxDocument: https://spdx.org/spdxdocs/spdx-tools-v2.1-3F2504E0-4F89-41D3-9A0C-0305E82C3301
+  hasExtractedLicensingInfos:
+  - comment: This is tye CyperNeko License
+    extractedText: "The CyberNeko Software License, Version 1.0\n\n \n(C) Copyright\
+      \ 2002-2005, Andy Clark.  All rights reserved.\n \nRedistribution and use in\
+      \ source and binary forms, with or without\nmodification, are permitted provided\
+      \ that the following conditions\nare met:\n\n1. Redistributions of source code\
+      \ must retain the above copyright\n   notice, this list of conditions and the\
+      \ following disclaimer. \n\n2. Redistributions in binary form must reproduce\
+      \ the above copyright\n   notice, this list of conditions and the following\
+      \ disclaimer in\n   the documentation and/or other materials provided with the\n\
+      \   distribution.\n\n3. The end-user documentation included with the redistribution,\n\
+      \   if any, must include the following acknowledgment:  \n     \"This product\
+      \ includes software developed by Andy Clark.\"\n   Alternately, this acknowledgment\
+      \ may appear in the software itself,\n   if and wherever such third-party acknowledgments\
+      \ normally appear.\n\n4. The names \"CyberNeko\" and \"NekoHTML\" must not be\
+      \ used to endorse\n   or promote products derived from this software without\
+      \ prior \n   written permission. For written permission, please contact \n \
+      \  andyc@cyberneko.net.\n\n5. Products derived from this software may not be\
+      \ called \"CyberNeko\",\n   nor may \"CyberNeko\" appear in their name, without\
+      \ prior written\n   permission of the author.\n\nTHIS SOFTWARE IS PROVIDED ``AS\
+      \ IS'' AND ANY EXPRESSED OR IMPLIED\nWARRANTIES, INCLUDING, BUT NOT LIMITED\
+      \ TO, THE IMPLIED WARRANTIES\nOF MERCHANTABILITY AND FITNESS FOR A PARTICULAR\
+      \ PURPOSE ARE\nDISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR OTHER CONTRIBUTORS\n\
+      BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, \nOR CONSEQUENTIAL\
+      \ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT \nOF SUBSTITUTE GOODS\
+      \ OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR \nBUSINESS INTERRUPTION) HOWEVER\
+      \ CAUSED AND ON ANY THEORY OF LIABILITY, \nWHETHER IN CONTRACT, STRICT LIABILITY,\
+      \ OR TORT (INCLUDING NEGLIGENCE \nOR OTHERWISE) ARISING IN ANY WAY OUT OF THE\
+      \ USE OF THIS SOFTWARE, \nEVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE."
+    licenseId: LicenseRef-3
+    name: CyberNeko License
+    seeAlso:
+    - http://justasample.url.com
+    - http://people.apache.org/~andyc/neko/LICENSE
+  - extractedText: "/*\n * (c) Copyright 2000, 2001, 2002, 2003, 2004, 2005, 2006,\
+      \ 2007, 2008, 2009 Hewlett-Packard Development Company, LP\n * All rights reserved.\n\
+      \ *\n * Redistribution and use in source and binary forms, with or without\n\
+      \ * modification, are permitted provided that the following conditions\n * are\
+      \ met:\n * 1. Redistributions of source code must retain the above copyright\n\
+      \ *    notice, this list of conditions and the following disclaimer.\n * 2.\
+      \ Redistributions in binary form must reproduce the above copyright\n *    notice,\
+      \ this list of conditions and the following disclaimer in the\n *    documentation\
+      \ and/or other materials provided with the distribution.\n * 3. The name of\
+      \ the author may not be used to endorse or promote products\n *    derived from\
+      \ this software without specific prior written permission.\n *\n * THIS SOFTWARE\
+      \ IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR\n * IMPLIED WARRANTIES,\
+      \ INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES\n * OF MERCHANTABILITY\
+      \ AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.\n * IN NO EVENT SHALL\
+      \ THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,\n * INCIDENTAL, SPECIAL, EXEMPLARY,\
+      \ OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT\n * NOT LIMITED TO, PROCUREMENT OF\
+      \ SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,\n * DATA, OR PROFITS; OR BUSINESS\
+      \ INTERRUPTION) HOWEVER CAUSED AND ON ANY\n * THEORY OF LIABILITY, WHETHER IN\
+      \ CONTRACT, STRICT LIABILITY, OR TORT\n * (INCLUDING NEGLIGENCE OR OTHERWISE)\
+      \ ARISING IN ANY WAY OUT OF THE USE OF\n * THIS SOFTWARE, EVEN IF ADVISED OF\
+      \ THE POSSIBILITY OF SUCH DAMAGE.\n */"
+    licenseId: LicenseRef-1
+  - extractedText: "This package includes the GRDDL parser developed by Hewlett Packard\
+      \ under the following license:\n\xA9 Copyright 2007 Hewlett-Packard Development\
+      \ Company, LP\n\nRedistribution and use in source and binary forms, with or\
+      \ without modification, are permitted provided that the following conditions\
+      \ are met: \n\nRedistributions of source code must retain the above copyright\
+      \ notice, this list of conditions and the following disclaimer. \nRedistributions\
+      \ in binary form must reproduce the above copyright notice, this list of conditions\
+      \ and the following disclaimer in the documentation and/or other materials provided\
+      \ with the distribution. \nThe name of the author may not be used to endorse\
+      \ or promote products derived from this software without specific prior written\
+      \ permission. \nTHIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS\
+      \ OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES\
+      \ OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN\
+      \ NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,\
+      \ SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,\
+      \ PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;\
+      \ OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER\
+      \ IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)\
+      \ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE\
+      \ POSSIBILITY OF SUCH DAMAGE. "
+    licenseId: LicenseRef-2
+  - extractedText: "/*\n * (c) Copyright 2009 University of Bristol\n * All rights\
+      \ reserved.\n *\n * Redistribution and use in source and binary forms, with\
+      \ or without\n * modification, are permitted provided that the following conditions\n\
+      \ * are met:\n * 1. Redistributions of source code must retain the above copyright\n\
+      \ *    notice, this list of conditions and the following disclaimer.\n * 2.\
+      \ Redistributions in binary form must reproduce the above copyright\n *    notice,\
+      \ this list of conditions and the following disclaimer in the\n *    documentation\
+      \ and/or other materials provided with the distribution.\n * 3. The name of\
+      \ the author may not be used to endorse or promote products\n *    derived from\
+      \ this software without specific prior written permission.\n *\n * THIS SOFTWARE\
+      \ IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR\n * IMPLIED WARRANTIES,\
+      \ INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES\n * OF MERCHANTABILITY\
+      \ AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.\n * IN NO EVENT SHALL\
+      \ THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,\n * INCIDENTAL, SPECIAL, EXEMPLARY,\
+      \ OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT\n * NOT LIMITED TO, PROCUREMENT OF\
+      \ SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,\n * DATA, OR PROFITS; OR BUSINESS\
+      \ INTERRUPTION) HOWEVER CAUSED AND ON ANY\n * THEORY OF LIABILITY, WHETHER IN\
+      \ CONTRACT, STRICT LIABILITY, OR TORT\n * (INCLUDING NEGLIGENCE OR OTHERWISE)\
+      \ ARISING IN ANY WAY OUT OF THE USE OF\n * THIS SOFTWARE, EVEN IF ADVISED OF\
+      \ THE POSSIBILITY OF SUCH DAMAGE.\n */  "
+    licenseId: LicenseRef-4
+  SPDXID: SPDXRef-DOCUMENT
+  name: Sample_Document-V2.1
+  documentNamespace: https://spdx.org/spdxdocs/spdx-example-444504E0-4F89-41D3-9A0C-0305E82C3301
+  relationships:
+  - spdxElementId: "SPDXRef-DOCUMENT"
+    relatedSpdxElement: "SPDXRef-Package"
+    relationshipType: "DESCRIBES"
+  - spdxElementId: "SPDXRef-DOCUMENT"
+    relatedSpdxElement: "SPDXRef-Package"
+    relationshipType: "CONTAINS"
+  - spdxElementId: "SPDXRef-DOCUMENT"
+    relatedSpdxElement: "SPDXRef-File"
+    relationshipType: "DESCRIBES"
+  reviewers:
+  - comment: Another example reviewer.
+    reviewDate: '2011-03-13T00:00:00Z'
+    reviewer: 'Person: Suzanne Reviewer'
+  - comment: This is just an example.  Some of the non-standard licenses look like
+      they are actually BSD 3 clause licenses
+    reviewDate: '2010-02-10T00:00:00Z'
+    reviewer: 'Person: Joe Reviewer'
+  snippets:
+  - comment: This snippet was identified as significant and highlighted in this Apache-2.0
+      file, when a commercial scanner identified it as being derived from file foo.c
+      in package xyz which is licensed under GPL-2.0-or-later.
+    copyrightText: Copyright 2008-2010 John Smith
+    fileId: SPDXRef-DoapSource
+    SPDXID: SPDXRef-Snippet
+    licenseComments: The concluded license was taken from package xyz, from which
+      the snippet was copied into the current file. The concluded license information
+      was found in the COPYING.txt file in package xyz.
+    licenseConcluded: Apache-2.0
+    licenseInfoFromSnippet:
+    - Apache-2.0
+    name: from linux kernel
+  spdxVersion: SPDX-2.1

--- a/tests/data/parse_anything_test_files/SPDXYamlExample.yaml.tag
+++ b/tests/data/parse_anything_test_files/SPDXYamlExample.yaml.tag
@@ -1,0 +1,237 @@
+---
+Document:
+  annotations:
+  - annotationDate: '2012-06-13T00:00:00Z'
+    annotationType: REVIEW
+    annotator: 'Person: Jim Reviewer'
+    comment: This is just an example. Some of the non-standard licenses look like
+      they are actually BSD 3 clause licenses
+    SPDXID: SPDXRef-45
+  comment: This is a sample spreadsheet
+  creationInfo:
+    comment: This is an example of an SPDX spreadsheet format
+    created: '2010-02-03T00:00:00Z'
+    creators:
+    - 'Tool: SourceAuditor-V1.2'
+    - 'Organization: Source Auditor Inc.'
+    - 'Person: Gary O''Neall'
+    licenseListVersion: '3.6'
+  dataLicense: CC0-1.0
+  documentDescribes:
+  - Package:
+      SPDXID: SPDXRef-Package
+      checksums:
+      - algorithm: checksumAlgorithm_sha1
+        checksumValue: 2fd4e1c67a2d28fced849ee1bb76e7391b93eb12
+      copyrightText: ' Copyright 2010, 2011 Source Auditor Inc.'
+      description: This utility translates and SPDX RDF XML document to a spreadsheet,
+        translates a spreadsheet to an SPDX RDF XML document and translates an SPDX
+        RDFa document to an SPDX RDF XML document.
+      downloadLocation: http://www.spdx.org/tools
+      attributionTexts:
+      - "The GNU C Library is free software.  See the file COPYING.LIB for copying conditions,\
+        \ and LICENSES for notices about a few contributions that require these additional\
+        \ notices to be distributed.  License copyright years may be listed using range\
+        \ notation, e.g., 1996-2015, indicating that every year in the range, inclusive,\
+        \ is a copyrightable year that would otherwise be listed individually."
+      files:
+      - File:
+          checksums:
+          - algorithm: checksumAlgorithm_sha1
+            checksumValue: 3ab4e1c67a2d28fced849ee1bb76e7391b93f125
+          comment: This file belongs to Jena
+          copyrightText: (c) Copyright 2000, 2001, 2002, 2003, 2004, 2005, 2006, 2007,
+            2008, 2009 Hewlett-Packard Development Company, LP
+          artifactOf:
+            - name: "Jena"
+              homePage: "http://www.openjena.org/"
+              projectUri: "http://subversion.apache.org/doap.rdf"
+          fileTypes:
+          - fileType_archive
+          SPDXID: SPDXRef-File1
+          licenseComments: This license is used by Jena
+          licenseConcluded: LicenseRef-1
+          licenseInfoFromFiles:
+          - LicenseRef-1
+          name: Jenna-2.6.3/jena-2.6.3-sources.jar
+          sha1: 3ab4e1c67a2d28fced849ee1bb76e7391b93f125
+      - File:
+          checksums:
+          - algorithm: checksumAlgorithm_sha1
+            checksumValue: 2fd4e1c67a2d28fced849ee1bb76e7391b93eb12
+          copyrightText: Copyright 2010, 2011 Source Auditor Inc.
+          fileTypes:
+          - fileType_source
+          SPDXID: SPDXRef-File2
+          licenseConcluded: Apache-2.0
+          licenseInfoFromFiles:
+          - Apache-2.0
+          name: src/org/spdx/parser/DOAPProject.java
+          sha1: 2fd4e1c67a2d28fced849ee1bb76e7391b93eb12
+      licenseComments: The declared license information can be found in the NOTICE
+        file at the root of the archive file
+      licenseConcluded: (LicenseRef-3 AND LicenseRef-1 AND MPL-1.1 AND Apache-2.0
+        AND LicenseRef-2 AND Apache-1.0 AND LicenseRef-4)
+      licenseDeclared: (MPL-1.1 AND LicenseRef-4 AND LicenseRef-2 AND LicenseRef-1
+        AND Apache-2.0 AND LicenseRef-3)
+      licenseInfoFromFiles:
+      - Apache-2.0
+      - MPL-1.1
+      - LicenseRef-3
+      - LicenseRef-1
+      - LicenseRef-4
+      - Apache-1.0
+      - LicenseRef-2
+      name: SPDX Translator
+      originator: 'Organization: SPDX'
+      packageFileName: spdxtranslator-1.0.zip
+      packageVerificationCode:
+        packageVerificationCodeExcludedFiles:
+        - SpdxTranslatorSpdx.txt
+        - SpdxTranslatorSpdx.rdf
+        packageVerificationCodeValue: 4e3211c67a2d28fced849ee1bb76e7391b93feba
+      sha1: 2fd4e1c67a2d28fced849ee1bb76e7391b93eb12
+      sourceInfo: Version 1.0 of the SPDX Translator application
+      summary: SPDX Translator utility
+      supplier: 'Organization: Linux Foundation'
+      versionInfo: Version 0.9.2
+  externalDocumentRefs:
+  - checksum:
+      algorithm: checksumAlgorithm_sha1
+      checksumValue: d6a770ba38583ed4bb4525bd96e50461655d2759
+    externalDocumentId: DocumentRef-spdx-tool-2.1
+    spdxDocument: https://spdx.org/spdxdocs/spdx-tools-v2.1-3F2504E0-4F89-41D3-9A0C-0305E82C3301
+  hasExtractedLicensingInfos:
+  - comment: This is tye CyperNeko License
+    extractedText: "The CyberNeko Software License, Version 1.0\n\n \n(C) Copyright\
+      \ 2002-2005, Andy Clark.  All rights reserved.\n \nRedistribution and use in\
+      \ source and binary forms, with or without\nmodification, are permitted provided\
+      \ that the following conditions\nare met:\n\n1. Redistributions of source code\
+      \ must retain the above copyright\n   notice, this list of conditions and the\
+      \ following disclaimer. \n\n2. Redistributions in binary form must reproduce\
+      \ the above copyright\n   notice, this list of conditions and the following\
+      \ disclaimer in\n   the documentation and/or other materials provided with the\n\
+      \   distribution.\n\n3. The end-user documentation included with the redistribution,\n\
+      \   if any, must include the following acknowledgment:  \n     \"This product\
+      \ includes software developed by Andy Clark.\"\n   Alternately, this acknowledgment\
+      \ may appear in the software itself,\n   if and wherever such third-party acknowledgments\
+      \ normally appear.\n\n4. The names \"CyberNeko\" and \"NekoHTML\" must not be\
+      \ used to endorse\n   or promote products derived from this software without\
+      \ prior \n   written permission. For written permission, please contact \n \
+      \  andyc@cyberneko.net.\n\n5. Products derived from this software may not be\
+      \ called \"CyberNeko\",\n   nor may \"CyberNeko\" appear in their name, without\
+      \ prior written\n   permission of the author.\n\nTHIS SOFTWARE IS PROVIDED ``AS\
+      \ IS'' AND ANY EXPRESSED OR IMPLIED\nWARRANTIES, INCLUDING, BUT NOT LIMITED\
+      \ TO, THE IMPLIED WARRANTIES\nOF MERCHANTABILITY AND FITNESS FOR A PARTICULAR\
+      \ PURPOSE ARE\nDISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR OTHER CONTRIBUTORS\n\
+      BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, \nOR CONSEQUENTIAL\
+      \ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT \nOF SUBSTITUTE GOODS\
+      \ OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR \nBUSINESS INTERRUPTION) HOWEVER\
+      \ CAUSED AND ON ANY THEORY OF LIABILITY, \nWHETHER IN CONTRACT, STRICT LIABILITY,\
+      \ OR TORT (INCLUDING NEGLIGENCE \nOR OTHERWISE) ARISING IN ANY WAY OUT OF THE\
+      \ USE OF THIS SOFTWARE, \nEVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE."
+    licenseId: LicenseRef-3
+    name: CyberNeko License
+    seeAlso:
+    - http://justasample.url.com
+    - http://people.apache.org/~andyc/neko/LICENSE
+  - extractedText: "/*\n * (c) Copyright 2000, 2001, 2002, 2003, 2004, 2005, 2006,\
+      \ 2007, 2008, 2009 Hewlett-Packard Development Company, LP\n * All rights reserved.\n\
+      \ *\n * Redistribution and use in source and binary forms, with or without\n\
+      \ * modification, are permitted provided that the following conditions\n * are\
+      \ met:\n * 1. Redistributions of source code must retain the above copyright\n\
+      \ *    notice, this list of conditions and the following disclaimer.\n * 2.\
+      \ Redistributions in binary form must reproduce the above copyright\n *    notice,\
+      \ this list of conditions and the following disclaimer in the\n *    documentation\
+      \ and/or other materials provided with the distribution.\n * 3. The name of\
+      \ the author may not be used to endorse or promote products\n *    derived from\
+      \ this software without specific prior written permission.\n *\n * THIS SOFTWARE\
+      \ IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR\n * IMPLIED WARRANTIES,\
+      \ INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES\n * OF MERCHANTABILITY\
+      \ AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.\n * IN NO EVENT SHALL\
+      \ THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,\n * INCIDENTAL, SPECIAL, EXEMPLARY,\
+      \ OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT\n * NOT LIMITED TO, PROCUREMENT OF\
+      \ SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,\n * DATA, OR PROFITS; OR BUSINESS\
+      \ INTERRUPTION) HOWEVER CAUSED AND ON ANY\n * THEORY OF LIABILITY, WHETHER IN\
+      \ CONTRACT, STRICT LIABILITY, OR TORT\n * (INCLUDING NEGLIGENCE OR OTHERWISE)\
+      \ ARISING IN ANY WAY OUT OF THE USE OF\n * THIS SOFTWARE, EVEN IF ADVISED OF\
+      \ THE POSSIBILITY OF SUCH DAMAGE.\n */"
+    licenseId: LicenseRef-1
+  - extractedText: "This package includes the GRDDL parser developed by Hewlett Packard\
+      \ under the following license:\n\xA9 Copyright 2007 Hewlett-Packard Development\
+      \ Company, LP\n\nRedistribution and use in source and binary forms, with or\
+      \ without modification, are permitted provided that the following conditions\
+      \ are met: \n\nRedistributions of source code must retain the above copyright\
+      \ notice, this list of conditions and the following disclaimer. \nRedistributions\
+      \ in binary form must reproduce the above copyright notice, this list of conditions\
+      \ and the following disclaimer in the documentation and/or other materials provided\
+      \ with the distribution. \nThe name of the author may not be used to endorse\
+      \ or promote products derived from this software without specific prior written\
+      \ permission. \nTHIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS\
+      \ OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES\
+      \ OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN\
+      \ NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,\
+      \ SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,\
+      \ PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;\
+      \ OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER\
+      \ IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)\
+      \ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE\
+      \ POSSIBILITY OF SUCH DAMAGE. "
+    licenseId: LicenseRef-2
+  - extractedText: "/*\n * (c) Copyright 2009 University of Bristol\n * All rights\
+      \ reserved.\n *\n * Redistribution and use in source and binary forms, with\
+      \ or without\n * modification, are permitted provided that the following conditions\n\
+      \ * are met:\n * 1. Redistributions of source code must retain the above copyright\n\
+      \ *    notice, this list of conditions and the following disclaimer.\n * 2.\
+      \ Redistributions in binary form must reproduce the above copyright\n *    notice,\
+      \ this list of conditions and the following disclaimer in the\n *    documentation\
+      \ and/or other materials provided with the distribution.\n * 3. The name of\
+      \ the author may not be used to endorse or promote products\n *    derived from\
+      \ this software without specific prior written permission.\n *\n * THIS SOFTWARE\
+      \ IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR\n * IMPLIED WARRANTIES,\
+      \ INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES\n * OF MERCHANTABILITY\
+      \ AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.\n * IN NO EVENT SHALL\
+      \ THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,\n * INCIDENTAL, SPECIAL, EXEMPLARY,\
+      \ OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT\n * NOT LIMITED TO, PROCUREMENT OF\
+      \ SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,\n * DATA, OR PROFITS; OR BUSINESS\
+      \ INTERRUPTION) HOWEVER CAUSED AND ON ANY\n * THEORY OF LIABILITY, WHETHER IN\
+      \ CONTRACT, STRICT LIABILITY, OR TORT\n * (INCLUDING NEGLIGENCE OR OTHERWISE)\
+      \ ARISING IN ANY WAY OUT OF THE USE OF\n * THIS SOFTWARE, EVEN IF ADVISED OF\
+      \ THE POSSIBILITY OF SUCH DAMAGE.\n */  "
+    licenseId: LicenseRef-4
+  SPDXID: SPDXRef-DOCUMENT
+  name: Sample_Document-V2.1
+  documentNamespace: https://spdx.org/spdxdocs/spdx-example-444504E0-4F89-41D3-9A0C-0305E82C3301
+  relationships:
+  - spdxElementId: "SPDXRef-DOCUMENT"
+    relatedSpdxElement: "SPDXRef-Package"
+    relationshipType: "DESCRIBES"
+  - spdxElementId: "SPDXRef-DOCUMENT"
+    relatedSpdxElement: "SPDXRef-Package"
+    relationshipType: "CONTAINS"
+  - spdxElementId: "SPDXRef-DOCUMENT"
+    relatedSpdxElement: "SPDXRef-File"
+    relationshipType: "DESCRIBES"
+  reviewers:
+  - comment: Another example reviewer.
+    reviewDate: '2011-03-13T00:00:00Z'
+    reviewer: 'Person: Suzanne Reviewer'
+  - comment: This is just an example.  Some of the non-standard licenses look like
+      they are actually BSD 3 clause licenses
+    reviewDate: '2010-02-10T00:00:00Z'
+    reviewer: 'Person: Joe Reviewer'
+  snippets:
+  - comment: This snippet was identified as significant and highlighted in this Apache-2.0
+      file, when a commercial scanner identified it as being derived from file foo.c
+      in package xyz which is licensed under GPL-2.0-or-later.
+    copyrightText: Copyright 2008-2010 John Smith
+    fileId: SPDXRef-DoapSource
+    SPDXID: SPDXRef-Snippet
+    licenseComments: The concluded license was taken from package xyz, from which
+      the snippet was copied into the current file. The concluded license information
+      was found in the COPYING.txt file in package xyz.
+    licenseConcluded: Apache-2.0
+    licenseInfoFromSnippet:
+    - Apache-2.0
+    name: from linux kernel
+  spdxVersion: SPDX-2.1

--- a/tests/data/parse_anything_test_files/SPDXYamlExample.yaml.xml
+++ b/tests/data/parse_anything_test_files/SPDXYamlExample.yaml.xml
@@ -1,0 +1,237 @@
+---
+Document:
+  annotations:
+  - annotationDate: '2012-06-13T00:00:00Z'
+    annotationType: REVIEW
+    annotator: 'Person: Jim Reviewer'
+    comment: This is just an example. Some of the non-standard licenses look like
+      they are actually BSD 3 clause licenses
+    SPDXID: SPDXRef-45
+  comment: This is a sample spreadsheet
+  creationInfo:
+    comment: This is an example of an SPDX spreadsheet format
+    created: '2010-02-03T00:00:00Z'
+    creators:
+    - 'Tool: SourceAuditor-V1.2'
+    - 'Organization: Source Auditor Inc.'
+    - 'Person: Gary O''Neall'
+    licenseListVersion: '3.6'
+  dataLicense: CC0-1.0
+  documentDescribes:
+  - Package:
+      SPDXID: SPDXRef-Package
+      checksums:
+      - algorithm: checksumAlgorithm_sha1
+        checksumValue: 2fd4e1c67a2d28fced849ee1bb76e7391b93eb12
+      copyrightText: ' Copyright 2010, 2011 Source Auditor Inc.'
+      description: This utility translates and SPDX RDF XML document to a spreadsheet,
+        translates a spreadsheet to an SPDX RDF XML document and translates an SPDX
+        RDFa document to an SPDX RDF XML document.
+      downloadLocation: http://www.spdx.org/tools
+      attributionTexts:
+      - "The GNU C Library is free software.  See the file COPYING.LIB for copying conditions,\
+        \ and LICENSES for notices about a few contributions that require these additional\
+        \ notices to be distributed.  License copyright years may be listed using range\
+        \ notation, e.g., 1996-2015, indicating that every year in the range, inclusive,\
+        \ is a copyrightable year that would otherwise be listed individually."
+      files:
+      - File:
+          checksums:
+          - algorithm: checksumAlgorithm_sha1
+            checksumValue: 3ab4e1c67a2d28fced849ee1bb76e7391b93f125
+          comment: This file belongs to Jena
+          copyrightText: (c) Copyright 2000, 2001, 2002, 2003, 2004, 2005, 2006, 2007,
+            2008, 2009 Hewlett-Packard Development Company, LP
+          artifactOf:
+            - name: "Jena"
+              homePage: "http://www.openjena.org/"
+              projectUri: "http://subversion.apache.org/doap.rdf"
+          fileTypes:
+          - fileType_archive
+          SPDXID: SPDXRef-File1
+          licenseComments: This license is used by Jena
+          licenseConcluded: LicenseRef-1
+          licenseInfoFromFiles:
+          - LicenseRef-1
+          name: Jenna-2.6.3/jena-2.6.3-sources.jar
+          sha1: 3ab4e1c67a2d28fced849ee1bb76e7391b93f125
+      - File:
+          checksums:
+          - algorithm: checksumAlgorithm_sha1
+            checksumValue: 2fd4e1c67a2d28fced849ee1bb76e7391b93eb12
+          copyrightText: Copyright 2010, 2011 Source Auditor Inc.
+          fileTypes:
+          - fileType_source
+          SPDXID: SPDXRef-File2
+          licenseConcluded: Apache-2.0
+          licenseInfoFromFiles:
+          - Apache-2.0
+          name: src/org/spdx/parser/DOAPProject.java
+          sha1: 2fd4e1c67a2d28fced849ee1bb76e7391b93eb12
+      licenseComments: The declared license information can be found in the NOTICE
+        file at the root of the archive file
+      licenseConcluded: (LicenseRef-3 AND LicenseRef-1 AND MPL-1.1 AND Apache-2.0
+        AND LicenseRef-2 AND Apache-1.0 AND LicenseRef-4)
+      licenseDeclared: (MPL-1.1 AND LicenseRef-4 AND LicenseRef-2 AND LicenseRef-1
+        AND Apache-2.0 AND LicenseRef-3)
+      licenseInfoFromFiles:
+      - Apache-2.0
+      - MPL-1.1
+      - LicenseRef-3
+      - LicenseRef-1
+      - LicenseRef-4
+      - Apache-1.0
+      - LicenseRef-2
+      name: SPDX Translator
+      originator: 'Organization: SPDX'
+      packageFileName: spdxtranslator-1.0.zip
+      packageVerificationCode:
+        packageVerificationCodeExcludedFiles:
+        - SpdxTranslatorSpdx.txt
+        - SpdxTranslatorSpdx.rdf
+        packageVerificationCodeValue: 4e3211c67a2d28fced849ee1bb76e7391b93feba
+      sha1: 2fd4e1c67a2d28fced849ee1bb76e7391b93eb12
+      sourceInfo: Version 1.0 of the SPDX Translator application
+      summary: SPDX Translator utility
+      supplier: 'Organization: Linux Foundation'
+      versionInfo: Version 0.9.2
+  externalDocumentRefs:
+  - checksum:
+      algorithm: checksumAlgorithm_sha1
+      checksumValue: d6a770ba38583ed4bb4525bd96e50461655d2759
+    externalDocumentId: DocumentRef-spdx-tool-2.1
+    spdxDocument: https://spdx.org/spdxdocs/spdx-tools-v2.1-3F2504E0-4F89-41D3-9A0C-0305E82C3301
+  hasExtractedLicensingInfos:
+  - comment: This is tye CyperNeko License
+    extractedText: "The CyberNeko Software License, Version 1.0\n\n \n(C) Copyright\
+      \ 2002-2005, Andy Clark.  All rights reserved.\n \nRedistribution and use in\
+      \ source and binary forms, with or without\nmodification, are permitted provided\
+      \ that the following conditions\nare met:\n\n1. Redistributions of source code\
+      \ must retain the above copyright\n   notice, this list of conditions and the\
+      \ following disclaimer. \n\n2. Redistributions in binary form must reproduce\
+      \ the above copyright\n   notice, this list of conditions and the following\
+      \ disclaimer in\n   the documentation and/or other materials provided with the\n\
+      \   distribution.\n\n3. The end-user documentation included with the redistribution,\n\
+      \   if any, must include the following acknowledgment:  \n     \"This product\
+      \ includes software developed by Andy Clark.\"\n   Alternately, this acknowledgment\
+      \ may appear in the software itself,\n   if and wherever such third-party acknowledgments\
+      \ normally appear.\n\n4. The names \"CyberNeko\" and \"NekoHTML\" must not be\
+      \ used to endorse\n   or promote products derived from this software without\
+      \ prior \n   written permission. For written permission, please contact \n \
+      \  andyc@cyberneko.net.\n\n5. Products derived from this software may not be\
+      \ called \"CyberNeko\",\n   nor may \"CyberNeko\" appear in their name, without\
+      \ prior written\n   permission of the author.\n\nTHIS SOFTWARE IS PROVIDED ``AS\
+      \ IS'' AND ANY EXPRESSED OR IMPLIED\nWARRANTIES, INCLUDING, BUT NOT LIMITED\
+      \ TO, THE IMPLIED WARRANTIES\nOF MERCHANTABILITY AND FITNESS FOR A PARTICULAR\
+      \ PURPOSE ARE\nDISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR OTHER CONTRIBUTORS\n\
+      BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, \nOR CONSEQUENTIAL\
+      \ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT \nOF SUBSTITUTE GOODS\
+      \ OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR \nBUSINESS INTERRUPTION) HOWEVER\
+      \ CAUSED AND ON ANY THEORY OF LIABILITY, \nWHETHER IN CONTRACT, STRICT LIABILITY,\
+      \ OR TORT (INCLUDING NEGLIGENCE \nOR OTHERWISE) ARISING IN ANY WAY OUT OF THE\
+      \ USE OF THIS SOFTWARE, \nEVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE."
+    licenseId: LicenseRef-3
+    name: CyberNeko License
+    seeAlso:
+    - http://justasample.url.com
+    - http://people.apache.org/~andyc/neko/LICENSE
+  - extractedText: "/*\n * (c) Copyright 2000, 2001, 2002, 2003, 2004, 2005, 2006,\
+      \ 2007, 2008, 2009 Hewlett-Packard Development Company, LP\n * All rights reserved.\n\
+      \ *\n * Redistribution and use in source and binary forms, with or without\n\
+      \ * modification, are permitted provided that the following conditions\n * are\
+      \ met:\n * 1. Redistributions of source code must retain the above copyright\n\
+      \ *    notice, this list of conditions and the following disclaimer.\n * 2.\
+      \ Redistributions in binary form must reproduce the above copyright\n *    notice,\
+      \ this list of conditions and the following disclaimer in the\n *    documentation\
+      \ and/or other materials provided with the distribution.\n * 3. The name of\
+      \ the author may not be used to endorse or promote products\n *    derived from\
+      \ this software without specific prior written permission.\n *\n * THIS SOFTWARE\
+      \ IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR\n * IMPLIED WARRANTIES,\
+      \ INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES\n * OF MERCHANTABILITY\
+      \ AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.\n * IN NO EVENT SHALL\
+      \ THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,\n * INCIDENTAL, SPECIAL, EXEMPLARY,\
+      \ OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT\n * NOT LIMITED TO, PROCUREMENT OF\
+      \ SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,\n * DATA, OR PROFITS; OR BUSINESS\
+      \ INTERRUPTION) HOWEVER CAUSED AND ON ANY\n * THEORY OF LIABILITY, WHETHER IN\
+      \ CONTRACT, STRICT LIABILITY, OR TORT\n * (INCLUDING NEGLIGENCE OR OTHERWISE)\
+      \ ARISING IN ANY WAY OUT OF THE USE OF\n * THIS SOFTWARE, EVEN IF ADVISED OF\
+      \ THE POSSIBILITY OF SUCH DAMAGE.\n */"
+    licenseId: LicenseRef-1
+  - extractedText: "This package includes the GRDDL parser developed by Hewlett Packard\
+      \ under the following license:\n\xA9 Copyright 2007 Hewlett-Packard Development\
+      \ Company, LP\n\nRedistribution and use in source and binary forms, with or\
+      \ without modification, are permitted provided that the following conditions\
+      \ are met: \n\nRedistributions of source code must retain the above copyright\
+      \ notice, this list of conditions and the following disclaimer. \nRedistributions\
+      \ in binary form must reproduce the above copyright notice, this list of conditions\
+      \ and the following disclaimer in the documentation and/or other materials provided\
+      \ with the distribution. \nThe name of the author may not be used to endorse\
+      \ or promote products derived from this software without specific prior written\
+      \ permission. \nTHIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS\
+      \ OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES\
+      \ OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN\
+      \ NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,\
+      \ SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,\
+      \ PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;\
+      \ OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER\
+      \ IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)\
+      \ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE\
+      \ POSSIBILITY OF SUCH DAMAGE. "
+    licenseId: LicenseRef-2
+  - extractedText: "/*\n * (c) Copyright 2009 University of Bristol\n * All rights\
+      \ reserved.\n *\n * Redistribution and use in source and binary forms, with\
+      \ or without\n * modification, are permitted provided that the following conditions\n\
+      \ * are met:\n * 1. Redistributions of source code must retain the above copyright\n\
+      \ *    notice, this list of conditions and the following disclaimer.\n * 2.\
+      \ Redistributions in binary form must reproduce the above copyright\n *    notice,\
+      \ this list of conditions and the following disclaimer in the\n *    documentation\
+      \ and/or other materials provided with the distribution.\n * 3. The name of\
+      \ the author may not be used to endorse or promote products\n *    derived from\
+      \ this software without specific prior written permission.\n *\n * THIS SOFTWARE\
+      \ IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR\n * IMPLIED WARRANTIES,\
+      \ INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES\n * OF MERCHANTABILITY\
+      \ AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.\n * IN NO EVENT SHALL\
+      \ THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,\n * INCIDENTAL, SPECIAL, EXEMPLARY,\
+      \ OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT\n * NOT LIMITED TO, PROCUREMENT OF\
+      \ SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,\n * DATA, OR PROFITS; OR BUSINESS\
+      \ INTERRUPTION) HOWEVER CAUSED AND ON ANY\n * THEORY OF LIABILITY, WHETHER IN\
+      \ CONTRACT, STRICT LIABILITY, OR TORT\n * (INCLUDING NEGLIGENCE OR OTHERWISE)\
+      \ ARISING IN ANY WAY OUT OF THE USE OF\n * THIS SOFTWARE, EVEN IF ADVISED OF\
+      \ THE POSSIBILITY OF SUCH DAMAGE.\n */  "
+    licenseId: LicenseRef-4
+  SPDXID: SPDXRef-DOCUMENT
+  name: Sample_Document-V2.1
+  documentNamespace: https://spdx.org/spdxdocs/spdx-example-444504E0-4F89-41D3-9A0C-0305E82C3301
+  relationships:
+  - spdxElementId: "SPDXRef-DOCUMENT"
+    relatedSpdxElement: "SPDXRef-Package"
+    relationshipType: "DESCRIBES"
+  - spdxElementId: "SPDXRef-DOCUMENT"
+    relatedSpdxElement: "SPDXRef-Package"
+    relationshipType: "CONTAINS"
+  - spdxElementId: "SPDXRef-DOCUMENT"
+    relatedSpdxElement: "SPDXRef-File"
+    relationshipType: "DESCRIBES"
+  reviewers:
+  - comment: Another example reviewer.
+    reviewDate: '2011-03-13T00:00:00Z'
+    reviewer: 'Person: Suzanne Reviewer'
+  - comment: This is just an example.  Some of the non-standard licenses look like
+      they are actually BSD 3 clause licenses
+    reviewDate: '2010-02-10T00:00:00Z'
+    reviewer: 'Person: Joe Reviewer'
+  snippets:
+  - comment: This snippet was identified as significant and highlighted in this Apache-2.0
+      file, when a commercial scanner identified it as being derived from file foo.c
+      in package xyz which is licensed under GPL-2.0-or-later.
+    copyrightText: Copyright 2008-2010 John Smith
+    fileId: SPDXRef-DoapSource
+    SPDXID: SPDXRef-Snippet
+    licenseComments: The concluded license was taken from package xyz, from which
+      the snippet was copied into the current file. The concluded license information
+      was found in the COPYING.txt file in package xyz.
+    licenseConcluded: Apache-2.0
+    licenseInfoFromSnippet:
+    - Apache-2.0
+    name: from linux kernel
+  spdxVersion: SPDX-2.1

--- a/tests/data/parse_anything_test_files/SPDXYamlExample.yaml.yml
+++ b/tests/data/parse_anything_test_files/SPDXYamlExample.yaml.yml
@@ -1,0 +1,237 @@
+---
+Document:
+  annotations:
+  - annotationDate: '2012-06-13T00:00:00Z'
+    annotationType: REVIEW
+    annotator: 'Person: Jim Reviewer'
+    comment: This is just an example. Some of the non-standard licenses look like
+      they are actually BSD 3 clause licenses
+    SPDXID: SPDXRef-45
+  comment: This is a sample spreadsheet
+  creationInfo:
+    comment: This is an example of an SPDX spreadsheet format
+    created: '2010-02-03T00:00:00Z'
+    creators:
+    - 'Tool: SourceAuditor-V1.2'
+    - 'Organization: Source Auditor Inc.'
+    - 'Person: Gary O''Neall'
+    licenseListVersion: '3.6'
+  dataLicense: CC0-1.0
+  documentDescribes:
+  - Package:
+      SPDXID: SPDXRef-Package
+      checksums:
+      - algorithm: checksumAlgorithm_sha1
+        checksumValue: 2fd4e1c67a2d28fced849ee1bb76e7391b93eb12
+      copyrightText: ' Copyright 2010, 2011 Source Auditor Inc.'
+      description: This utility translates and SPDX RDF XML document to a spreadsheet,
+        translates a spreadsheet to an SPDX RDF XML document and translates an SPDX
+        RDFa document to an SPDX RDF XML document.
+      downloadLocation: http://www.spdx.org/tools
+      attributionTexts:
+      - "The GNU C Library is free software.  See the file COPYING.LIB for copying conditions,\
+        \ and LICENSES for notices about a few contributions that require these additional\
+        \ notices to be distributed.  License copyright years may be listed using range\
+        \ notation, e.g., 1996-2015, indicating that every year in the range, inclusive,\
+        \ is a copyrightable year that would otherwise be listed individually."
+      files:
+      - File:
+          checksums:
+          - algorithm: checksumAlgorithm_sha1
+            checksumValue: 3ab4e1c67a2d28fced849ee1bb76e7391b93f125
+          comment: This file belongs to Jena
+          copyrightText: (c) Copyright 2000, 2001, 2002, 2003, 2004, 2005, 2006, 2007,
+            2008, 2009 Hewlett-Packard Development Company, LP
+          artifactOf:
+            - name: "Jena"
+              homePage: "http://www.openjena.org/"
+              projectUri: "http://subversion.apache.org/doap.rdf"
+          fileTypes:
+          - fileType_archive
+          SPDXID: SPDXRef-File1
+          licenseComments: This license is used by Jena
+          licenseConcluded: LicenseRef-1
+          licenseInfoFromFiles:
+          - LicenseRef-1
+          name: Jenna-2.6.3/jena-2.6.3-sources.jar
+          sha1: 3ab4e1c67a2d28fced849ee1bb76e7391b93f125
+      - File:
+          checksums:
+          - algorithm: checksumAlgorithm_sha1
+            checksumValue: 2fd4e1c67a2d28fced849ee1bb76e7391b93eb12
+          copyrightText: Copyright 2010, 2011 Source Auditor Inc.
+          fileTypes:
+          - fileType_source
+          SPDXID: SPDXRef-File2
+          licenseConcluded: Apache-2.0
+          licenseInfoFromFiles:
+          - Apache-2.0
+          name: src/org/spdx/parser/DOAPProject.java
+          sha1: 2fd4e1c67a2d28fced849ee1bb76e7391b93eb12
+      licenseComments: The declared license information can be found in the NOTICE
+        file at the root of the archive file
+      licenseConcluded: (LicenseRef-3 AND LicenseRef-1 AND MPL-1.1 AND Apache-2.0
+        AND LicenseRef-2 AND Apache-1.0 AND LicenseRef-4)
+      licenseDeclared: (MPL-1.1 AND LicenseRef-4 AND LicenseRef-2 AND LicenseRef-1
+        AND Apache-2.0 AND LicenseRef-3)
+      licenseInfoFromFiles:
+      - Apache-2.0
+      - MPL-1.1
+      - LicenseRef-3
+      - LicenseRef-1
+      - LicenseRef-4
+      - Apache-1.0
+      - LicenseRef-2
+      name: SPDX Translator
+      originator: 'Organization: SPDX'
+      packageFileName: spdxtranslator-1.0.zip
+      packageVerificationCode:
+        packageVerificationCodeExcludedFiles:
+        - SpdxTranslatorSpdx.txt
+        - SpdxTranslatorSpdx.rdf
+        packageVerificationCodeValue: 4e3211c67a2d28fced849ee1bb76e7391b93feba
+      sha1: 2fd4e1c67a2d28fced849ee1bb76e7391b93eb12
+      sourceInfo: Version 1.0 of the SPDX Translator application
+      summary: SPDX Translator utility
+      supplier: 'Organization: Linux Foundation'
+      versionInfo: Version 0.9.2
+  externalDocumentRefs:
+  - checksum:
+      algorithm: checksumAlgorithm_sha1
+      checksumValue: d6a770ba38583ed4bb4525bd96e50461655d2759
+    externalDocumentId: DocumentRef-spdx-tool-2.1
+    spdxDocument: https://spdx.org/spdxdocs/spdx-tools-v2.1-3F2504E0-4F89-41D3-9A0C-0305E82C3301
+  hasExtractedLicensingInfos:
+  - comment: This is tye CyperNeko License
+    extractedText: "The CyberNeko Software License, Version 1.0\n\n \n(C) Copyright\
+      \ 2002-2005, Andy Clark.  All rights reserved.\n \nRedistribution and use in\
+      \ source and binary forms, with or without\nmodification, are permitted provided\
+      \ that the following conditions\nare met:\n\n1. Redistributions of source code\
+      \ must retain the above copyright\n   notice, this list of conditions and the\
+      \ following disclaimer. \n\n2. Redistributions in binary form must reproduce\
+      \ the above copyright\n   notice, this list of conditions and the following\
+      \ disclaimer in\n   the documentation and/or other materials provided with the\n\
+      \   distribution.\n\n3. The end-user documentation included with the redistribution,\n\
+      \   if any, must include the following acknowledgment:  \n     \"This product\
+      \ includes software developed by Andy Clark.\"\n   Alternately, this acknowledgment\
+      \ may appear in the software itself,\n   if and wherever such third-party acknowledgments\
+      \ normally appear.\n\n4. The names \"CyberNeko\" and \"NekoHTML\" must not be\
+      \ used to endorse\n   or promote products derived from this software without\
+      \ prior \n   written permission. For written permission, please contact \n \
+      \  andyc@cyberneko.net.\n\n5. Products derived from this software may not be\
+      \ called \"CyberNeko\",\n   nor may \"CyberNeko\" appear in their name, without\
+      \ prior written\n   permission of the author.\n\nTHIS SOFTWARE IS PROVIDED ``AS\
+      \ IS'' AND ANY EXPRESSED OR IMPLIED\nWARRANTIES, INCLUDING, BUT NOT LIMITED\
+      \ TO, THE IMPLIED WARRANTIES\nOF MERCHANTABILITY AND FITNESS FOR A PARTICULAR\
+      \ PURPOSE ARE\nDISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR OTHER CONTRIBUTORS\n\
+      BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, \nOR CONSEQUENTIAL\
+      \ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT \nOF SUBSTITUTE GOODS\
+      \ OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR \nBUSINESS INTERRUPTION) HOWEVER\
+      \ CAUSED AND ON ANY THEORY OF LIABILITY, \nWHETHER IN CONTRACT, STRICT LIABILITY,\
+      \ OR TORT (INCLUDING NEGLIGENCE \nOR OTHERWISE) ARISING IN ANY WAY OUT OF THE\
+      \ USE OF THIS SOFTWARE, \nEVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE."
+    licenseId: LicenseRef-3
+    name: CyberNeko License
+    seeAlso:
+    - http://justasample.url.com
+    - http://people.apache.org/~andyc/neko/LICENSE
+  - extractedText: "/*\n * (c) Copyright 2000, 2001, 2002, 2003, 2004, 2005, 2006,\
+      \ 2007, 2008, 2009 Hewlett-Packard Development Company, LP\n * All rights reserved.\n\
+      \ *\n * Redistribution and use in source and binary forms, with or without\n\
+      \ * modification, are permitted provided that the following conditions\n * are\
+      \ met:\n * 1. Redistributions of source code must retain the above copyright\n\
+      \ *    notice, this list of conditions and the following disclaimer.\n * 2.\
+      \ Redistributions in binary form must reproduce the above copyright\n *    notice,\
+      \ this list of conditions and the following disclaimer in the\n *    documentation\
+      \ and/or other materials provided with the distribution.\n * 3. The name of\
+      \ the author may not be used to endorse or promote products\n *    derived from\
+      \ this software without specific prior written permission.\n *\n * THIS SOFTWARE\
+      \ IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR\n * IMPLIED WARRANTIES,\
+      \ INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES\n * OF MERCHANTABILITY\
+      \ AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.\n * IN NO EVENT SHALL\
+      \ THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,\n * INCIDENTAL, SPECIAL, EXEMPLARY,\
+      \ OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT\n * NOT LIMITED TO, PROCUREMENT OF\
+      \ SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,\n * DATA, OR PROFITS; OR BUSINESS\
+      \ INTERRUPTION) HOWEVER CAUSED AND ON ANY\n * THEORY OF LIABILITY, WHETHER IN\
+      \ CONTRACT, STRICT LIABILITY, OR TORT\n * (INCLUDING NEGLIGENCE OR OTHERWISE)\
+      \ ARISING IN ANY WAY OUT OF THE USE OF\n * THIS SOFTWARE, EVEN IF ADVISED OF\
+      \ THE POSSIBILITY OF SUCH DAMAGE.\n */"
+    licenseId: LicenseRef-1
+  - extractedText: "This package includes the GRDDL parser developed by Hewlett Packard\
+      \ under the following license:\n\xA9 Copyright 2007 Hewlett-Packard Development\
+      \ Company, LP\n\nRedistribution and use in source and binary forms, with or\
+      \ without modification, are permitted provided that the following conditions\
+      \ are met: \n\nRedistributions of source code must retain the above copyright\
+      \ notice, this list of conditions and the following disclaimer. \nRedistributions\
+      \ in binary form must reproduce the above copyright notice, this list of conditions\
+      \ and the following disclaimer in the documentation and/or other materials provided\
+      \ with the distribution. \nThe name of the author may not be used to endorse\
+      \ or promote products derived from this software without specific prior written\
+      \ permission. \nTHIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS\
+      \ OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES\
+      \ OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN\
+      \ NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,\
+      \ SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,\
+      \ PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;\
+      \ OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER\
+      \ IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)\
+      \ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE\
+      \ POSSIBILITY OF SUCH DAMAGE. "
+    licenseId: LicenseRef-2
+  - extractedText: "/*\n * (c) Copyright 2009 University of Bristol\n * All rights\
+      \ reserved.\n *\n * Redistribution and use in source and binary forms, with\
+      \ or without\n * modification, are permitted provided that the following conditions\n\
+      \ * are met:\n * 1. Redistributions of source code must retain the above copyright\n\
+      \ *    notice, this list of conditions and the following disclaimer.\n * 2.\
+      \ Redistributions in binary form must reproduce the above copyright\n *    notice,\
+      \ this list of conditions and the following disclaimer in the\n *    documentation\
+      \ and/or other materials provided with the distribution.\n * 3. The name of\
+      \ the author may not be used to endorse or promote products\n *    derived from\
+      \ this software without specific prior written permission.\n *\n * THIS SOFTWARE\
+      \ IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR\n * IMPLIED WARRANTIES,\
+      \ INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES\n * OF MERCHANTABILITY\
+      \ AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.\n * IN NO EVENT SHALL\
+      \ THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,\n * INCIDENTAL, SPECIAL, EXEMPLARY,\
+      \ OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT\n * NOT LIMITED TO, PROCUREMENT OF\
+      \ SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,\n * DATA, OR PROFITS; OR BUSINESS\
+      \ INTERRUPTION) HOWEVER CAUSED AND ON ANY\n * THEORY OF LIABILITY, WHETHER IN\
+      \ CONTRACT, STRICT LIABILITY, OR TORT\n * (INCLUDING NEGLIGENCE OR OTHERWISE)\
+      \ ARISING IN ANY WAY OUT OF THE USE OF\n * THIS SOFTWARE, EVEN IF ADVISED OF\
+      \ THE POSSIBILITY OF SUCH DAMAGE.\n */  "
+    licenseId: LicenseRef-4
+  SPDXID: SPDXRef-DOCUMENT
+  name: Sample_Document-V2.1
+  documentNamespace: https://spdx.org/spdxdocs/spdx-example-444504E0-4F89-41D3-9A0C-0305E82C3301
+  relationships:
+  - spdxElementId: "SPDXRef-DOCUMENT"
+    relatedSpdxElement: "SPDXRef-Package"
+    relationshipType: "DESCRIBES"
+  - spdxElementId: "SPDXRef-DOCUMENT"
+    relatedSpdxElement: "SPDXRef-Package"
+    relationshipType: "CONTAINS"
+  - spdxElementId: "SPDXRef-DOCUMENT"
+    relatedSpdxElement: "SPDXRef-File"
+    relationshipType: "DESCRIBES"
+  reviewers:
+  - comment: Another example reviewer.
+    reviewDate: '2011-03-13T00:00:00Z'
+    reviewer: 'Person: Suzanne Reviewer'
+  - comment: This is just an example.  Some of the non-standard licenses look like
+      they are actually BSD 3 clause licenses
+    reviewDate: '2010-02-10T00:00:00Z'
+    reviewer: 'Person: Joe Reviewer'
+  snippets:
+  - comment: This snippet was identified as significant and highlighted in this Apache-2.0
+      file, when a commercial scanner identified it as being derived from file foo.c
+      in package xyz which is licensed under GPL-2.0-or-later.
+    copyrightText: Copyright 2008-2010 John Smith
+    fileId: SPDXRef-DoapSource
+    SPDXID: SPDXRef-Snippet
+    licenseComments: The concluded license was taken from package xyz, from which
+      the snippet was copied into the current file. The concluded license information
+      was found in the COPYING.txt file in package xyz.
+    licenseConcluded: Apache-2.0
+    licenseInfoFromSnippet:
+    - Apache-2.0
+    name: from linux kernel
+  spdxVersion: SPDX-2.1

--- a/tests/test_parse_anything.py
+++ b/tests/test_parse_anything.py
@@ -28,3 +28,17 @@ def test_parse_anything(test_file):
     # test a few fields, the core of the tests are per parser
     assert doc.name in ('Sample_Document-V2.1', 'xyz-0.1.0')
     assert doc.comment in (None, 'This is a sample spreadsheet', 'Sample Comment')
+
+dirname = os.path.join(os.path.dirname(__file__), "data", "formats")
+test_files = [os.path.join(dirname, fn) for fn in os.listdir(dirname)]
+
+
+@pytest.mark.parametrize("test_file", test_files)
+def test_parse_anything_formats(test_file):
+    doc, error = parse_anything.parse_file(test_file)
+
+    assert not error
+
+    # test a few fields, the core of the tests are per parser
+    assert doc.name in ('Sample_Document-V2.1', 'xyz-0.1.0')
+    assert doc.comment in (None, 'This is a sample spreadsheet', 'Sample Comment')

--- a/tests/test_parse_anything.py
+++ b/tests/test_parse_anything.py
@@ -15,7 +15,7 @@ import pytest
 from spdx.parsers import parse_anything
 
 
-dirname = os.path.join(os.path.dirname(__file__), "data", "formats")
+dirname = os.path.join(os.path.dirname(__file__), "data", "parse_anything_test_files")
 test_files = [os.path.join(dirname, fn) for fn in os.listdir(dirname)]
 
 


### PR DESCRIPTION
I tried parsing the SBOMs in the SPDX DocFest 20220127 and more than two thirds of the documents could not be parsed due to their file extensions. This was because most files had the extension .spdx and the parse_anything function assumed that every .spdx file should be parsed as a .tag file. However, there were many .spdx files that were not tag files and an error was thrown before they were parsed. Furthermore, there were examples of files with incorrect file extensions which prevented them from being parsed at all. I discussed with @licquia during the summer and he suggested that I try all the parsers for each file until the correct parser matches the type of the file. Below is piece of code where most .spdx documents fail on.
<img width="418" alt="Screen Shot 2023-01-14 at 4 09 53 AM" src="https://user-images.githubusercontent.com/63569843/212471144-a94bc5f1-47bb-4e10-b6d3-00cf1db49943.png">
