### PR TITLE
[issue-427] adapt bump methods to allow bumping of actors within other elements

### DIFF
--- a/src/spdx3/bump_from_spdx2/annotation.py
+++ b/src/spdx3/bump_from_spdx2/annotation.py
@@ -8,6 +8,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from copy import deepcopy
 
 from spdx.model.annotation import Annotation as Spdx2_Annotation
 from spdx3.bump_from_spdx2.message import print_missing_conversion
@@ -19,6 +20,7 @@ from spdx3.payload import Payload
 def bump_annotation(spdx2_annotation: Spdx2_Annotation, payload: Payload, creation_info: CreationInformation,
                     counter: int):
     spdx_id: str = f"SPDXRef-Annotation-{counter}"
+    creation_info = deepcopy(creation_info)
     creation_info.created = spdx2_annotation.annotation_date
     # creation_info.created_by = bump_actor(spdx2_annotation.annotator)   waiting for entity implementation
     print_missing_conversion("annotation.annotator", 1, "of Entity")

--- a/src/spdx3/bump_from_spdx2/annotation.py
+++ b/src/spdx3/bump_from_spdx2/annotation.py
@@ -13,9 +13,11 @@ from spdx.model.annotation import Annotation as Spdx2_Annotation
 from spdx3.bump_from_spdx2.message import print_missing_conversion
 from spdx3.model.annotation import Annotation, AnnotationType
 from spdx3.model.creation_information import CreationInformation
+from spdx3.payload import Payload
 
 
-def bump_annotation(spdx2_annotation: Spdx2_Annotation, creation_info: CreationInformation, counter: int) -> Annotation:
+def bump_annotation(spdx2_annotation: Spdx2_Annotation, payload: Payload, creation_info: CreationInformation,
+                    counter: int):
     spdx_id: str = f"SPDXRef-Annotation-{counter}"
     creation_info.created = spdx2_annotation.annotation_date
     # creation_info.created_by = bump_actor(spdx2_annotation.annotator)   waiting for entity implementation
@@ -24,4 +26,4 @@ def bump_annotation(spdx2_annotation: Spdx2_Annotation, creation_info: CreationI
     subject: str = spdx2_annotation.spdx_id
     statement: str = spdx2_annotation.annotation_comment
 
-    return Annotation(spdx_id, creation_info, annotation_type, subject, statement=statement)
+    payload.add_element(Annotation(spdx_id, creation_info, annotation_type, subject, statement=statement))

--- a/src/spdx3/bump_from_spdx2/file.py
+++ b/src/spdx3/bump_from_spdx2/file.py
@@ -13,9 +13,10 @@ from spdx3.bump_from_spdx2.checksum import bump_checksum
 from spdx3.bump_from_spdx2.message import print_missing_conversion
 from spdx3.model.creation_information import CreationInformation
 from spdx3.model.software.file import File
+from spdx3.payload import Payload
 
 
-def bump_file(spdx2_file: Spdx2_File, creation_information: CreationInformation) -> File:
+def bump_file(spdx2_file: Spdx2_File, payload: Payload, creation_information: CreationInformation):
     name = spdx2_file.name
     spdx_id = spdx2_file.spdx_id
     integrity_methods = [bump_checksum(checksum) for checksum in spdx2_file.checksums]
@@ -30,6 +31,5 @@ def bump_file(spdx2_file: Spdx2_File, creation_information: CreationInformation)
     print_missing_conversion("file.notice, file.contributors, file.attribution_texts", 0,
                              "missing definition for license profile")
 
-    file = File(spdx_id, creation_info=creation_information, name=name, comment=comment,
-                verified_using=integrity_methods)
-    return file
+    payload.add_element(File(spdx_id, creation_info=creation_information, name=name, comment=comment,
+                             verified_using=integrity_methods))

--- a/src/spdx3/bump_from_spdx2/package.py
+++ b/src/spdx3/bump_from_spdx2/package.py
@@ -15,9 +15,10 @@ from spdx3.bump_from_spdx2.message import print_missing_conversion
 from spdx3.model.creation_information import CreationInformation
 from spdx3.model.software.package import Package
 from spdx3.model.software.software_purpose import SoftwarePurpose
+from spdx3.payload import Payload
 
 
-def bump_package(spdx2_package: Spdx2_Package, creation_information: CreationInformation) -> Package:
+def bump_package(spdx2_package: Spdx2_Package, payload: Payload, creation_information: CreationInformation):
     spdx_id = spdx2_package.spdx_id
     name = spdx2_package.name
     download_location = handle_no_assertion_or_none(spdx2_package.download_location, "package.download_location")
@@ -49,7 +50,6 @@ def bump_package(spdx2_package: Spdx2_Package, creation_information: CreationInf
                            spdx2_package.primary_package_purpose.name]] if spdx2_package.primary_package_purpose else []
     print_missing_conversion("package2.release_date, package2.built_date, package2.valid_until_date", 0)
 
