### PR TITLE
Add python 3.11 to GitHub Action

### DIFF
--- a/.github/workflows/install_and_test.yml
+++ b/.github/workflows/install_and_test.yml
@@ -1,6 +1,11 @@
 name: Install and Test
 
-on: [ workflow_dispatch, pull_request ]
+on:
+  push:
+    branches:
+      - refactor-python-tools
+  pull_request:
+  workflow_dispatch:
 
 jobs:
   install_and_test:

--- a/.github/workflows/install_and_test.yml
+++ b/.github/workflows/install_and_test.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
-        python-version: [ "3.7", "3.8", "3.9", "3.10" ]
+        python-version: [ "3.7", "3.8", "3.9", "3.10", "3.11" ]
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
As we support Python 3.11 we should also test against it in our GitHub Action.
Additionally I added a push to the branch as a trigger for this workflow. When merging this we will need to adapt this. 