### PR TITLE
[issue-479] fix parsing of package version that looks like a range value

### DIFF
--- a/spdx/parsers/lexers/tagvalue.py
+++ b/spdx/parsers/lexers/tagvalue.py
@@ -137,7 +137,6 @@ class Lexer(object):
         "PERSON_VALUE",
         "DATE",
         "LINE",
-        "RANGE",
         "CHKSUM",
         "DOC_REF_ID",
         "DOC_URI",
@@ -219,9 +218,6 @@ class Lexer(object):
         if t.value in self.reserved.keys():
             t.type = self.reserved[t.value]
             return t
-        range_pattern = re.compile("\d+:\d(?!\D)")
-        if range_pattern.match(t.value):
-            t.type = "RANGE"
         else:
             t.type = "LINE"
         return t

--- a/spdx/parsers/tagvalue.py
+++ b/spdx/parsers/tagvalue.py
@@ -1393,9 +1393,9 @@ class Parser(object):
         self.logger.log(msg)
 
     def p_snippet_byte_range(self, p):
-        """snip_byte_range : SNIPPET_BYTE_RANGE RANGE"""
+        """snip_byte_range : SNIPPET_BYTE_RANGE LINE"""
         try:
-            self.builder.set_snippet_byte_range(self.document, p[2])
+            self.builder.set_snippet_byte_range(self.document, p[2].strip())
         except OrderError:
             self.order_error("SnippetByteRange", "SnippetSPDXID", p.lineno(1))
         except SPDXValueError:
@@ -1411,9 +1411,9 @@ class Parser(object):
         self.logger.log(msg)
 
     def p_snippet_line_range(self, p):
-        """snip_line_range : SNIPPET_LINE_RANGE RANGE"""
+        """snip_line_range : SNIPPET_LINE_RANGE LINE"""
         try:
-            self.builder.set_snippet_line_range(self.document, p[2])
+            self.builder.set_snippet_line_range(self.document, p[2].strip())
         except OrderError:
             self.order_error("SnippetLineRange", "SnippetSPDXID", p.lineno(1))
         except SPDXValueError:

--- a/spdx/parsers/tagvaluebuilders.py
+++ b/spdx/parsers/tagvaluebuilders.py
@@ -1614,8 +1614,11 @@ class SnippetBuilder(object):
         Raise SPDXValueError if the data is malformed.
         """
         self.assert_snippet_exists()
-        startpoint = int(parsed.split(":")[0])
-        endpoint = int(parsed.split(":")[-1])
+        range_re = re.compile(r"^(\d+):(\d+)$", re.UNICODE)
+        if not range_re.match(parsed):
+            raise SPDXValueError("Snippet:ByteRange")
+        startpoint = int(range_re.match(parsed).group(1))
+        endpoint = int(range_re.match(parsed).group(2))
         if startpoint <= endpoint:
             doc.snippet[-1].byte_range = (startpoint, endpoint)
         else:
@@ -1627,8 +1630,11 @@ class SnippetBuilder(object):
         Raise SPDXValueError if the data is malformed.
         """
         self.assert_snippet_exists()
-        startpoint = int(parsed.split(":")[0])
-        endpoint = int(parsed.split(":")[-1])
+        range_re = re.compile(r"^(\d+):(\d+)$", re.UNICODE)
+        if not range_re.match(parsed):
+            raise SPDXValueError("Snippet:LineRange")
+        startpoint = int(range_re.match(parsed).group(1))
+        endpoint = int(range_re.match(parsed).group(2))
         if startpoint <= endpoint:
             doc.snippet[-1].line_range = (startpoint, endpoint)
         else:

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -823,6 +823,11 @@ class TestSnippetBuilder(TestCase):
         self.builder.create_snippet(self.document, "SPDXRef-Snippet")
         self.builder.set_snippet_byte_range(self.document, "310:30")
 
+    @testing_utils.raises(builders.SPDXValueError)
+    def test_snippet_byte_range_value_wrong_format(self):
+        self.builder.create_snippet(self.document, "SPDXRef-Snippet")
+        self.builder.set_snippet_byte_range(self.document, "30")
+
     def test_snippet_line_range(self):
         self.builder.create_snippet(self.document, "SPDXRef-Snippet")
         self.builder.set_snippet_line_range(self.document, "5:23")
