### PR TITLE
small changes to tag-value lexer/parser

### DIFF
--- a/src/spdx/parser/tagvalue/lexer.py
+++ b/src/spdx/parser/tagvalue/lexer.py
@@ -14,7 +14,7 @@ from ply import lex
 from ply.lex import TOKEN
 
 
-class SPDXLexer(object):
+class SPDXLexer:
     reserved = {
         # Top level fields
         "SPDXVersion": "DOC_VERSION",
@@ -107,7 +107,7 @@ class SPDXLexer(object):
                  "UNKNOWN_TAG",
                  "ORGANIZATION_VALUE",
                  "PERSON_VALUE",
-                 "DATE",
+                 "ISO8601_DATE",
                  "LINE",
                  "CHECKSUM"
              ] + list(reserved.values())
@@ -158,7 +158,7 @@ class SPDXLexer(object):
         return t
 
     @TOKEN(r":\s*\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\dZ")
-    def t_DATE(self, t):
+    def t_ISO8601_DATE(self, t):
         t.value = t.value[1:].strip()
         return t
 

--- a/src/spdx/parser/tagvalue/parser.py
+++ b/src/spdx/parser/tagvalue/parser.py
@@ -44,7 +44,7 @@ ELEMENT_EXPECTED_START_TAG = dict(File="FileName", Annotation="Annotator", Relat
                                   Snippet="SnippetSPDXID", Package="PackageName", ExtractedLicensingInfo="LicenseID")
 
 
-class Parser(object):
+class Parser:
     tokens: List[str]
     logger: Logger
     current_element: Dict[str, Any]
@@ -169,7 +169,7 @@ class Parser(object):
         if self.check_that_current_element_matches_class_for_value(TAG_DATA_MODEL_FIELD[p[1]][0], p.lineno(1)):
             set_value(p, self.current_element)
 
-    @grammar_rule("unknown_tag : UNKNOWN_TAG text_or_line\n | UNKNOWN_TAG DATE\n | UNKNOWN_TAG PERSON_VALUE \n"
+    @grammar_rule("unknown_tag : UNKNOWN_TAG text_or_line\n | UNKNOWN_TAG ISO8601_DATE\n | UNKNOWN_TAG PERSON_VALUE \n"
                   "| UNKNOWN_TAG")
     def p_unknown_tag(self, p):
         self.logger.append(f"Unknown tag provided in line {p.lineno(1)}")
@@ -252,7 +252,7 @@ class Parser(object):
     def p_creator(self, p):
         self.creation_info.setdefault("creators", []).append(ActorParser.parse_actor(p[2]))
 
-    @grammar_rule("created : CREATED DATE")
+    @grammar_rule("created : CREATED ISO8601_DATE")
     def p_created(self, p):
         set_value(p, self.creation_info, method_to_apply=datetime_from_str)
 
@@ -384,8 +384,8 @@ class Parser(object):
         if self.check_that_current_element_matches_class_for_value(Package, p.lineno(1)):
             set_value(p, self.current_element, method_to_apply=lambda x: PackagePurpose[x.replace("-", "_")])
 
-    @grammar_rule("built_date : BUILT_DATE DATE\n release_date : RELEASE_DATE DATE\n "
-                  "valid_until_date : VALID_UNTIL_DATE DATE")
+    @grammar_rule("built_date : BUILT_DATE ISO8601_DATE\n release_date : RELEASE_DATE ISO8601_DATE\n "
+                  "valid_until_date : VALID_UNTIL_DATE ISO8601_DATE")
     def p_package_dates(self, p):
         if self.check_that_current_element_matches_class_for_value(Package, p.lineno(1)):
             set_value(p, self.current_element, method_to_apply=datetime_from_str)
@@ -428,7 +428,7 @@ class Parser(object):
         self.initialize_new_current_element(Annotation)
         set_value(p, self.current_element, method_to_apply=ActorParser.parse_actor)
 
-    @grammar_rule("annotation_date : ANNOTATION_DATE DATE")
+    @grammar_rule("annotation_date : ANNOTATION_DATE ISO8601_DATE")
     def p_annotation_date(self, p):
         if self.check_that_current_element_matches_class_for_value(Annotation, p.lineno(1)):
             set_value(p, self.current_element, method_to_apply=datetime_from_str)

--- a/tests/spdx/parser/tagvalue/test_tag_value_lexer.py
+++ b/tests/spdx/parser/tagvalue/test_tag_value_lexer.py
@@ -120,7 +120,7 @@ def test_tokenization_of_creation_info(lexer):
     token_assert_helper(lexer.token(), "CREATOR", "Creator", 2)
     token_assert_helper(lexer.token(), "ORGANIZATION_VALUE", "Organization: Acme.", 2)
     token_assert_helper(lexer.token(), "CREATED", "Created", 3)
-    token_assert_helper(lexer.token(), "DATE", "2010-02-03T00:00:00Z", 3)
+    token_assert_helper(lexer.token(), "ISO8601_DATE", "2010-02-03T00:00:00Z", 3)
     token_assert_helper(lexer.token(), "CREATOR_COMMENT", "CreatorComment", 4)
     token_assert_helper(lexer.token(), "TEXT", "<text>Sample Comment</text>", 4)
 
@@ -205,11 +205,11 @@ def test_tokenization_of_package(lexer):
     token_assert_helper(lexer.token(), "PRIMARY_PACKAGE_PURPOSE", "PrimaryPackagePurpose", 23)
     token_assert_helper(lexer.token(), "LINE", "OPERATING-SYSTEM", 23)
     token_assert_helper(lexer.token(), "BUILT_DATE", "BuiltDate", 24)
-    token_assert_helper(lexer.token(), "DATE", "2020-01-01T12:00:00Z", 24)
+    token_assert_helper(lexer.token(), "ISO8601_DATE", "2020-01-01T12:00:00Z", 24)
     token_assert_helper(lexer.token(), "RELEASE_DATE", "ReleaseDate", 25)
-    token_assert_helper(lexer.token(), "DATE", "2021-01-01T12:00:00Z", 25)
+    token_assert_helper(lexer.token(), "ISO8601_DATE", "2021-01-01T12:00:00Z", 25)
     token_assert_helper(lexer.token(), "VALID_UNTIL_DATE", "ValidUntilDate", 26)
-    token_assert_helper(lexer.token(), "DATE", "2022-01-01T12:00:00Z", 26)
+    token_assert_helper(lexer.token(), "ISO8601_DATE", "2022-01-01T12:00:00Z", 26)
 
 
 def test_tokenization_of_unknown_tag(lexer):
@@ -269,7 +269,7 @@ def test_tokenization_of_annotation(lexer):
     token_assert_helper(lexer.token(), "ANNOTATOR", "Annotator", 1)
     token_assert_helper(lexer.token(), "PERSON_VALUE", "Person: Jane Doe()", 1)
     token_assert_helper(lexer.token(), "ANNOTATION_DATE", "AnnotationDate", 2)
-    token_assert_helper(lexer.token(), "DATE", "2010-01-29T18:30:22Z", 2)
+    token_assert_helper(lexer.token(), "ISO8601_DATE", "2010-01-29T18:30:22Z", 2)
     token_assert_helper(lexer.token(), "ANNOTATION_COMMENT", "AnnotationComment", 3)
     token_assert_helper(lexer.token(), "TEXT", "<text>Document level annotation</text>", 3)
     token_assert_helper(lexer.token(), "ANNOTATION_TYPE", "AnnotationType", 4)


### PR DESCRIPTION
change `DATE` to `ISO8601_DATE`, don't inherit from `object`