### PR TITLE
[issue-402] add validation option to tag-value writer

### DIFF
--- a/src/spdx/writer/rdf/rdf_writer.py
+++ b/src/spdx/writer/rdf/rdf_writer.py
@@ -28,8 +28,7 @@ from spdx.rdfschema.namespace import SPDX_NAMESPACE, POINTER_NAMESPACE
 
 def write_document_to_file(document: Document, file_name: str, validate: bool):
     if validate:
-        validation_messages: List[ValidationMessage] = validate_full_spdx_document(document,
-                                                                                   document.creation_info.spdx_version)
+        validation_messages: List[ValidationMessage] = validate_full_spdx_document(document)
         if validation_messages:
             raise ValueError(f"Document is not valid. The following errors were detected: {validation_messages}")
 

--- a/src/spdx/writer/tagvalue/tagvalue_writer.py
+++ b/src/spdx/writer/tagvalue/tagvalue_writer.py
@@ -8,10 +8,11 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-
-from typing import TextIO
+from typing import TextIO, List
 
 from spdx.model.document import Document
+from spdx.validation.document_validator import validate_full_spdx_document
+from spdx.validation.validation_message import ValidationMessage
 from spdx.writer.tagvalue.annotation_writer import write_annotation
 from spdx.writer.tagvalue.creation_info_writer import write_creation_info
 from spdx.writer.tagvalue.extracted_licensing_info_writer import write_extracted_licensing_info
@@ -23,7 +24,13 @@ from spdx.writer.tagvalue.tagvalue_writer_helper_functions import write_separato
     get_file_ids_with_contained_snippets, write_optional_heading, write_list_of_elements
 
 
-def write_document_to_file(document: Document, file_name: str):
+def write_document_to_file(document: Document, file_name: str, validate: bool = True):
+    if validate:
+        validation_messages: List[ValidationMessage] = validate_full_spdx_document(document,
+                                                                                   document.creation_info.spdx_version)
+        if validation_messages:
+            raise ValueError(f"Document is not valid. The following errors were detected: {validation_messages}")
+
     with open(file_name, "w") as out:
         write_document(document, out)
 

--- a/src/spdx/writer/tagvalue/tagvalue_writer.py
+++ b/src/spdx/writer/tagvalue/tagvalue_writer.py
@@ -26,8 +26,7 @@ from spdx.writer.tagvalue.tagvalue_writer_helper_functions import write_separato
 
 def write_document_to_file(document: Document, file_name: str, validate: bool = True):
     if validate:
-        validation_messages: List[ValidationMessage] = validate_full_spdx_document(document,
-                                                                                   document.creation_info.spdx_version)
+        validation_messages: List[ValidationMessage] = validate_full_spdx_document(document)
         if validation_messages:
             raise ValueError(f"Document is not valid. The following errors were detected: {validation_messages}")
 

--- a/src/spdx/writer/write_anything.py
+++ b/src/spdx/writer/write_anything.py
@@ -27,6 +27,6 @@ def write_file(document: Document, file_name: str, validate: bool = True):
     elif output_format == FileFormat.XML:
         xml_writer.write_document_to_file(document, file_name, validate)
     elif output_format == FileFormat.TAG_VALUE:
-        tagvalue_writer.write_document_to_file(document, file_name)
+        tagvalue_writer.write_document_to_file(document, file_name, validate)
     elif output_format == FileFormat.RDF_XML:
         rdf_writer.write_document_to_file(document, file_name, validate)

--- a/src/spdx/writer/xml/xml_writer.py
+++ b/src/spdx/writer/xml/xml_writer.py
@@ -18,15 +18,15 @@ from spdx.validation.document_validator import validate_full_spdx_document
 from spdx.validation.validation_message import ValidationMessage
 
 
-def write_document_to_file(document: Document, file_name: str, validate: bool = True, converter: DocumentConverter = None):
+def write_document_to_file(document: Document, file_name: str, validate: bool = True,
+                           converter: DocumentConverter = None):
     """
     Serializes the provided document to XML and writes it to a file with the provided name. Unless validate is set
     to False, validates the document before serialization. Unless a DocumentConverter instance is provided,
     a new one is created.
     """
     if validate:
-        validation_messages: List[ValidationMessage] = validate_full_spdx_document(document,
-                                                                                   document.creation_info.spdx_version)
+        validation_messages: List[ValidationMessage] = validate_full_spdx_document(document)
         if validation_messages:
             raise ValueError(f"Document is not valid. The following errors were detected: {validation_messages}")
     if converter is None:

--- a/src/spdx/writer/yaml/yaml_writer.py
+++ b/src/spdx/writer/yaml/yaml_writer.py
@@ -18,15 +18,15 @@ from spdx.validation.document_validator import validate_full_spdx_document
 from spdx.validation.validation_message import ValidationMessage
 
 
-def write_document_to_file(document: Document, file_name: str, validate: bool = True, converter: DocumentConverter = None):
+def write_document_to_file(document: Document, file_name: str, validate: bool = True,
+                           converter: DocumentConverter = None):
     """
     Serializes the provided document to yaml and writes it to a file with the provided name. Unless validate is set
     to False, validates the document before serialization. Unless a DocumentConverter instance is provided,
     a new one is created.
     """
     if validate:
-        validation_messages: List[ValidationMessage] = validate_full_spdx_document(document,
-                                                                                   document.creation_info.spdx_version)
+        validation_messages: List[ValidationMessage] = validate_full_spdx_document(document)
         if validation_messages:
             raise ValueError(f"Document is not valid. The following errors were detected: {validation_messages}")
     if converter is None:

--- a/tests/spdx/writer/tagvalue/test_tagvalue_writer.py
+++ b/tests/spdx/writer/tagvalue/test_tagvalue_writer.py
@@ -28,7 +28,7 @@ def temporary_file_path() -> str:
 def test_write_tag_value(temporary_file_path: str):
     document = document_fixture()
 
-    write_document_to_file(document, temporary_file_path)
+    write_document_to_file(document, temporary_file_path, False)
 
     parsed_document = tagvalue_parser.parse_from_file(temporary_file_path)
 


### PR DESCRIPTION
Reading through the migration guideline I came across the line 

> Now, when calling write_file(), by default a Document will be validated against the specification before it can be written to a file.

which lead me to this addition.

part of #402 