@@ -835,3 +840,8 @@ class TestSnippetBuilder(TestCase):
     def test_snippet_line_range_value(self):
         self.builder.create_snippet(self.document, "SPDXRef-Snippet")
         self.builder.set_snippet_line_range(self.document, "23:5")
+
+    @testing_utils.raises(builders.SPDXValueError)
+    def test_snippet_line_range_value_wrong_format(self):
+        self.builder.create_snippet(self.document, "SPDXRef-Snippet")
+        self.builder.set_snippet_line_range(self.document, "5:23d")

--- a/tests/test_tag_value_parser.py
+++ b/tests/test_tag_value_parser.py
@@ -50,7 +50,7 @@ review_str = '\n'.join([
 package_str = '\n'.join([
     'PackageName: Test',
     'SPDXID: SPDXRef-Package',
-    'PackageVersion: 1:2.36.1-8+deb11u1',
+    'PackageVersion: 1:22.36.1-8+deb11u1',
     'PackageDownloadLocation: http://example.com/test',
     'FilesAnalyzed: True',
     'PackageSummary: <text>Test package</text>',
@@ -103,7 +103,7 @@ snippet_str = '\n'.join([
     'SnippetFromFileSPDXID: SPDXRef-DoapSource',
     'SnippetLicenseConcluded: Apache-2.0',
     'LicenseInfoInSnippet: Apache-2.0',
-    'SnippetByteRange: 310:420',
+    'SnippetByteRange: 310:420  ',
     'SnippetLineRange: 5:7',
 ])
 
@@ -198,7 +198,7 @@ class TestLexer(TestCase):
         self.token_assert_helper(self.l.token(), 'SPDX_ID', 'SPDXID', 2)
         self.token_assert_helper(self.l.token(), 'LINE', 'SPDXRef-Package', 2)
         self.token_assert_helper(self.l.token(), 'PKG_VERSION', 'PackageVersion', 3)
-        self.token_assert_helper(self.l.token(), 'LINE', '1:2.36.1-8+deb11u1', 3)
+        self.token_assert_helper(self.l.token(), 'LINE', '1:22.36.1-8+deb11u1', 3)
         self.token_assert_helper(self.l.token(), 'PKG_DOWN', 'PackageDownloadLocation', 4)
         self.token_assert_helper(self.l.token(), 'LINE', 'http://example.com/test', 4)
         self.token_assert_helper(self.l.token(), 'PKG_FILES_ANALYZED', 'FilesAnalyzed', 5)
@@ -276,9 +276,9 @@ class TestLexer(TestCase):
                                  'LicenseInfoInSnippet', 8)
         self.token_assert_helper(self.l.token(), 'LINE', 'Apache-2.0', 8)
         self.token_assert_helper(self.l.token(), 'SNIPPET_BYTE_RANGE', 'SnippetByteRange', 9)
-        self.token_assert_helper(self.l.token(), 'RANGE', '310:420', 9)
+        self.token_assert_helper(self.l.token(), 'LINE', '310:420', 9)
         self.token_assert_helper(self.l.token(), 'SNIPPET_LINE_RANGE', 'SnippetLineRange', 10)
-        self.token_assert_helper(self.l.token(), 'RANGE', '5:7', 10)
+        self.token_assert_helper(self.l.token(), 'LINE', '5:7', 10)
 
     def test_annotation(self):
         data = annotation_str
@@ -348,7 +348,7 @@ class TestParser(TestCase):
         assert not error
         assert document.package.name == 'Test'
         assert document.package.spdx_id == 'SPDXRef-Package'
-        assert document.package.version == '1:2.36.1-8+deb11u1'
+        assert document.package.version == '1:22.36.1-8+deb11u1'
         assert len(document.package.licenses_from_files) == 2
         assert (document.package.conc_lics.identifier == 'LicenseRef-2.0 AND Apache-2.0')
         assert document.package.files_analyzed is True


### PR DESCRIPTION
To be able to also parse package versions that might look like a range, e.g. `1:2` I decided to delete the token `RANGE` from the tag-value parser. The build functions for `SnippetByteRange` and `SnippetLineRange` therefore need to check if the parsed value matches the expected pattern and will raise a `SPDXValueError` if not. Since the tests in `test_builder.py` are wrapped in a class that is inherited from `TestCase` I can't use `pytest.mark.parametrize` and additional parameters for the tests `test_snippet_byte_range_value` and `test_snippet_line_range_value`.