### PR TITLE
Fix tag value writer

### DIFF
--- a/src/spdx/writer/tagvalue/creation_info_writer.py
+++ b/src/spdx/writer/tagvalue/creation_info_writer.py
@@ -32,7 +32,7 @@ def write_creation_info(creation_info: CreationInfo, text_output: TextIO):
     write_separator(text_output)
 
     text_output.write("## Creation Information\n")
-    write_value("LicenseListVersion", str(creation_info.license_list_version), text_output)
+    write_value("LicenseListVersion", creation_info.license_list_version, text_output)
     for creator in creation_info.creators:
         write_value("Creator", creator.to_serialized_string(), text_output)
     write_value("Created", datetime_to_iso_string(creation_info.created), text_output)

--- a/tests/spdx/writer/tagvalue/test_creation_info_writer.py
+++ b/tests/spdx/writer/tagvalue/test_creation_info_writer.py
@@ -1,0 +1,44 @@
+# SPDX-FileCopyrightText: 2023 SPDX Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+import datetime
+from unittest.mock import mock_open, patch, call, MagicMock
+
+import pytest
+
+from spdx.model.document import CreationInfo
+from tests.spdx.fixtures import creation_info_fixture, actor_fixture
+
+from spdx.writer.tagvalue.creation_info_writer import write_creation_info
+
+
+@pytest.mark.parametrize("creation_info, expected_calls",
+                         [(creation_info_fixture(), [call("SPDXVersion: SPDX-2.3\n"), call("DataLicense: CC0-1.0\n"),
+                                                     call("SPDXID: SPDXRef-DOCUMENT\n"),
+                                                     call("DocumentName: documentName\n"),
+                                                     call("DocumentNamespace: https://some.namespace\n"),
+                                                     call("DocumentComment: documentComment\n"),
+                                                     call("\n## External Document References\n"), call(
+                                 "ExternalDocumentRef: DocumentRef-external https://namespace.com SHA1: 71c4025dd9897b364f3ebbb42c484ff43d00791c\n"),
+                                                     call("\n"), call("## Creation Information\n"),
+                                                     call("LicenseListVersion: 3.19\n"),
+                                                     call("Creator: Person: creatorName (some@mail.com)\n"),
+                                                     call("Created: 2022-12-01T00:00:00Z\n"),
+                                                     call("CreatorComment: creatorComment\n")]),
+                          (CreationInfo(spdx_version="SPDX-2.3", spdx_id="SPDXRef-DOCUMENT", creators=[actor_fixture()],
+                                        name="Test document", document_namespace="https://namespace.com",
+                                        created=datetime.datetime(2022, 3, 10)),
+                           [call("SPDXVersion: SPDX-2.3\n"), call("DataLicense: CC0-1.0\n"),
+                            call("SPDXID: SPDXRef-DOCUMENT\n"), call("DocumentName: Test document\n"),
+                            call("DocumentNamespace: https://namespace.com\n"), call("\n"),
+                            call("## Creation Information\n"), call("Creator: Person: actorName (some@mail.com)\n"),
+                            call("Created: 2022-03-10T00:00:00Z\n")])])
+def test_creation_info_writer(creation_info, expected_calls):
+    mock: MagicMock = mock_open()
+    with patch(f"{__name__}.open", mock, create=True):
+        with open("foo", "w") as file:
+            write_creation_info(creation_info, file)
+
+    mock.assert_called_once_with("foo", "w")
+    handle = mock()
+    handle.write.assert_has_calls(expected_calls)

--- a/tests/spdx/writer/tagvalue/test_package_writer.py
+++ b/tests/spdx/writer/tagvalue/test_package_writer.py
@@ -8,7 +8,7 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-from unittest.mock import patch, mock_open, call
+from unittest.mock import patch, mock_open, call, MagicMock
 
 from tests.spdx.fixtures import package_fixture
 from spdx.writer.tagvalue.package_writer import write_package
@@ -17,40 +17,40 @@ from spdx.writer.tagvalue.package_writer import write_package
 def test_package_writer():
     package = package_fixture()
 
-    m = mock_open()
-    with patch('{}.open'.format(__name__), m, create=True):
-        with open('foo', 'w') as h:
-            write_package(package, h)
+    mock: MagicMock = mock_open()    
+    with patch(f"{__name__}.open", mock, create=True):
+        with open("foo", "w") as file:
+            write_package(package, file)
 
