### PR TITLE
Issue 465 fix line mismatch

### DIFF
--- a/spdx/parsers/lexers/tagvalue.py
+++ b/spdx/parsers/lexers/tagvalue.py
@@ -235,7 +235,7 @@ class Lexer(object):
         t.lexer.lineno += len(t.value)
 
     def t_whitespace(self, t):
-        r"\s"
+        r"[ \t]+"
         pass
 
     def build(self, **kwargs):

--- a/spdx/parsers/lexers/tagvalue.py
+++ b/spdx/parsers/lexers/tagvalue.py
@@ -235,7 +235,7 @@ class Lexer(object):
         t.lexer.lineno += len(t.value)
 
     def t_whitespace(self, t):
-        r"\s+"
+        r"\s"
         pass
 
     def build(self, **kwargs):

--- a/spdx/parsers/tagvalue.py
+++ b/spdx/parsers/tagvalue.py
@@ -37,6 +37,8 @@ ERROR_MESSAGES = {
     "DOC_VERSION_VALUE_TYPE": "Invalid SPDXVersion value, must be SPDX-M.N where M and N are numbers. Line: {0}",
     "DOC_NAME_VALUE": "DocumentName must be single line of text, line: {0}",
     "DOC_SPDX_ID_VALUE": "Invalid SPDXID value, SPDXID must be SPDXRef-DOCUMENT, line: {0}",
+    "LIC_LIST_VER_VALUE": "Invalid LicenseListVersion '{0}', must be of type M.N where M and N are numbers. Line: {1}",
+    "LIC_LIST_VER_VALUE_TYPE": "Could not read value after LicenseListVersion-tag. Line{0}",
     "EXT_DOC_REF_VALUE": "ExternalDocumentRef must contain External Document ID, SPDX Document URI and Checksum"
                          "in the standard format, line:{0}.",
     "DOC_COMMENT_VALUE_TYPE": "DocumentComment value must be free form text between <text></text> tags"

--- a/tests/test_tag_value_parser.py
+++ b/tests/test_tag_value_parser.py
@@ -115,6 +115,9 @@ annotation_str = '\n'.join([
     'SPDXREF: SPDXRef-DOCUMENT'
 ])
 
+document_str_with_empty_line = "\n".join(
+    ['SPDXVersion: SPDX-2.1', '  ', 'DataLicense: CC0-1.0'])
+
 
 class TestLexer(TestCase):
     maxDiff = None
@@ -290,6 +293,14 @@ class TestLexer(TestCase):
         self.token_assert_helper(self.l.token(), 'OTHER', 'OTHER', 4)
         self.token_assert_helper(self.l.token(), 'ANNOTATION_SPDX_ID', 'SPDXREF', 5)
         self.token_assert_helper(self.l.token(), 'LINE', 'SPDXRef-DOCUMENT', 5)
+
+    def test_correct_line_number_with_empty_line_between(self):
+        data = document_str_with_empty_line
+        self.l.input(data)
+        self.token_assert_helper(self.l.token(), 'DOC_VERSION', 'SPDXVersion', 1)
+        self.token_assert_helper(self.l.token(), 'LINE', 'SPDX-2.1', 1)
+        self.token_assert_helper(self.l.token(), 'DOC_LICENSE', 'DataLicense', 3)
+        self.token_assert_helper(self.l.token(), 'LINE', 'CC0-1.0', 3)
 
     def token_assert_helper(self, token, ttype, value, line):
         assert token.type == ttype


### PR DESCRIPTION
Without this fix lines that contain a whitespace and a line break were not taken into account when counting the lines. This lead to a mismatch in the line number printed within the error message and the actual falsy line.

Working on this, I saw that the tag value parser was missing two error messages. This seems to be missing from the early states of the repo and it's rather interesting that this never popped up as it could easily cause a `KeyError`.

fixes #465