### PR TITLE
[issue-496] fix SPDXJsonExampleEmptyArrays.json test

### DIFF
--- a/tests/data/formats/SPDXJsonExampleEmptyArrays.json
+++ b/tests/data/formats/SPDXJsonExampleEmptyArrays.json
@@ -15,34 +15,15 @@
       "description" : "Coverlet is a cross platform code coverage library for .NET, with support for line, branch and method coverage.",
       "downloadLocation" : "https://api.nuget.org/packages/coverlet.collector.3.2.0.nupkg",
       "filesAnalyzed" : false,
-      "hasFiles" : [ ],
+      "hasFiles" : [],
       "homepage" : "https://github.com/coverlet-coverage/coverlet",
       "licenseConcluded" : "(MIT)",
       "licenseDeclared" : "(MIT)",
-      "licenseInfoFromFiles" : [ ],
+      "licenseInfoFromFiles" : [],
       "name" : "coverlet.collector.3.2.0.nupkg",
       "originator" : "Organization: tonerdo",
       "packageFileName" : "coverlet.collector.3.2.0.nupkg",
-      "supplier" : "Organization: tonerdo",
-      "versionInfo" : "3.2.0"
-    },
-    {
-      "SPDXID" : "SPDXRef-2269-coverlet.collector.3.2.0.nupkg",
-      "checksums" : [ {
-        "algorithm" : "SHA1",
-        "checksumValue" : "0cf7564fcbdee13f6313edd8bc261ca0564a4bf7"
-      } ],
-      "copyrightText" : "NOASSERTION",
-      "description" : "Coverlet is a cross platform code coverage library for .NET, with support for line, branch and method coverage.",
-      "downloadLocation" : "https://api.nuget.org/packages/coverlet.collector.3.2.0.nupkg",
-      "filesAnalyzed" : false,
-      "homepage" : "https://github.com/coverlet-coverage/coverlet",
-      "licenseConcluded" : "(MIT)",
-      "licenseDeclared" : "(MIT)",
-      "name" : "coverlet.collector.3.2.0.nupkg",
-      "originator" : "Organization: tonerdo",
-      "packageFileName" : "coverlet.collector.3.2.0.nupkg",
-      "supplier" : "Organization: tonerdo",
+      "supplier" : "NOASSERTION",
       "versionInfo" : "3.2.0"
     }
   ],

--- a/tests/test_write_anything.py
+++ b/tests/test_write_anything.py
@@ -35,10 +35,7 @@ UNSTABLE_CONVERSIONS = {
     "SPDXXMLExample-v2.2.spdx.xml-tag",
     "SPDXYAMLExample-2.3.spdx.yaml-tag",
     "SPDXJSONExample-v2.3.spdx.json-tag",
-    "SPDXXMLExample-v2.3.spdx.xml-tag",
-    "SPDXJsonExampleEmptyArrays.json-json",
-    "SPDXJsonExampleEmptyArrays.json-xml",
-    "SPDXJsonExampleEmptyArrays.json-yaml"
+    "SPDXXMLExample-v2.3.spdx.xml-tag"
 }
 
 


### PR DESCRIPTION
fixed during a review round before 0.7.1 pre-release

the package in the example was duplicated, I erased one of them, making the conversion tests stable