-    m.assert_called_once_with('foo', 'w')
-    handle = m()
+    mock.assert_called_once_with("foo", "w")
+    handle = mock()
     handle.write.assert_has_calls(
-        [call('## Package Information\n'),
-         call('PackageName: packageName\n'),
-         call('SPDXID: SPDXRef-Package\n'),
-         call('PackageVersion: 12.2\n'),
-         call('PackageFileName: ./packageFileName\n'),
-         call('PackageSupplier: Person: supplierName (some@mail.com)\n'),
-         call('PackageOriginator: Person: originatorName (some@mail.com)\n'),
-         call('PackageDownloadLocation: https://download.com\n'),
-         call('FilesAnalyzed: True\n'),
-         call('PackageVerificationCode: 85ed0817af83a24ad8da68c2b5094de69833983c (excludes: ./exclude.py)\n'),
-         call('PackageChecksum: SHA1: 71c4025dd9897b364f3ebbb42c484ff43d00791c\n'),
-         call('PackageHomePage: https://homepage.com\n'),
-         call('PackageSourceInfo: sourceInfo\n'),
-         call('PackageLicenseConcluded: MIT AND GPL-2.0-only\n'),
-         call('PackageLicenseInfoFromFiles: MIT\n'),
-         call('PackageLicenseInfoFromFiles: GPL-2.0-only\n'),
-         call('PackageLicenseDeclared: MIT AND GPL-2.0-only\n'),
-         call('PackageLicenseComments: packageLicenseComment\n'),
-         call('PackageCopyrightText: packageCopyrightText\n'),
-         call('PackageSummary: packageSummary\n'),
-         call('PackageDescription: packageDescription\n'),
-         call('PackageComment: packageComment\n'),
-         call('ExternalRef: PACKAGE-MANAGER maven-central org.apache.tomcat:tomcat:9.0.0.M4\n'),
-         call('ExternalRefComment: externalPackageRefComment\n'),
-         call('PackageAttributionText: packageAttributionText\n'),
-         call('PrimaryPackagePurpose: SOURCE\n'),
-         call('ReleaseDate: 2022-12-01T00:00:00Z\n'),
-         call('BuiltDate: 2022-12-02T00:00:00Z\n'),
-         call('ValidUntilDate: 2022-12-03T00:00:00Z\n')])
+        [call("## Package Information\n"),
+         call("PackageName: packageName\n"),
+         call("SPDXID: SPDXRef-Package\n"),
+         call("PackageVersion: 12.2\n"),
+         call("PackageFileName: ./packageFileName\n"),
+         call("PackageSupplier: Person: supplierName (some@mail.com)\n"),
+         call("PackageOriginator: Person: originatorName (some@mail.com)\n"),
+         call("PackageDownloadLocation: https://download.com\n"),
+         call("FilesAnalyzed: True\n"),
+         call("PackageVerificationCode: 85ed0817af83a24ad8da68c2b5094de69833983c (excludes: ./exclude.py)\n"),
+         call("PackageChecksum: SHA1: 71c4025dd9897b364f3ebbb42c484ff43d00791c\n"),
+         call("PackageHomePage: https://homepage.com\n"),
+         call("PackageSourceInfo: sourceInfo\n"),
+         call("PackageLicenseConcluded: MIT AND GPL-2.0-only\n"),
+         call("PackageLicenseInfoFromFiles: MIT\n"),
+         call("PackageLicenseInfoFromFiles: GPL-2.0-only\n"),
+         call("PackageLicenseDeclared: MIT AND GPL-2.0-only\n"),
+         call("PackageLicenseComments: packageLicenseComment\n"),
+         call("PackageCopyrightText: packageCopyrightText\n"),
+         call("PackageSummary: packageSummary\n"),
+         call("PackageDescription: packageDescription\n"),
+         call("PackageComment: packageComment\n"),
+         call("ExternalRef: PACKAGE-MANAGER maven-central org.apache.tomcat:tomcat:9.0.0.M4\n"),
+         call("ExternalRefComment: externalPackageRefComment\n"),
+         call("PackageAttributionText: packageAttributionText\n"),
+         call("PrimaryPackagePurpose: SOURCE\n"),
+         call("ReleaseDate: 2022-12-01T00:00:00Z\n"),
+         call("BuiltDate: 2022-12-02T00:00:00Z\n"),
+         call("ValidUntilDate: 2022-12-03T00:00:00Z\n")])


### PR DESCRIPTION
Due to the type conversion before entering the `set_value` method a `None` value for `LicenseListVersion` was written to the outptut file. The `f-string` calls the implemented `str`-conversion for the instance of `Version`, so we don't need to do this conversion explicitly. 

To improve the test coverage here, I also added a test.