-    package = Package(spdx_id, creation_information, name, verified_using=integrity_methods,
-                      download_location=download_location, homepage=homepage, summary=summary, description=description,
-                      comment=comment, package_purpose=package_purpose)
-    return package
+    payload.add_element(Package(spdx_id, creation_information, name, verified_using=integrity_methods,
+                                download_location=download_location, homepage=homepage, summary=summary,
+                                description=description, comment=comment, package_purpose=package_purpose))

--- a/src/spdx3/bump_from_spdx2/relationship.py
+++ b/src/spdx3/bump_from_spdx2/relationship.py
@@ -16,10 +16,11 @@ from spdx.model.spdx_no_assertion import SpdxNoAssertion
 from spdx.model.spdx_none import SpdxNone
 from spdx3.model.creation_information import CreationInformation
 from spdx3.model.relationship import Relationship, RelationshipType, RelationshipCompleteness
+from spdx3.payload import Payload
 
 
-def bump_relationship(spdx2_relationship: Spdx2_Relationship,
-                      creation_information: CreationInformation, counter: int) -> Relationship:
+def bump_relationship(spdx2_relationship: Spdx2_Relationship, payload: Payload,
+                      creation_information: CreationInformation, counter: int):
     relationship_type, swap_direction = bump_relationship_type(spdx2_relationship.relationship_type)
 
     if isinstance(spdx2_relationship.related_spdx_element_id,
@@ -38,10 +39,8 @@ def bump_relationship(spdx2_relationship: Spdx2_Relationship,
         to = [spdx2_relationship.related_spdx_element_id]
     comment = spdx2_relationship.comment
 
-    relationship = Relationship(f"SPDXRef-Relationship-{counter}", creation_information, from_element, to,
-                                relationship_type, comment=comment, completeness=completeness)
-
-    return relationship
+    payload.add_element(Relationship(f"SPDXRef-Relationship-{counter}", creation_information, from_element, to,
+                                     relationship_type, comment=comment, completeness=completeness))
 
 
 def bump_relationship_type(spdx2_relationship_type: Spdx2_RelationshipType) -> Optional[Tuple[RelationshipType, bool]]:

--- a/src/spdx3/bump_from_spdx2/snippet.py
+++ b/src/spdx3/bump_from_spdx2/snippet.py
@@ -12,9 +12,10 @@ from spdx.model.snippet import Snippet as Spdx2_Snippet
 from spdx3.bump_from_spdx2.message import print_missing_conversion
 from spdx3.model.creation_information import CreationInformation
 from spdx3.model.software.snippet import Snippet
+from spdx3.payload import Payload
 
 
-def bump_snippet(spdx2_snippet: Spdx2_Snippet, creation_information: CreationInformation) -> Snippet:
+def bump_snippet(spdx2_snippet: Spdx2_Snippet, payload: Payload, creation_information: CreationInformation):
     spdx_id = spdx2_snippet.spdx_id
     print_missing_conversion("snippet.file_spdx_id", 0)
     byte_range = spdx2_snippet.byte_range
@@ -26,7 +27,5 @@ def bump_snippet(spdx2_snippet: Spdx2_Snippet, creation_information: CreationInf
 
     print_missing_conversion("snippet.attribution_texts", 0, "missing definitions for license profile")
 
-    snippet = Snippet(spdx_id=spdx_id, creation_info=creation_information, byte_range=byte_range, line_range=line_range,
-                      comment=comment, name=name)
-
-    return snippet
+    payload.add_element(Snippet(spdx_id=spdx_id, creation_info=creation_information, byte_range=byte_range,
+                                line_range=line_range, comment=comment, name=name))

--- a/src/spdx3/bump_from_spdx2/spdx_document.py
+++ b/src/spdx3/bump_from_spdx2/spdx_document.py
@@ -17,43 +17,35 @@ from spdx3.bump_from_spdx2.relationship import bump_relationship
 from spdx3.bump_from_spdx2.snippet import bump_snippet
 from spdx3.model.creation_information import CreationInformation
 from spdx3.model.spdx_document import SpdxDocument
-from spdx3.spdx_id_map import SpdxIdMap
+from spdx3.payload import Payload
 
 """ We want to implement a bump_from_spdx2 from the data model in src.spdx to the data model in src.spdx3.
     As there are many fundamental differences between these version we want each bump_from_spdx2 method to take
-    the object from src.spdx and return all objects that the input is translated to."""
+    the object from src.spdx and add all objects that the input is translated to into the payload."""
 
 
-def bump_spdx_document(document: Spdx2_Document) -> SpdxIdMap:
-    spdx_id_map = SpdxIdMap()
+def bump_spdx_document(document: Spdx2_Document) -> Payload:
+    payload = Payload()
     spdx_document: SpdxDocument = bump_creation_information(document.creation_info)
     creation_info: CreationInformation = spdx_document.creation_info
 
-    spdx_id_map.add_element(spdx_document)
+    payload.add_element(spdx_document)
 
     for spdx2_package in document.packages:
-        package = bump_package(spdx2_package, creation_info)
-        spdx_id_map.add_element(package)
-        spdx_document.elements.append(package.spdx_id)
+        bump_package(spdx2_package, payload, creation_info)
 
     for spdx2_file in document.files:
-        file = bump_file(spdx2_file, creation_info)
-        spdx_id_map.add_element(file)
-        spdx_document.elements.append(file.spdx_id)
+        bump_file(spdx2_file, payload, creation_info)
 
     for spdx2_snippet in document.snippets:
-        snippet = bump_snippet(spdx2_snippet, creation_info)
-        spdx_id_map.add_element(snippet)
-        spdx_document.elements.append(snippet.spdx_id)
+        bump_snippet(spdx2_snippet, payload, creation_info)
 
     for counter, spdx2_relationship in enumerate(document.relationships):
-        relationship = bump_relationship(spdx2_relationship, creation_info, counter)
-        spdx_id_map.add_element(relationship)
-        spdx_document.elements.append(relationship.spdx_id)
+        bump_relationship(spdx2_relationship, payload, creation_info, counter)
 
     for counter, spdx2_annotation in enumerate(document.annotations):
-        annotation = bump_annotation(spdx2_annotation, creation_info, counter)
-        spdx_id_map.add_element(annotation)
-        spdx_document.elements.append(annotation.spdx_id)
+        bump_annotation(spdx2_annotation, payload, creation_info, counter)
 
-    return spdx_id_map
+    spdx_document.elements = [spdx_id for spdx_id in payload.get_full_map() if spdx_id != spdx_document.spdx_id]
+
+    return payload

--- a/src/spdx3/clitools/pyspdxtools3.py
+++ b/src/spdx3/clitools/pyspdxtools3.py
@@ -18,8 +18,8 @@ from spdx.parser.parse_anything import parse_file
 from spdx.validation.document_validator import validate_full_spdx_document
 from spdx.validation.validation_message import ValidationMessage
 from spdx3.bump_from_spdx2.spdx_document import bump_spdx_document
-from spdx3.spdx_id_map import SpdxIdMap
-from spdx3.writer.console.spdx_id_map_writer import write_spdx_id_map
+from spdx3.payload import Payload
+from spdx3.writer.console.spdx_id_map_writer import write_payload
 
 
 @click.command()
@@ -50,8 +50,8 @@ def main(infile: str, outfile: str, version: str, novalidation: bool):
                 print("The document is valid.", file=sys.stderr)
 
         if outfile == "-":
-            spdx_id_map: SpdxIdMap = bump_spdx_document(document)
-            write_spdx_id_map(spdx_id_map, sys.stdout)
+            payload: Payload = bump_spdx_document(document)
+            write_payload(payload, sys.stdout)
 
     except NotImplementedError as err:
         print(err.args[0])

--- a/src/spdx3/payload.py
+++ b/src/spdx3/payload.py
@@ -13,7 +13,7 @@ from typing import Dict
 from spdx3.model.element import Element
 
 
-class SpdxIdMap:
+class Payload:
     _spdx_id_map: Dict[str, Element]
 
     def __init__(self, spdx_id_map: Dict[str, Element] = None):

--- a/src/spdx3/writer/console/spdx_id_map_writer.py
+++ b/src/spdx3/writer/console/spdx_id_map_writer.py
@@ -19,7 +19,7 @@ from spdx3.model.software.package import Package
 from spdx3.model.software.sbom import Sbom
 from spdx3.model.software.snippet import Snippet
 from spdx3.model.spdx_document import SpdxDocument
-from spdx3.spdx_id_map import SpdxIdMap
+from spdx3.payload import Payload
 from spdx3.writer.console.annotation_writer import write_annotation
 from spdx3.writer.console.bom_writer import write_bom
 from spdx3.writer.console.bundle_writer import write_bundle
@@ -43,8 +43,8 @@ MAP_CLASS_TO_WRITE_METHOD = {
 }
 
 
-def write_spdx_id_map(spdx_id_map: SpdxIdMap, text_output: TextIO):
-    for element in spdx_id_map.get_full_map().values():
+def write_payload(payload: Payload, text_output: TextIO):
+    for element in payload.get_full_map().values():
         write_method = MAP_CLASS_TO_WRITE_METHOD[type(element)]
         write_method(element, text_output)
         text_output.write("\n")

--- a/tests/spdx/fixtures.py
+++ b/tests/spdx/fixtures.py
@@ -128,7 +128,7 @@ def snippet_fixture(spdx_id="SPDXRef-Snippet", file_spdx_id="SPDXRef-File", byte
 
 
 def annotation_fixture(spdx_id="SPDXRef-File", annotation_type=AnnotationType.REVIEW,
-                       annotator=actor_fixture(name="annotatorName"), annotation_date=datetime(2022, 12, 1),
+                       annotator=actor_fixture(name="annotatorName"), annotation_date=datetime(2022, 12, 24),
                        annotation_comment="annotationComment") -> Annotation:
     return Annotation(spdx_id=spdx_id, annotation_type=annotation_type, annotator=annotator,
                       annotation_date=annotation_date, annotation_comment=annotation_comment)

--- a/tests/spdx/writer/json/expected_results/expected.json
+++ b/tests/spdx/writer/json/expected_results/expected.json
@@ -29,7 +29,7 @@
             "SPDXID": "SPDXRef-File",
             "annotations": [
                 {
-                    "annotationDate": "2022-12-01T00:00:00Z",
+                    "annotationDate": "2022-12-24T00:00:00Z",
                     "annotationType": "REVIEW",
                     "annotator": "Person: annotatorName (some@mail.com)",
                     "comment": "annotationComment"

--- a/tests/spdx3/bump/test_file_bump.py
+++ b/tests/spdx3/bump/test_file_bump.py
@@ -13,6 +13,7 @@ from unittest import mock
 from spdx3.bump_from_spdx2.file import bump_file
 from spdx3.model.hash import Hash, HashAlgorithm
 from spdx3.model.software.file import File
+from spdx3.payload import Payload
 
 from tests.spdx.fixtures import file_fixture
 from spdx.model.file import File as Spdx2_File
@@ -22,7 +23,9 @@ def test_bump_file(creation_information):
     spdx2_file: Spdx2_File = file_fixture()
     integrity_method: Hash = Hash(HashAlgorithm.SHA1, "71c4025dd9897b364f3ebbb42c484ff43d00791c")
 
-    file: File = bump_file(spdx2_file, creation_information=creation_information)
-
+    payload = Payload()
+    bump_file(spdx2_file, payload, creation_information=creation_information)
+    file = payload.get_element(file_fixture().spdx_id)
+    assert isinstance(file, File)
     assert file.spdx_id == "SPDXRef-File"
     assert file.verified_using == [integrity_method]

--- a/tests/spdx3/bump/test_package_bump.py
+++ b/tests/spdx3/bump/test_package_bump.py
@@ -12,6 +12,7 @@ from unittest import mock
 
 from spdx3.bump_from_spdx2.package import bump_package
 from spdx3.model.software.package import Package
+from spdx3.payload import Payload
 
 from tests.spdx.fixtures import package_fixture
 from spdx.model.package import Package as Spdx2_Package
@@ -21,7 +22,9 @@ from spdx.model.package import Package as Spdx2_Package
 def test_bump_package(creation_information):
     spdx2_package: Spdx2_Package = package_fixture()
 
-    package: Package = bump_package(spdx2_package, creation_information=creation_information)
-
+    payload = Payload()
+    bump_package(spdx2_package, payload, creation_information=creation_information)
+    package = payload.get_element(package_fixture().spdx_id)
+    assert isinstance(package, Package)
 
     assert package.spdx_id == "SPDXRef-Package"

--- a/tests/spdx3/bump/test_snippet_bump.py
+++ b/tests/spdx3/bump/test_snippet_bump.py
@@ -11,6 +11,7 @@
 from unittest import mock
 
 from spdx3.bump_from_spdx2.snippet import bump_snippet
+from spdx3.payload import Payload
 from tests.spdx.fixtures import snippet_fixture
 from spdx.model.snippet import Snippet as Spdx2_Snippet
 from spdx3.model.software.snippet import Snippet
@@ -20,6 +21,8 @@ from spdx3.model.software.snippet import Snippet
 def test_bump_snippet(creation_information):
     spdx2_snippet: Spdx2_Snippet = snippet_fixture()
 
-    snippet: Snippet = bump_snippet(spdx2_snippet, creation_information=creation_information)
-
+    payload = Payload()
+    bump_snippet(spdx2_snippet, payload, creation_information=creation_information)
+    snippet = payload.get_element(snippet_fixture().spdx_id)
+    assert isinstance(snippet, Snippet)
     assert snippet.spdx_id == "SPDXRef-Snippet"

--- a/tests/spdx3/bump/test_spdx_document_bump.py
+++ b/tests/spdx3/bump/test_spdx_document_bump.py
@@ -13,18 +13,17 @@ import sys
 from spdx.model.document import Document as Spdx2_Document
 
 from spdx3.bump_from_spdx2.spdx_document import bump_spdx_document
-from spdx3.spdx_id_map import SpdxIdMap
-from spdx3.writer.console.spdx_id_map_writer import write_spdx_id_map
-from tests.spdx.fixtures import document_fixture
+from spdx3.payload import Payload
+from spdx3.writer.console.spdx_id_map_writer import write_payload
+from tests.spdx.fixtures import document_fixture, creation_info_fixture, annotation_fixture
 
 
 def test_bump_spdx_document():
     spdx2_document: Spdx2_Document = document_fixture()
 
-    spdx_id_map: SpdxIdMap = bump_spdx_document(spdx2_document)
+    payload: Payload = bump_spdx_document(spdx2_document)
 
-    write_spdx_id_map(spdx_id_map, sys.stdout)
+    write_payload(payload, sys.stdout)
 
-    assert "SPDXRef-Package" in list(spdx_id_map.get_full_map().keys())
-    assert len(
-        spdx_id_map.get_full_map().values()) == 6
+    assert "SPDXRef-Package" in payload.get_full_map()
+    assert len(payload.get_full_map()) == 6

--- a/tests/spdx3/bump/test_spdx_document_bump.py
+++ b/tests/spdx3/bump/test_spdx_document_bump.py
@@ -27,3 +27,7 @@ def test_bump_spdx_document():
 
     assert "SPDXRef-Package" in payload.get_full_map()
     assert len(payload.get_full_map()) == 6
+
+    #this is more of a temporary test to make sure the dates don't get messed up again
+    assert payload.get_element("SPDXRef-DOCUMENT").creation_info.created == creation_info_fixture().created
+    assert payload.get_element("SPDXRef-Annotation-0").creation_info.created == annotation_fixture().annotation_date


### PR DESCRIPTION
also change `spdx_id_map` to `payload` and fix a bug where `bump_annotation` changed the `creation_info`