### PR TITLE
[issue-449] fix parsing of package supplier and package originator

### DIFF
--- a/spdx/package.py
+++ b/spdx/package.py
@@ -12,14 +12,16 @@ import warnings
 from datetime import datetime
 from enum import Enum
 from functools import reduce
-from typing import Optional
+from typing import Optional, Union
 
 from spdx import creationinfo
 from spdx import license
 from spdx import utils
 from spdx.checksum import Checksum, ChecksumAlgorithm
+from spdx.creationinfo import Creator
 from spdx.parsers.builderexceptions import SPDXValueError
 from spdx.parsers.loggers import ErrorMessages
+from spdx.utils import NoAssert
 
 
 class PackagePurpose(Enum):
@@ -95,8 +97,8 @@ class Package(object):
         self.spdx_id = spdx_id
         self.version = version
         self.file_name = file_name
-        self.supplier = supplier
-        self.originator = originator
+        self.supplier: Optional[Union[Creator, NoAssert]] = supplier
+        self.originator: Optional[Union[Creator, NoAssert]] = originator
         self.download_location = download_location
         self.files_analyzed = None
         self.homepage = None

--- a/spdx/parsers/jsonyamlxml.py
+++ b/spdx/parsers/jsonyamlxml.py
@@ -20,7 +20,7 @@ from spdx.parsers import rdf
 from spdx.parsers.builderexceptions import SPDXValueError, CardinalityError, OrderError
 from spdx.parsers.loggers import ErrorMessages
 from spdx.snippet import Snippet
-from spdx.utils import UnKnown
+from spdx.utils import UnKnown, NoAssert
 
 ERROR_MESSAGES = rdf.ERROR_MESSAGES
 
@@ -1243,6 +1243,8 @@ class PackageParser(BaseParser):
         - pkg_supplier: Python str/unicode
         """
         if isinstance(pkg_supplier, str):
+            if pkg_supplier == "NOASSERTION":
+                return self.builder.set_pkg_supplier(self.document, NoAssert())
             entity = self.builder.create_entity(self.document, pkg_supplier)
             try:
                 return self.builder.set_pkg_supplier(self.document, entity)
@@ -1261,6 +1263,8 @@ class PackageParser(BaseParser):
         - pkg_originator: Python str/unicode
         """
         if isinstance(pkg_originator, str):
+            if pkg_originator == "NOASSERTION":
+                return self.builder.set_pkg_originator(self.document, NoAssert())
             entity = self.builder.create_entity(self.document, pkg_originator)
             try:
                 return self.builder.set_pkg_originator(self.document, entity)


### PR DESCRIPTION
fixes #449 

I tried to add a test for this but as the builder and parser are quite nested and I couldn't really isolate this function, I gave up. If you think it is necessary to add a test here, I would simply adapt the [testfile](https://github.com/spdx/tools-python/blob/main/tests/data/formats/SPDXJsonExample.json). 

Signed-off-by: Meret Behrens <meret.behrens@tngtech.com>