### PR TITLE
Change error messages related to ISO 8601

### DIFF
--- a/spdx/parsers/rdf.py
+++ b/spdx/parsers/rdf.py
@@ -36,7 +36,7 @@ ERROR_MESSAGES = {
     "DOC_NAMESPACE_VALUE": 'Invalid DocumentNamespace value {0}, must contain a scheme (e.g. "https:") '
     'and should not contain the "#" delimiter.',
     "LL_VALUE": "Invalid licenseListVersion '{0}' must be of the format N.N where N is a number",
-    "CREATED_VALUE": "Invalid created value '{0}' must be date in ISO 8601 format.",
+    "CREATED_VALUE": "Invalid created value '{0}' is not in 'YYYY-MM-DDThh:mm:ssZ' format.",
     "CREATOR_VALUE": "Invalid creator value '{0}' must be Organization, Tool or Person.",
     "EXT_DOC_REF_VALUE": "Failed to extract {0} from ExternalDocumentRef.",
     "PKG_SPDX_ID_VALUE": 'SPDXID must be "SPDXRef-[idstring]" where [idstring] is a unique string containing '
@@ -56,9 +56,9 @@ ERROR_MESSAGES = {
     "FILE_TYPE": "Unknown file type.",
     "FILE_SINGLE_LICS": "File concluded license must be a license url or spdx:noassertion or spdx:none.",
     "REVIEWER_VALUE": "Invalid reviewer value '{0}' must be Organization, Tool or Person.",
-    "REVIEW_DATE": "Invalid review date value '{0}' must be date in ISO 8601 format.",
+    "REVIEW_DATE": "Invalid review date value '{0}' is not in 'YYYY-MM-DDThh:mm:ssZ' format.",
     "ANNOTATOR_VALUE": "Invalid annotator value '{0}' must be Organization, Tool or Person.",
-    "ANNOTATION_DATE": "Invalid annotation date value '{0}' must be date in ISO 8601 format.",
+    "ANNOTATION_DATE": "Invalid annotation date value '{0}' is not in 'YYYY-MM-DDThh:mm:ssZ' format.",
     "SNIPPET_SPDX_ID_VALUE": 'SPDXID must be "SPDXRef-[idstring]" where [idstring] is a unique string '
     'containing letters, numbers, ".", "-".',
     "SNIPPET_SINGLE_LICS": "Snippet Concluded License must be a license url or spdx:noassertion or spdx:none.",

--- a/spdx/parsers/tagvalue.py
+++ b/spdx/parsers/tagvalue.py
@@ -28,7 +28,7 @@ ERROR_MESSAGES = {
     "TOOL_VALUE": "Invalid tool value {0} at line: {1}",
     "ORG_VALUE": "Invalid organization value {0} at line: {1}",
     "PERSON_VALUE": "Invalid person value {0} at line: {1}",
-    "CREATED_VALUE_TYPE": "Created value must be date in ISO 8601 format, line: {0}",
+    "CREATED_VALUE_TYPE": "Created value must be in 'YYYY-MM-DDThh:mm:ssZ' format, line: {0}",
     "MORE_THAN_ONE": "Only one {0} allowed, extra at line: {1}",
     "CREATOR_COMMENT_VALUE_TYPE": "CreatorComment value must be free form text between <text></text> tags or"
                                   "single line of text, line:{0}",
@@ -50,11 +50,11 @@ ERROR_MESSAGES = {
                                 'and should not contain the "#" delimiter, line: {0}',
     "REVIEWER_VALUE_TYPE": "Invalid Reviewer value must be a Person, Organization or Tool. Line: {0}",
     "CREATOR_VALUE_TYPE": "Invalid Reviewer value must be a Person, Organization or Tool. Line: {0}",
-    "REVIEW_DATE_VALUE_TYPE": "ReviewDate value must be date in ISO 8601 format, line: {0}",
+    "REVIEW_DATE_VALUE_TYPE": "ReviewDate value must be in 'YYYY-MM-DDThh:mm:ssZ' format, line: {0}",
     "REVIEW_COMMENT_VALUE_TYPE": "ReviewComment value must be free form text between <text></text> tags"
                                  "or single line of text, line:{0}",
     "ANNOTATOR_VALUE_TYPE": "Invalid Annotator value must be a Person, Organization or Tool. Line: {0}",
-    "ANNOTATION_DATE_VALUE_TYPE": "AnnotationDate value must be date in ISO 8601 format, line: {0}",
+    "ANNOTATION_DATE_VALUE_TYPE": "AnnotationDate value must be in 'YYYY-MM-DDThh:mm:ssZ' format, line: {0}",
     "ANNOTATION_COMMENT_VALUE_TYPE": "AnnotationComment value must be free form text between <text></text> tags"
                                      "or single line of text, line:{0}",
     "ANNOTATION_TYPE_VALUE": 'AnnotationType must be "REVIEW" or "OTHER". Line: {0}',
@@ -89,9 +89,9 @@ ERROR_MESSAGES = {
     "PKG_VERF_CODE_VALUE": "VerificationCode doesn't match verifcode form, line:{0}",
     "PRIMARY_PACKAGE_PURPOSE_VALUE": 'PrimaryPackagePurpose must be one of APPLICATION, FRAMEWORK, LIBRARY, CONTAINER, '
                                      'OPERATING-SYSTEM, DEVICE, FIRMWARE, SOURCE, ARCHIVE, FILE, INSTALL, OTHER',
-    "BUILT_DATE_VALUE_TYPE": "Built date value must be date in ISO 8601 format, line: {0}",
-    "RELEASE_DATE_VALUE_TYPE": "Release date value must be date in ISO 8601 format, line: {0}",
-    "VALID_UNTIL_DATE_VALUE_TYPE": "Valid until date value must be date in ISO 8601 format, line: {0}",
+    "BUILT_DATE_VALUE_TYPE": "Built date value must be in 'YYYY-MM-DDThh:mm:ssZ' format, line: {0}",
+    "RELEASE_DATE_VALUE_TYPE": "Release date value must be in 'YYYY-MM-DDThh:mm:ssZ' format, line: {0}",
+    "VALID_UNTIL_DATE_VALUE_TYPE": "Valid until date value must be in 'YYYY-MM-DDThh:mm:ssZ' format, line: {0}",
     "FILE_NAME_VALUE": "FileName must be a single line of text, line: {0}",
     "FILE_COMMENT_VALUE": "FileComment must be free form text or single line of text, line:{0}",
     "FILE_TYPE_VALUE": 'FileType must be one of SOURCE, BINARY, ARCHIVE, APPLICATION, AUDIO, IMAGE, TEXT, VIDEO, '

--- a/spdx/utils.py
+++ b/spdx/utils.py
@@ -34,7 +34,7 @@ def datetime_iso_format(date):
     return date.isoformat() + "Z"
 
 
-# Matches an iso 8601 date representation
+# Matches an ISO-8601 date representation without fractional seconds
 DATE_ISO_REGEX = re.compile(
     r"(\d\d\d\d)-(\d\d)-(\d\d)T(\d\d):(\d\d):(\d\d)Z", re.UNICODE
 )


### PR DESCRIPTION
Fix #529.

Because the SPDX specification uses a subset of ISO-8601 for datetime values, error messages that request the user use ISO-8601 dates are incorrect. These changes make clear to the user the exact format, as dictated by the SPDX specification, that dates should be specified in.

I also changed one comment in `utils.py` to make clear to future readers of the codebase what `DATE_ISO_REGEX` represents.