### PR TITLE
use datetime.fromisoformat to parse date string, instead of own imple…

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,6 +83,17 @@ jobs:
     - update_packaging_tools
     - install_run_tests
 
+  mac_python_3_11:
+    shell: /bin/bash --login
+    macos:
+      xcode: '13.0.0'
+    steps:
+    - checkout
+    - mac_install_python:
+        python_version: "3.11.2"
+    - update_packaging_tools
+    - install_run_tests
+
   linux_python_3_7:
     docker:
       - image: python:3.7
@@ -115,6 +126,15 @@ jobs:
     - update_packaging_tools
     - install_run_tests
 
+  linux_python_3_11:
+    docker:
+      - image: python:3.11
+    steps:
+    - checkout
+    - update_packaging_tools
+    - install_run_tests
+
+
 workflows:
   version: 2
   python_matrix_build:
@@ -123,7 +143,9 @@ workflows:
       - mac_python_3_8
       - mac_python_3_9
       - mac_python_3_10
+      - mac_python_3_11
       - linux_python_3_7
       - linux_python_3_8
       - linux_python_3_9
       - linux_python_3_10
+      - linux_python_3_11

--- a/spdx/utils.py
+++ b/spdx/utils.py
@@ -9,9 +9,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import datetime
 import hashlib
 import re
+from datetime import datetime
 from typing import Dict, List, TYPE_CHECKING
 
 from ply import lex
@@ -30,21 +30,12 @@ def datetime_iso_format(date):
     """
     Return an ISO-8601 representation of a datetime object.
     """
-    return date.isoformat() + "Z"
-
+    return date.strftime('%Y-%m-%dT%H:%M:%SZ')
 
 # Matches an iso 8601 date representation
 DATE_ISO_REGEX = re.compile(
-    r"(\d\d\d\d)-(\d\d)-(\d\d)T(\d\d):(\d\d):(\d\d)Z", re.UNICODE
+    r"(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})Z", re.UNICODE
 )
-
-# Groups for retrieving values from DATE_ISO_REGEX matches.
-DATE_ISO_YEAR_GRP = 1
-DATE_ISO_MONTH_GRP = 2
-DATE_ISO_DAY_GRP = 3
-DATE_ISO_HOUR_GRP = 4
-DATE_ISO_MIN_GRP = 5
-DATE_ISO_SEC_GRP = 6
 
 
 def datetime_from_iso_format(string):
@@ -53,18 +44,12 @@ def datetime_from_iso_format(string):
     Return None if string is non conforming.
     """
     match = DATE_ISO_REGEX.match(string)
-    if match:
-        date = datetime.datetime(
-            year=int(match.group(DATE_ISO_YEAR_GRP)),
-            month=int(match.group(DATE_ISO_MONTH_GRP)),
-            day=int(match.group(DATE_ISO_DAY_GRP)),
-            hour=int(match.group(DATE_ISO_HOUR_GRP)),
-            second=int(match.group(DATE_ISO_SEC_GRP)),
-            minute=int(match.group(DATE_ISO_MIN_GRP)),
-        )
-        return date
-    else:
+    if not match:
         return None
+
+    if string.endswith("Z"):
+        string = string[:-len("Z")] + "+00:00"
+    return datetime.fromisoformat(string)
 
 
 class NoAssert(object):

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -244,7 +244,7 @@ class TestCreationInfoBuilder(TestCase):
 
     @testing_utils.raises(builders.SPDXValueError)
     def test_created_value(self):
-        created_str = "2010-02-03T00:00:00"
+        created_str = "INVALID"
         self.builder.set_created_date(self.document, created_str)
 
     def test_license_list_vers(self):

--- a/tests/test_jsonyamlxml_writer.py
+++ b/tests/test_jsonyamlxml_writer.py
@@ -1,6 +1,6 @@
 import glob
 import os
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import List
 
 import pytest
@@ -69,9 +69,9 @@ def test_primary_package_purpose(temporary_file_path: str, out_format: str):
 def test_release_built_valid_until_date(temporary_file_path: str, out_format: str):
     document: Document = minimal_document_with_package()
     package: Package = document.packages[0]
-    package.release_date = datetime(2021, 1, 1, 12, 0, 0)
-    package.built_date = datetime(2021, 1, 1, 12, 0, 0)
-    package.valid_until_date = datetime(2022, 1, 1, 12, 0, 0)
+    package.release_date = datetime(2021, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+    package.built_date = datetime(2021, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+    package.valid_until_date = datetime(2022, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
 
     file_path_with_ending = temporary_file_path + "." + out_format
     write_anything.write_file(document, file_path_with_ending, validate=False)

--- a/tests/test_tag_value_parser.py
+++ b/tests/test_tag_value_parser.py
@@ -10,7 +10,7 @@
 # limitations under the License.
 
 import sys
-from datetime import datetime
+from datetime import datetime, timezone
 from unittest import TestCase
 
 import spdx
@@ -347,9 +347,9 @@ class TestParser(TestCase):
         assert document.package.pkg_ext_refs[-1].locator == 'cpe:2.3:a:pivotal_software:spring_framework:4.1.0:*:*:*:*:*:*:'
         assert document.package.pkg_ext_refs[-1].comment == 'Some comment about the package.'
         assert document.package.primary_package_purpose == PackagePurpose.OPERATING_SYSTEM
-        assert document.package.built_date == datetime(2020, 1, 1, 12, 0, 0)
-        assert document.package.release_date == datetime(2021, 1, 1, 12, 0, 0)
-        assert document.package.valid_until_date == datetime(2022, 1, 1, 12, 0, 0)
+        assert document.package.built_date == datetime(2020, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+        assert document.package.release_date == datetime(2021, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+        assert document.package.valid_until_date == datetime(2022, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
 
     def test_file(self):
         document, error = self.p.parse(self.complete_str)


### PR DESCRIPTION
I tried to validate a date in the following format and got an error

`2023-02-15T11:13:01.729997`

This is the output from: `datetime.utcnow().isoformat()` (https://docs.python.org/3/library/datetime.html#datetime.date.isoformat)

As you describe in the comment that you want an ISO 8601 format I think it would be better to use the python default method to validate the date

`datetime.fromisoformat(string)`. (https://docs.python.org/3/library/datetime.html#datetime.datetime.fromisoformat)

Therefore the above datetime is a valid datetime with no timezone

From the python documentation:         
The full format looks like 'YYYY-MM-DD HH:MM:SS.mmmmmm'. By default, the fractional part is omitted if self.microsecond == 0.
If self.tzinfo is not None, the UTC offset is also attached, giving a full format of 'YYYY-MM-DD HH:MM:SS.mmmmmm+HH:MM'.