### PR TITLE
fix the version of typeguard

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 ]
 urls = { Homepage = "https://github.com/spdx/tools-python" }
 requires-python = ">=3.7"
-dependencies = ["click", "pyyaml", "xmltodict", "rdflib", "typeguard", "uritools", "license_expression", "ply"]
+dependencies = ["click", "pyyaml", "xmltodict", "rdflib", "typeguard==2.13.3", "uritools", "license_expression", "ply"]
 dynamic = ["version"]
 
 [project.optional-dependencies]


### PR DESCRIPTION
typeguard 3.0.0 introduces breaking changes, but so far we are not certain that we need any new features of it.