### PR TITLE
fix helper method

### DIFF
--- a/src/spdx/parser/jsonlikedict/dict_parsing_functions.py
+++ b/src/spdx/parser/jsonlikedict/dict_parsing_functions.py
@@ -43,7 +43,7 @@ def parse_field_or_log_error(logger: Logger, field: Any, parsing_method: Callabl
     except SPDXParsingError as err:
         logger.extend(err.get_messages())
     except (TypeError, ValueError) as err:
-        logger.extend(err.args[0])
+        logger.append(err.args[0])
     return default
 
 


### PR DESCRIPTION
The return value of err.args[0] is a string, so we need to use append to add this string to the list of messages in the logger.

