### PR TITLE
[fix] use correct value for LicenseListVersion

### DIFF
--- a/src/spdx/writer/tagvalue/creation_info_writer.py
+++ b/src/spdx/writer/tagvalue/creation_info_writer.py
@@ -32,7 +32,7 @@ def write_creation_info(creation_info: CreationInfo, text_output: TextIO):
     write_separator(text_output)
 
     text_output.write("## Creation Information\n")
-    write_value("LicenseListVersion", str(creation_info.spdx_version), text_output)
+    write_value("LicenseListVersion", str(creation_info.license_list_version), text_output)
     for creator in creation_info.creators:
         write_value("Creator", creator.to_serialized_string(), text_output)
     write_value("Created", datetime_to_iso_string(creation_info.created), text_output)


### PR DESCRIPTION
While working on the parser  for tag-value files I came across this little bug. 