### PR TITLE
Revise a test document creation info time to have second fractions

### DIFF
--- a/spdx/utils.py
+++ b/spdx/utils.py
@@ -36,7 +36,7 @@ def datetime_iso_format(date):
 
 # Matches an iso 8601 date representation
 DATE_ISO_REGEX = re.compile(
-    r"(\d\d\d\d)-(\d\d)-(\d\d)T(\d\d):(\d\d):(\d\d)Z", re.UNICODE
+    r"(\d\d\d\d)-(\d\d)-(\d\d)T(\d\d):(\d\d):(\d\d)(\.[\d]*)?Z", re.UNICODE
 )
 
 # Groups for retrieving values from DATE_ISO_REGEX matches.
@@ -60,8 +60,8 @@ def datetime_from_iso_format(string):
             month=int(match.group(DATE_ISO_MONTH_GRP)),
             day=int(match.group(DATE_ISO_DAY_GRP)),
             hour=int(match.group(DATE_ISO_HOUR_GRP)),
-            second=int(match.group(DATE_ISO_SEC_GRP)),
             minute=int(match.group(DATE_ISO_MIN_GRP)),
+            second=int(match.group(DATE_ISO_SEC_GRP)),
         )
         return date
     else:

--- a/tests/data/formats/SPDXJSONExample-v2.2.spdx.json
+++ b/tests/data/formats/SPDXJSONExample-v2.2.spdx.json
@@ -3,7 +3,7 @@
   "spdxVersion" : "SPDX-2.2",
   "creationInfo" : {
     "comment" : "This package has been shipped in source and binary form.\nThe binaries were created with gcc 4.5.1 and expect to link to\ncompatible system run time libraries.",
-    "created" : "2010-01-29T18:30:22Z",
+    "created" : "2023-03-17T19:44:10.100000Z",
     "creators" : [ "Tool: LicenseFind-1.0", "Organization: ExampleCodeInspect ()", "Person: Jane Doe ()" ],
     "licenseListVersion" : "3.9"
   },


### PR DESCRIPTION
Fix #527

Two changes:

- Implements an 8601 timestamp with fractions of a second in one of the test documents
- Revises the 8601 regular expression to allow fractions of a second

I also moved around one code line because it seemed to be out of order.