### PR TITLE
[issue-228] make type hints in code readable for downstream packages

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,9 @@ include-package-data = true
 [tool.setuptools.packages.find]
 where = ["src"]
 
+[tool.setuptools.package-data]
+"*" = ["py.typed"]
+
 # the default git describe resolves to the tag `python3.6` because the current release tag is not on main
 # by adding "v" the command resolves to the alpha release of 0.7.0 which leads to the desired name spdx-tools-0.7.0
 [tool.setuptools_scm]


### PR DESCRIPTION
We need to add a `py.typed` file to the source directory of the package so that other downstream tools can use the type hints. 
 
For reference: 
- https://mypy.readthedocs.io/en/stable/installed_packages.html#creating-pep-561-compatible-packages
- https://jugmac00.github.io/blog/bite-my-shiny-type-annotated-library/#poetry