### PR TITLE
[issue-457] add "no #" requirement to validation messages

### DIFF
--- a/src/spdx/validation/external_package_ref_validator.py
+++ b/src/spdx/validation/external_package_ref_validator.py
@@ -11,6 +11,8 @@
 import re
 from typing import List, Dict
 
+import uritools
+
 from spdx.model.package import ExternalPackageRef, ExternalPackageRefCategory, CATEGORY_TO_EXTERNAL_PACKAGE_REF_TYPES
 from spdx.validation.uri_validators import validate_url, validate_uri
 from spdx.validation.validation_message import ValidationMessage, ValidationContext, SpdxElementType
@@ -75,7 +77,7 @@ def validate_external_package_ref(external_package_ref: ExternalPackageRef, pare
         return []
 
     if reference_type == "swid":
-        if validate_uri(locator) or not locator.startswith("swid"):
+        if not uritools.isuri(locator) or not locator.startswith("swid"):
             return [ValidationMessage(
                 f'externalPackageRef locator of type "swid" must be a valid URI with scheme swid, but is: {locator}',
                 context)]

--- a/src/spdx/validation/uri_validators.py
+++ b/src/spdx/validation/uri_validators.py
@@ -38,7 +38,7 @@ def validate_download_location(location: str) -> List[str]:
 
 def validate_uri(uri: str) -> List[str]:
     if not isabsuri(uri):
-        return [f"must be a valid URI specified in RFC-3986, but is: {uri}"]
+        return [f"must be a valid URI specified in RFC-3986 and must contain no fragment (#), but is: {uri}"]
     else:
         split = urisplit(uri)
         if split.scheme is None:

--- a/tests/spdx/validation/test_creation_info_validator.py
+++ b/tests/spdx/validation/test_creation_info_validator.py
@@ -32,7 +32,7 @@ def test_valid_creation_info():
           (creation_info_fixture(data_license="MIT"), "SPDXRef-DOCUMENT",
            'data_license must be "CC0-1.0", but is: MIT'),
           (creation_info_fixture(document_namespace="some_namespace"), "SPDXRef-DOCUMENT",
-           "document_namespace must be a valid URI specified in RFC-3986, but is: some_namespace"),
+           "document_namespace must be a valid URI specified in RFC-3986 and must contain no fragment (#), but is: some_namespace"),
           ])
 def test_invalid_creation_info(creation_info_input, expected_message, spdx_id):
     validation_messages: List[ValidationMessage] = validate_creation_info(creation_info_input)

--- a/tests/spdx/validation/test_uri_validators.py
+++ b/tests/spdx/validation/test_uri_validators.py
@@ -99,7 +99,7 @@ def test_valid_uri(input_value):
 def test_invalid_uri(input_value):
     message = validate_uri(input_value)
 
-    assert message == [f"must be a valid URI specified in RFC-3986, but is: {input_value}"]
+    assert message == [f"must be a valid URI specified in RFC-3986 and must contain no fragment (#), but is: {input_value}"]
 
 
 @pytest.mark.parametrize("input_value", ["://spdx.org/spdxdocs/spdx-tools-v1.2-3F2504E0-4F89-41D3-9A0C-0305E82..."])


### PR DESCRIPTION
also make swid accept non-absolute URIs as I did not find information on that this would be forbidden

fixes #457 

Signed-off-by: Armin Tänzer <armin.taenzer@tngtech.com>