### PR TITLE
[issue-511] replace license text with SPDX license identifier

### DIFF
--- a/src/spdx/casing_tools.py
+++ b/src/spdx/casing_tools.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2022 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2022 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 from re import sub
 
 

--- a/src/spdx/clitools/pyspdxtools.py
+++ b/src/spdx/clitools/pyspdxtools.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
 
 # Copyright (c) 2020 Yash Varshney
+# Copyright (c) 2023 spdx contributors
+# SPDX-License-Identifier: Apache-2.0
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/src/spdx/datetime_conversions.py
+++ b/src/spdx/datetime_conversions.py
@@ -1,13 +1,6 @@
-#  Copyright (c) 2022 spdx contributors
-#  Licensed under the Apache License, Version 2.0 (the "License");
-#  you may not use this file except in compliance with the License.
-#  You may obtain a copy of the License at
-#    http://www.apache.org/licenses/LICENSE-2.0
-#  Unless required by applicable law or agreed to in writing, software
-#  distributed under the License is distributed on an "AS IS" BASIS,
-#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-#  See the License for the specific language governing permissions and
-#  limitations under the License.
+# SPDX-FileCopyrightText: 2022 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 from datetime import datetime
 
 

--- a/src/spdx/document_utils.py
+++ b/src/spdx/document_utils.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2022 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2022 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 from typing import List, Union
 
 from spdx.model.document import Document

--- a/src/spdx/formats.py
+++ b/src/spdx/formats.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2022 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2022 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 from enum import Enum, auto
 
 from spdx.parser.error import SPDXParsingError

--- a/src/spdx/jsonschema/annotation_converter.py
+++ b/src/spdx/jsonschema/annotation_converter.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2022 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2022 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 from typing import Any, Type
 
 from spdx.datetime_conversions import datetime_to_iso_string

--- a/src/spdx/jsonschema/annotation_properties.py
+++ b/src/spdx/jsonschema/annotation_properties.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2022 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2022 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 from enum import auto
 
 from spdx.jsonschema.json_property import JsonProperty

--- a/src/spdx/jsonschema/checksum_converter.py
+++ b/src/spdx/jsonschema/checksum_converter.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2022 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2022 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 from typing import Type
 
 from spdx.jsonschema.checksum_properties import ChecksumProperty

--- a/src/spdx/jsonschema/checksum_properties.py
+++ b/src/spdx/jsonschema/checksum_properties.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2022 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2022 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 from enum import auto
 
 from spdx.jsonschema.json_property import JsonProperty

--- a/src/spdx/jsonschema/converter.py
+++ b/src/spdx/jsonschema/converter.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2022 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2022 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 from abc import ABC, abstractmethod
 from typing import Any, Dict, Generic, Type, TypeVar
 

--- a/src/spdx/jsonschema/creation_info_converter.py
+++ b/src/spdx/jsonschema/creation_info_converter.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2022 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2022 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 from typing import Any, Type
 
 from spdx.datetime_conversions import datetime_to_iso_string

--- a/src/spdx/jsonschema/creation_info_properties.py
+++ b/src/spdx/jsonschema/creation_info_properties.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2022 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2022 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 from enum import auto
 
 from spdx.jsonschema.json_property import JsonProperty

--- a/src/spdx/jsonschema/document_converter.py
+++ b/src/spdx/jsonschema/document_converter.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2022 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2022 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 from typing import Any, Type
 
 from spdx.document_utils import get_contained_spdx_element_ids

--- a/src/spdx/jsonschema/document_properties.py
+++ b/src/spdx/jsonschema/document_properties.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2022 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2022 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 from enum import auto
 
 from spdx.jsonschema.json_property import JsonProperty

--- a/src/spdx/jsonschema/external_document_ref_converter.py
+++ b/src/spdx/jsonschema/external_document_ref_converter.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2022 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2022 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 from typing import Any, Type
 
 from spdx.jsonschema.checksum_converter import ChecksumConverter

--- a/src/spdx/jsonschema/external_document_ref_properties.py
+++ b/src/spdx/jsonschema/external_document_ref_properties.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2022 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2022 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 from enum import auto
 
 from spdx.jsonschema.json_property import JsonProperty

--- a/src/spdx/jsonschema/external_package_ref_converter.py
+++ b/src/spdx/jsonschema/external_package_ref_converter.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2022 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2022 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 from typing import Any, Type
 
 from spdx.jsonschema.converter import TypedConverter

--- a/src/spdx/jsonschema/external_package_ref_properties.py
+++ b/src/spdx/jsonschema/external_package_ref_properties.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2022 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2022 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 from enum import auto
 
 from spdx.jsonschema.json_property import JsonProperty

--- a/src/spdx/jsonschema/extracted_licensing_info_converter.py
+++ b/src/spdx/jsonschema/extracted_licensing_info_converter.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2022 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2022 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 from typing import Any, Type
 
 from spdx.jsonschema.converter import TypedConverter

--- a/src/spdx/jsonschema/extracted_licensing_info_properties.py
+++ b/src/spdx/jsonschema/extracted_licensing_info_properties.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2022 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2022 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 from enum import auto
 
 from spdx.jsonschema.json_property import JsonProperty

--- a/src/spdx/jsonschema/file_converter.py
+++ b/src/spdx/jsonschema/file_converter.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2022 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2022 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 from typing import Any, Type
 
 from spdx.jsonschema.annotation_converter import AnnotationConverter

--- a/src/spdx/jsonschema/file_properties.py
+++ b/src/spdx/jsonschema/file_properties.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2022 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2022 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 from enum import auto
 
 from spdx.jsonschema.json_property import JsonProperty

--- a/src/spdx/jsonschema/json_property.py
+++ b/src/spdx/jsonschema/json_property.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2022 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2022 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 from enum import Enum
 
 

--- a/src/spdx/jsonschema/optional_utils.py
+++ b/src/spdx/jsonschema/optional_utils.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2022 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2022 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 from typing import Callable, Optional, TypeVar
 
 T = TypeVar("T")

--- a/src/spdx/jsonschema/package_converter.py
+++ b/src/spdx/jsonschema/package_converter.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2022 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2022 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 from typing import Any, Type
 
 from spdx.datetime_conversions import datetime_to_iso_string

--- a/src/spdx/jsonschema/package_properties.py
+++ b/src/spdx/jsonschema/package_properties.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2022 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2022 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 from enum import auto
 
 from spdx.jsonschema.json_property import JsonProperty

--- a/src/spdx/jsonschema/package_verification_code_converter.py
+++ b/src/spdx/jsonschema/package_verification_code_converter.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2022 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2022 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 from typing import Any, Type
 
 from spdx.jsonschema.converter import TypedConverter

--- a/src/spdx/jsonschema/package_verification_code_properties.py
+++ b/src/spdx/jsonschema/package_verification_code_properties.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2022 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2022 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 from enum import auto
 
 from spdx.jsonschema.json_property import JsonProperty

--- a/src/spdx/jsonschema/relationship_converter.py
+++ b/src/spdx/jsonschema/relationship_converter.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2022 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2022 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 from typing import Any, Type
 
 from spdx.jsonschema.converter import TypedConverter

--- a/src/spdx/jsonschema/relationship_properties.py
+++ b/src/spdx/jsonschema/relationship_properties.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2022 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2022 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 from enum import auto
 
 from spdx.jsonschema.json_property import JsonProperty

--- a/src/spdx/jsonschema/snippet_converter.py
+++ b/src/spdx/jsonschema/snippet_converter.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2022 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2022 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 from typing import Any, Dict, Tuple, Type
 
 from spdx.jsonschema.annotation_converter import AnnotationConverter

--- a/src/spdx/jsonschema/snippet_properties.py
+++ b/src/spdx/jsonschema/snippet_properties.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2022 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2022 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 from enum import auto
 
 from spdx.jsonschema.json_property import JsonProperty

--- a/src/spdx/model/actor.py
+++ b/src/spdx/model/actor.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2022 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2022 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 from enum import Enum, auto
 from typing import Optional
 

--- a/src/spdx/model/annotation.py
+++ b/src/spdx/model/annotation.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2022 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2022 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 from datetime import datetime
 from enum import Enum, auto
 

--- a/src/spdx/model/checksum.py
+++ b/src/spdx/model/checksum.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2022 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2022 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 from enum import Enum, auto
 
 from common.typing.dataclass_with_properties import dataclass_with_properties

--- a/src/spdx/model/document.py
+++ b/src/spdx/model/document.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2022 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2022 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 from dataclasses import field
 from datetime import datetime
 from typing import List, Optional

--- a/src/spdx/model/external_document_ref.py
+++ b/src/spdx/model/external_document_ref.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2022 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2022 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 
 from common.typing.dataclass_with_properties import dataclass_with_properties
 from common.typing.type_checks import check_types_and_set_values

--- a/src/spdx/model/extracted_licensing_info.py
+++ b/src/spdx/model/extracted_licensing_info.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2022 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2022 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 from dataclasses import field
 from typing import List, Optional, Union
 

--- a/src/spdx/model/file.py
+++ b/src/spdx/model/file.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2022 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2022 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 from dataclasses import field
 from enum import Enum, auto
 from typing import List, Optional, Union

--- a/src/spdx/model/package.py
+++ b/src/spdx/model/package.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2022 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2022 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 from dataclasses import field
 from datetime import datetime
 from enum import Enum, auto

--- a/src/spdx/model/relationship.py
+++ b/src/spdx/model/relationship.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2022 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2022 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 from enum import Enum, auto
 from typing import Optional, Union
 

--- a/src/spdx/model/relationship_filters.py
+++ b/src/spdx/model/relationship_filters.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2022 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2022 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 from typing import List
 
 from spdx.model.document import Document

--- a/src/spdx/model/snippet.py
+++ b/src/spdx/model/snippet.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2022 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2022 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 from dataclasses import field
 from typing import List, Optional, Tuple, Union
 

--- a/src/spdx/model/spdx_no_assertion.py
+++ b/src/spdx/model/spdx_no_assertion.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2022 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2022 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 
 SPDX_NO_ASSERTION_STRING = "NOASSERTION"
 

--- a/src/spdx/model/spdx_none.py
+++ b/src/spdx/model/spdx_none.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2022 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2022 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 
 SPDX_NONE_STRING = "NONE"
 

--- a/src/spdx/model/version.py
+++ b/src/spdx/model/version.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2022 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2022 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 
 
 import re

--- a/src/spdx/parser/actor_parser.py
+++ b/src/spdx/parser/actor_parser.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2022 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2022 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 import re
 from typing import Match, Optional, Pattern
 

--- a/src/spdx/parser/error.py
+++ b/src/spdx/parser/error.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2022 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2022 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 from typing import List
 
 

--- a/src/spdx/parser/json/json_parser.py
+++ b/src/spdx/parser/json/json_parser.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2022 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2022 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 import json
 from typing import Dict
 

--- a/src/spdx/parser/jsonlikedict/annotation_parser.py
+++ b/src/spdx/parser/jsonlikedict/annotation_parser.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2022 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2022 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 from datetime import datetime
 from typing import Dict, List, Optional
 

--- a/src/spdx/parser/jsonlikedict/checksum_parser.py
+++ b/src/spdx/parser/jsonlikedict/checksum_parser.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2022 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2022 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 from typing import Dict, Optional
 
 from spdx.model.checksum import Checksum, ChecksumAlgorithm

--- a/src/spdx/parser/jsonlikedict/creation_info_parser.py
+++ b/src/spdx/parser/jsonlikedict/creation_info_parser.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2022 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2022 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 from datetime import datetime
 from typing import Dict, List, Optional
 

--- a/src/spdx/parser/jsonlikedict/dict_parsing_functions.py
+++ b/src/spdx/parser/jsonlikedict/dict_parsing_functions.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2022 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2022 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 from typing import Any, Callable, Dict, List, Optional
 
 from spdx.model.spdx_no_assertion import SpdxNoAssertion

--- a/src/spdx/parser/jsonlikedict/extracted_licensing_info_parser.py
+++ b/src/spdx/parser/jsonlikedict/extracted_licensing_info_parser.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2022 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2022 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 from typing import Dict, List, Optional, Union
 
 from spdx.model.extracted_licensing_info import ExtractedLicensingInfo

--- a/src/spdx/parser/jsonlikedict/file_parser.py
+++ b/src/spdx/parser/jsonlikedict/file_parser.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2022 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2022 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 from typing import Dict, List, Optional, Union
 
 from license_expression import LicenseExpression

--- a/src/spdx/parser/jsonlikedict/json_like_dict_parser.py
+++ b/src/spdx/parser/jsonlikedict/json_like_dict_parser.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2022 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2022 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 from typing import Dict
 
 from spdx.model.document import Document

--- a/src/spdx/parser/jsonlikedict/license_expression_parser.py
+++ b/src/spdx/parser/jsonlikedict/license_expression_parser.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2022 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2022 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 from typing import Union
 
 from license_expression import ExpressionError, LicenseExpression, Licensing

--- a/src/spdx/parser/jsonlikedict/package_parser.py
+++ b/src/spdx/parser/jsonlikedict/package_parser.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2022 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2022 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 from datetime import datetime
 from typing import Dict, List, Optional, Union
 

--- a/src/spdx/parser/jsonlikedict/relationship_parser.py
+++ b/src/spdx/parser/jsonlikedict/relationship_parser.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2022 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2022 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 from typing import Dict, List, Optional
 
 from common.typing.constructor_type_errors import ConstructorTypeErrors

--- a/src/spdx/parser/jsonlikedict/snippet_parser.py
+++ b/src/spdx/parser/jsonlikedict/snippet_parser.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2022 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2022 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 from enum import Enum, auto
 from typing import Dict, List, Optional, Tuple, Union
 

--- a/src/spdx/parser/logger.py
+++ b/src/spdx/parser/logger.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2022 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2022 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 from typing import List
 
 

--- a/src/spdx/parser/parsing_functions.py
+++ b/src/spdx/parser/parsing_functions.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2023 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2023 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 from typing import Any, Dict
 
 from common.typing.constructor_type_errors import ConstructorTypeErrors

--- a/src/spdx/parser/rdf/annotation_parser.py
+++ b/src/spdx/parser/rdf/annotation_parser.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2023 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2023 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 from rdflib import RDFS, Graph, URIRef
 
 from spdx.datetime_conversions import datetime_from_str

--- a/src/spdx/parser/rdf/checksum_parser.py
+++ b/src/spdx/parser/rdf/checksum_parser.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2023 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2023 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 from rdflib import Graph, URIRef
 
 from spdx.model.checksum import Checksum, ChecksumAlgorithm

--- a/src/spdx/parser/rdf/creation_info_parser.py
+++ b/src/spdx/parser/rdf/creation_info_parser.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2023 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2023 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 import logging
 import sys
 from typing import Tuple

--- a/src/spdx/parser/rdf/extracted_licensing_info_parser.py
+++ b/src/spdx/parser/rdf/extracted_licensing_info_parser.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2023 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2023 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 from rdflib import RDFS, Graph, URIRef
 
 from spdx.model.extracted_licensing_info import ExtractedLicensingInfo

--- a/src/spdx/parser/rdf/file_parser.py
+++ b/src/spdx/parser/rdf/file_parser.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2023 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2023 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 from rdflib import RDFS, Graph, URIRef
 
 from spdx.model.file import File, FileType

--- a/src/spdx/parser/rdf/graph_parsing_functions.py
+++ b/src/spdx/parser/rdf/graph_parsing_functions.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2023 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2023 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 from enum import Enum
 from typing import Any, Callable, Optional, Type
 

--- a/src/spdx/parser/rdf/license_expression_parser.py
+++ b/src/spdx/parser/rdf/license_expression_parser.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2023 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2023 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 from typing import Union
 
 from license_expression import LicenseExpression, get_spdx_licensing

--- a/src/spdx/parser/rdf/package_parser.py
+++ b/src/spdx/parser/rdf/package_parser.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2023 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2023 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 from typing import Optional
 
 from rdflib import DOAP, RDFS, Graph, URIRef

--- a/src/spdx/parser/rdf/rdf_parser.py
+++ b/src/spdx/parser/rdf/rdf_parser.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2023 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2023 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 from rdflib import RDF, Graph
 
 from spdx.model.document import Document

--- a/src/spdx/parser/rdf/relationship_parser.py
+++ b/src/spdx/parser/rdf/relationship_parser.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2023 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2023 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 from rdflib import RDFS, Graph, URIRef
 
 from spdx.model.relationship import Relationship, RelationshipType

--- a/src/spdx/parser/rdf/snippet_parser.py
+++ b/src/spdx/parser/rdf/snippet_parser.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2023 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2023 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 from typing import Dict, Optional, Tuple
 
 from rdflib import RDF, RDFS, Graph

--- a/src/spdx/parser/tagvalue/helper_methods.py
+++ b/src/spdx/parser/tagvalue/helper_methods.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2023 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2023 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 import re
 from typing import Any, Callable, Dict, Optional
 

--- a/src/spdx/parser/tagvalue/lexer.py
+++ b/src/spdx/parser/tagvalue/lexer.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2014 Ahmed H. Ismail
 # Copyright (c) 2023 spdx contributors
+# SPDX-License-Identifier: Apache-2.0
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/src/spdx/parser/tagvalue/parser.py
+++ b/src/spdx/parser/tagvalue/parser.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2014 Ahmed H. Ismail
 # Copyright (c) 2023 spdx contributors
+# SPDX-License-Identifier: Apache-2.0
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/src/spdx/parser/tagvalue/tagvalue_parser.py
+++ b/src/spdx/parser/tagvalue/tagvalue_parser.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2023 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2023 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 from spdx.model.document import Document
 from spdx.parser.tagvalue.parser import Parser
 

--- a/src/spdx/parser/xml/xml_parser.py
+++ b/src/spdx/parser/xml/xml_parser.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2023 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2023 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 from typing import Any, Dict
 
 import xmltodict

--- a/src/spdx/parser/yaml/yaml_parser.py
+++ b/src/spdx/parser/yaml/yaml_parser.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2023 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2023 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 from typing import Dict
 
 import yaml

--- a/src/spdx/rdfschema/namespace.py
+++ b/src/spdx/rdfschema/namespace.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2023 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2023 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 from rdflib import Namespace
 
 SPDX_NAMESPACE = Namespace("http://spdx.org/rdf/terms#")

--- a/src/spdx/validation/actor_validator.py
+++ b/src/spdx/validation/actor_validator.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2022 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2022 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 
 from typing import List
 

--- a/src/spdx/validation/annotation_validator.py
+++ b/src/spdx/validation/annotation_validator.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2022 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2022 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 
 from typing import List
 

--- a/src/spdx/validation/checksum_validator.py
+++ b/src/spdx/validation/checksum_validator.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2022 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2022 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 
 import re
 from typing import Dict, List

--- a/src/spdx/validation/creation_info_validator.py
+++ b/src/spdx/validation/creation_info_validator.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2022 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2022 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 
 from typing import List
 

--- a/src/spdx/validation/document_validator.py
+++ b/src/spdx/validation/document_validator.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2022 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2022 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 from typing import List
 
 from spdx.model.document import Document

--- a/src/spdx/validation/external_document_ref_validator.py
+++ b/src/spdx/validation/external_document_ref_validator.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2022 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2022 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 
 from typing import List
 

--- a/src/spdx/validation/external_package_ref_validator.py
+++ b/src/spdx/validation/external_package_ref_validator.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2022 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2022 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 import re
 from typing import Dict, List
 

--- a/src/spdx/validation/extracted_licensing_info_validator.py
+++ b/src/spdx/validation/extracted_licensing_info_validator.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2022 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2022 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 
 import re
 from typing import List, Optional

--- a/src/spdx/validation/file_validator.py
+++ b/src/spdx/validation/file_validator.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2022 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2022 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 
 from typing import List, Optional
 

--- a/src/spdx/validation/license_expression_validator.py
+++ b/src/spdx/validation/license_expression_validator.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2022 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2022 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 
 from typing import List, Optional, Union
 

--- a/src/spdx/validation/package_validator.py
+++ b/src/spdx/validation/package_validator.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2022 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2022 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 
 from typing import List, Optional
 

--- a/src/spdx/validation/package_verification_code_validator.py
+++ b/src/spdx/validation/package_verification_code_validator.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2022 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2022 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 
 import re
 from typing import List

--- a/src/spdx/validation/relationship_validator.py
+++ b/src/spdx/validation/relationship_validator.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2022 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2022 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 
 from typing import List
 

--- a/src/spdx/validation/snippet_validator.py
+++ b/src/spdx/validation/snippet_validator.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2022 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2022 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 
 from typing import List, Optional
 

--- a/src/spdx/validation/spdx_id_validators.py
+++ b/src/spdx/validation/spdx_id_validators.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2022 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2022 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 
 import re
 from typing import List

--- a/src/spdx/validation/uri_validators.py
+++ b/src/spdx/validation/uri_validators.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2022 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2022 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 
 import re
 from typing import List

--- a/src/spdx/validation/validation_message.py
+++ b/src/spdx/validation/validation_message.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2022 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2022 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 
 from dataclasses import dataclass
 from enum import Enum, auto

--- a/src/spdx/writer/json/json_writer.py
+++ b/src/spdx/writer/json/json_writer.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2022 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2022 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 import json
 from typing import List
 

--- a/src/spdx/writer/rdf/annotation_writer.py
+++ b/src/spdx/writer/rdf/annotation_writer.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2023 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2023 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 from typing import Dict
 
 from rdflib import RDF, RDFS, BNode, Graph, Literal, URIRef

--- a/src/spdx/writer/rdf/checksum_writer.py
+++ b/src/spdx/writer/rdf/checksum_writer.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2023 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2023 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 from rdflib import RDF, BNode, Graph, Literal, URIRef
 
 from spdx.model.checksum import Checksum, ChecksumAlgorithm

--- a/src/spdx/writer/rdf/creation_info_writer.py
+++ b/src/spdx/writer/rdf/creation_info_writer.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2023 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2023 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 from rdflib import RDF, RDFS, BNode, Graph, Literal, URIRef
 
 from spdx.datetime_conversions import datetime_to_iso_string

--- a/src/spdx/writer/rdf/external_document_ref_writer.py
+++ b/src/spdx/writer/rdf/external_document_ref_writer.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2023 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2023 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 from rdflib import RDF, Graph, URIRef
 
 from spdx.model.external_document_ref import ExternalDocumentRef

--- a/src/spdx/writer/rdf/extracted_licensing_info_writer.py
+++ b/src/spdx/writer/rdf/extracted_licensing_info_writer.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2023 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2023 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 from rdflib import RDF, RDFS, BNode, Graph, Literal, URIRef
 
 from spdx.model.extracted_licensing_info import ExtractedLicensingInfo

--- a/src/spdx/writer/rdf/file_writer.py
+++ b/src/spdx/writer/rdf/file_writer.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2023 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2023 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 from typing import Dict
 
 from rdflib import RDF, RDFS, Graph, Literal, URIRef

--- a/src/spdx/writer/rdf/license_expression_writer.py
+++ b/src/spdx/writer/rdf/license_expression_writer.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2023 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2023 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 from typing import List, Union
 
 from boolean import Expression

--- a/src/spdx/writer/rdf/package_writer.py
+++ b/src/spdx/writer/rdf/package_writer.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2023 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2023 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 from typing import Dict
 
 from rdflib import DOAP, RDF, RDFS, XSD, BNode, Graph, Literal, URIRef

--- a/src/spdx/writer/rdf/rdf_writer.py
+++ b/src/spdx/writer/rdf/rdf_writer.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2023 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2023 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 from typing import Dict, List
 
 from rdflib import DOAP, Graph

--- a/src/spdx/writer/rdf/relationship_writer.py
+++ b/src/spdx/writer/rdf/relationship_writer.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2023 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2023 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 from typing import Dict
 
 from rdflib import RDF, RDFS, BNode, Graph, Literal, URIRef

--- a/src/spdx/writer/rdf/snippet_writer.py
+++ b/src/spdx/writer/rdf/snippet_writer.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2023 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2023 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 from typing import Dict, Optional, Tuple
 
 from rdflib import RDF, RDFS, BNode, Graph, Literal, URIRef

--- a/src/spdx/writer/rdf/writer_utils.py
+++ b/src/spdx/writer/rdf/writer_utils.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2023 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2023 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 import logging
 from datetime import datetime
 from typing import Any, Dict, Optional

--- a/src/spdx/writer/write_anything.py
+++ b/src/spdx/writer/write_anything.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2022 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2022 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 from spdx.formats import FileFormat, file_name_to_format
 from spdx.model.document import Document
 from spdx.writer.json import json_writer

--- a/src/spdx/writer/xml/xml_writer.py
+++ b/src/spdx/writer/xml/xml_writer.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2023 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2023 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 from typing import List
 
 import xmltodict

--- a/src/spdx/writer/yaml/yaml_writer.py
+++ b/src/spdx/writer/yaml/yaml_writer.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2023 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2023 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 from typing import List
 
 import yaml

--- a/tests/spdx/fixtures.py
+++ b/tests/spdx/fixtures.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2022 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2022 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 from datetime import datetime
 
 from license_expression import get_spdx_licensing

--- a/tests/spdx/jsonschema/test_annotation_converter.py
+++ b/tests/spdx/jsonschema/test_annotation_converter.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2022 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2022 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 from datetime import datetime
 
 import pytest

--- a/tests/spdx/jsonschema/test_checksum_converter.py
+++ b/tests/spdx/jsonschema/test_checksum_converter.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2022 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2022 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 import pytest
 
 from spdx.jsonschema.checksum_converter import ChecksumConverter

--- a/tests/spdx/jsonschema/test_converter.py
+++ b/tests/spdx/jsonschema/test_converter.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2022 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2022 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 from enum import auto
 from typing import Any, Type
 

--- a/tests/spdx/jsonschema/test_creation_info_converter.py
+++ b/tests/spdx/jsonschema/test_creation_info_converter.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2022 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2022 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 from datetime import datetime
 
 import pytest

--- a/tests/spdx/jsonschema/test_document_converter.py
+++ b/tests/spdx/jsonschema/test_document_converter.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2022 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2022 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 from datetime import datetime
 from typing import Union
 from unittest import mock

--- a/tests/spdx/jsonschema/test_external_document_ref_converter.py
+++ b/tests/spdx/jsonschema/test_external_document_ref_converter.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2022 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2022 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 from unittest import mock
 from unittest.mock import MagicMock
 

--- a/tests/spdx/jsonschema/test_external_package_ref_converter.py
+++ b/tests/spdx/jsonschema/test_external_package_ref_converter.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2022 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2022 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 import pytest
 
 from spdx.jsonschema.external_package_ref_converter import ExternalPackageRefConverter

--- a/tests/spdx/jsonschema/test_extracted_licensing_info_converter.py
+++ b/tests/spdx/jsonschema/test_extracted_licensing_info_converter.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2022 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2022 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 import pytest
 
 from spdx.jsonschema.extracted_licensing_info_converter import ExtractedLicensingInfoConverter

--- a/tests/spdx/jsonschema/test_file_converter.py
+++ b/tests/spdx/jsonschema/test_file_converter.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2022 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2022 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 from datetime import datetime
 from typing import Union
 from unittest import mock

--- a/tests/spdx/jsonschema/test_package_converter.py
+++ b/tests/spdx/jsonschema/test_package_converter.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2022 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2022 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 from datetime import datetime
 from typing import Union
 from unittest import mock

--- a/tests/spdx/jsonschema/test_package_verification_code_converter.py
+++ b/tests/spdx/jsonschema/test_package_verification_code_converter.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2022 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2022 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 import pytest
 
 from spdx.jsonschema.package_verification_code_converter import PackageVerificationCodeConverter

--- a/tests/spdx/jsonschema/test_relationship_converter.py
+++ b/tests/spdx/jsonschema/test_relationship_converter.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2022 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2022 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 import pytest
 
 from spdx.jsonschema.relationship_converter import RelationshipConverter

--- a/tests/spdx/jsonschema/test_snippet_converter.py
+++ b/tests/spdx/jsonschema/test_snippet_converter.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2022 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2022 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 from datetime import datetime
 from typing import Union
 from unittest import mock

--- a/tests/spdx/mock_utils.py
+++ b/tests/spdx/mock_utils.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2022 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2022 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 from unittest.mock import NonCallableMagicMock
 
 

--- a/tests/spdx/model/test_version.py
+++ b/tests/spdx/model/test_version.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2022 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2022 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 
 
 import pytest

--- a/tests/spdx/parser/json/test_json_parser.py
+++ b/tests/spdx/parser/json/test_json_parser.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2022 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2022 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 
 import os
 

--- a/tests/spdx/parser/jsonlikedict/test_annotation_parser.py
+++ b/tests/spdx/parser/jsonlikedict/test_annotation_parser.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2022 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2022 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 import datetime
 from unittest import TestCase
 

--- a/tests/spdx/parser/jsonlikedict/test_checksum_parser.py
+++ b/tests/spdx/parser/jsonlikedict/test_checksum_parser.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2022 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2022 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 from unittest import TestCase
 
 import pytest

--- a/tests/spdx/parser/jsonlikedict/test_creation_info_parser.py
+++ b/tests/spdx/parser/jsonlikedict/test_creation_info_parser.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2022 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2022 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 from datetime import datetime
 from unittest import TestCase
 

--- a/tests/spdx/parser/jsonlikedict/test_extracted_licensing_info_parser.py
+++ b/tests/spdx/parser/jsonlikedict/test_extracted_licensing_info_parser.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2022 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2022 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 from unittest import TestCase
 
 import pytest

--- a/tests/spdx/parser/jsonlikedict/test_file_parser.py
+++ b/tests/spdx/parser/jsonlikedict/test_file_parser.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2022 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2022 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 from unittest import TestCase
 
 import pytest

--- a/tests/spdx/parser/jsonlikedict/test_license_expression_parser.py
+++ b/tests/spdx/parser/jsonlikedict/test_license_expression_parser.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2022 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2022 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 from unittest import TestCase
 
 import pytest

--- a/tests/spdx/parser/jsonlikedict/test_package_parser.py
+++ b/tests/spdx/parser/jsonlikedict/test_package_parser.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2022 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2022 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 from datetime import datetime
 from unittest import TestCase
 

--- a/tests/spdx/parser/jsonlikedict/test_relationship_parser.py
+++ b/tests/spdx/parser/jsonlikedict/test_relationship_parser.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2022 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2022 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 from unittest import TestCase
 
 import pytest

--- a/tests/spdx/parser/jsonlikedict/test_snippet_parser.py
+++ b/tests/spdx/parser/jsonlikedict/test_snippet_parser.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2022 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2022 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 from unittest import TestCase
 
 import pytest

--- a/tests/spdx/parser/rdf/test_annotation_parser.py
+++ b/tests/spdx/parser/rdf/test_annotation_parser.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2023 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2023 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 import os
 from datetime import datetime
 

--- a/tests/spdx/parser/rdf/test_checksum_parser.py
+++ b/tests/spdx/parser/rdf/test_checksum_parser.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2023 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2023 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 import os
 
 import pytest

--- a/tests/spdx/parser/rdf/test_creation_info_parser.py
+++ b/tests/spdx/parser/rdf/test_creation_info_parser.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2023 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2023 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 import os
 from datetime import datetime
 from typing import List, Tuple

--- a/tests/spdx/parser/rdf/test_extracted_licensing_info_parser.py
+++ b/tests/spdx/parser/rdf/test_extracted_licensing_info_parser.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2023 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2023 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 import os
 
 from rdflib import RDF, Graph

--- a/tests/spdx/parser/rdf/test_file_parser.py
+++ b/tests/spdx/parser/rdf/test_file_parser.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2023 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2023 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 import os
 from unittest import TestCase
 

--- a/tests/spdx/parser/rdf/test_graph_parsing_function.py
+++ b/tests/spdx/parser/rdf/test_graph_parsing_function.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2023 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2023 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 import pytest
 from rdflib import Graph, Namespace, URIRef
 

--- a/tests/spdx/parser/rdf/test_license_expression_parser.py
+++ b/tests/spdx/parser/rdf/test_license_expression_parser.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2023 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2023 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 import os
 from unittest import TestCase
 

--- a/tests/spdx/parser/rdf/test_package_parser.py
+++ b/tests/spdx/parser/rdf/test_package_parser.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2023 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2023 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 import os
 from unittest import TestCase
 

--- a/tests/spdx/parser/rdf/test_rdf_parser.py
+++ b/tests/spdx/parser/rdf/test_rdf_parser.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2023 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2023 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 import os
 
 import pytest

--- a/tests/spdx/parser/rdf/test_relationship_parser.py
+++ b/tests/spdx/parser/rdf/test_relationship_parser.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2023 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2023 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 import os
 
 from rdflib import RDF, Graph

--- a/tests/spdx/parser/rdf/test_snippet_parser.py
+++ b/tests/spdx/parser/rdf/test_snippet_parser.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2023 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2023 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 import os
 from unittest import TestCase
 

--- a/tests/spdx/parser/tagvalue/test_annotation_parser.py
+++ b/tests/spdx/parser/tagvalue/test_annotation_parser.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2023 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2023 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 from datetime import datetime
 
 import pytest

--- a/tests/spdx/parser/tagvalue/test_creation_info_parser.py
+++ b/tests/spdx/parser/tagvalue/test_creation_info_parser.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2023 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2023 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 from datetime import datetime
 from unittest import TestCase
 

--- a/tests/spdx/parser/tagvalue/test_extracted_licensing_info_parser.py
+++ b/tests/spdx/parser/tagvalue/test_extracted_licensing_info_parser.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2023 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2023 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 from unittest import TestCase
 
 import pytest

--- a/tests/spdx/parser/tagvalue/test_file_parser.py
+++ b/tests/spdx/parser/tagvalue/test_file_parser.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2023 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2023 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 import pytest
 from license_expression import get_spdx_licensing
 

--- a/tests/spdx/parser/tagvalue/test_helper_methods.py
+++ b/tests/spdx/parser/tagvalue/test_helper_methods.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2023 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2023 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 import pytest
 
 from spdx.model.checksum import ChecksumAlgorithm

--- a/tests/spdx/parser/tagvalue/test_package_parser.py
+++ b/tests/spdx/parser/tagvalue/test_package_parser.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2023 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2023 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 from datetime import datetime
 from unittest import TestCase
 

--- a/tests/spdx/parser/tagvalue/test_relationship_parser.py
+++ b/tests/spdx/parser/tagvalue/test_relationship_parser.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2023 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2023 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 import pytest
 
 from spdx.model.relationship import Relationship, RelationshipType

--- a/tests/spdx/parser/tagvalue/test_snippet_parser.py
+++ b/tests/spdx/parser/tagvalue/test_snippet_parser.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2023 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2023 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 from unittest import TestCase
 
 import pytest

--- a/tests/spdx/parser/tagvalue/test_tag_value_lexer.py
+++ b/tests/spdx/parser/tagvalue/test_tag_value_lexer.py
@@ -1,14 +1,7 @@
 # Copyright (c) 2014 Ahmed H. Ismail
-# Copyright (c) 2023 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2023 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 import pytest
 
 from spdx.parser.tagvalue.lexer import SPDXLexer

--- a/tests/spdx/parser/tagvalue/test_tag_value_parser.py
+++ b/tests/spdx/parser/tagvalue/test_tag_value_parser.py
@@ -1,14 +1,7 @@
 # Copyright (c) 2014 Ahmed H. Ismail
-# Copyright (c) 2023 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2023 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 import os
 
 import pytest

--- a/tests/spdx/test_actor_parser.py
+++ b/tests/spdx/test_actor_parser.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2022 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2022 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 from unittest import TestCase
 
 import pytest

--- a/tests/spdx/test_casing_tools.py
+++ b/tests/spdx/test_casing_tools.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2023 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2023 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 import pytest
 
 from spdx.casing_tools import camel_case_to_snake_case, snake_case_to_camel_case

--- a/tests/spdx/test_datetime_conversions.py
+++ b/tests/spdx/test_datetime_conversions.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2022 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2022 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 from datetime import datetime
 
 import pytest

--- a/tests/spdx/validation/test_actor_validator.py
+++ b/tests/spdx/validation/test_actor_validator.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2022 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2022 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 
 from typing import List
 

--- a/tests/spdx/validation/test_annotation_validator.py
+++ b/tests/spdx/validation/test_annotation_validator.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2022 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2022 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 
 from typing import List
 

--- a/tests/spdx/validation/test_checksum_validator.py
+++ b/tests/spdx/validation/test_checksum_validator.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2022 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2022 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 
 from typing import List
 

--- a/tests/spdx/validation/test_creation_info_validator.py
+++ b/tests/spdx/validation/test_creation_info_validator.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2022 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2022 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 
 from typing import List
 

--- a/tests/spdx/validation/test_document_validator.py
+++ b/tests/spdx/validation/test_document_validator.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2022 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2022 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 
 from typing import List, Optional
 

--- a/tests/spdx/validation/test_external_document_ref_validator.py
+++ b/tests/spdx/validation/test_external_document_ref_validator.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2022 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2022 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 
 from typing import List
 

--- a/tests/spdx/validation/test_external_package_ref_validator.py
+++ b/tests/spdx/validation/test_external_package_ref_validator.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2022 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2022 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 
 from typing import List
 

--- a/tests/spdx/validation/test_extracted_licensing_info_validator.py
+++ b/tests/spdx/validation/test_extracted_licensing_info_validator.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2022 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2022 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 
 from typing import List
 

--- a/tests/spdx/validation/test_file_validator.py
+++ b/tests/spdx/validation/test_file_validator.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2022 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2022 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 
 from typing import List
 from unittest import TestCase

--- a/tests/spdx/validation/test_license_expression_validator.py
+++ b/tests/spdx/validation/test_license_expression_validator.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2022 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2022 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 
 from typing import List
 from unittest import TestCase

--- a/tests/spdx/validation/test_package_validator.py
+++ b/tests/spdx/validation/test_package_validator.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2022 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2022 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 
 from typing import List
 from unittest import TestCase

--- a/tests/spdx/validation/test_package_verification_code_validator.py
+++ b/tests/spdx/validation/test_package_verification_code_validator.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2022 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2022 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 
 import pytest
 

--- a/tests/spdx/validation/test_relationship_validator.py
+++ b/tests/spdx/validation/test_relationship_validator.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2022 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2022 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 
 from typing import List
 

--- a/tests/spdx/validation/test_snippet_validator.py
+++ b/tests/spdx/validation/test_snippet_validator.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2022 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2022 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 
 from typing import List
 from unittest import TestCase

--- a/tests/spdx/validation/test_spdx_id_validators.py
+++ b/tests/spdx/validation/test_spdx_id_validators.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2022 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2022 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 from unittest import TestCase
 
 import pytest

--- a/tests/spdx/validation/test_uri_validators.py
+++ b/tests/spdx/validation/test_uri_validators.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2022 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2022 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 
 import pytest
 

--- a/tests/spdx/writer/json/test_json_writer.py
+++ b/tests/spdx/writer/json/test_json_writer.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2022 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2022 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 import json
 import os
 

--- a/tests/spdx/writer/rdf/test_annotation_writer.py
+++ b/tests/spdx/writer/rdf/test_annotation_writer.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2023 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2023 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 from rdflib import RDF, RDFS, Graph, Literal, URIRef
 
 from spdx.datetime_conversions import datetime_to_iso_string

--- a/tests/spdx/writer/rdf/test_checksum_writer.py
+++ b/tests/spdx/writer/rdf/test_checksum_writer.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2023 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2023 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 import pytest
 from rdflib import RDF, Graph, Literal, URIRef
 

--- a/tests/spdx/writer/rdf/test_creation_info_writer.py
+++ b/tests/spdx/writer/rdf/test_creation_info_writer.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2023 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2023 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 from rdflib import RDF, RDFS, Graph, Literal, URIRef
 
 from spdx.datetime_conversions import datetime_to_iso_string

--- a/tests/spdx/writer/rdf/test_external_document_ref_writer.py
+++ b/tests/spdx/writer/rdf/test_external_document_ref_writer.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2023 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2023 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 from rdflib import RDF, Graph, URIRef
 
 from spdx.rdfschema.namespace import SPDX_NAMESPACE

--- a/tests/spdx/writer/rdf/test_extracted_licensing_info_writer.py
+++ b/tests/spdx/writer/rdf/test_extracted_licensing_info_writer.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2023 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2023 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 from rdflib import RDF, RDFS, Graph, Literal, URIRef
 
 from spdx.rdfschema.namespace import SPDX_NAMESPACE

--- a/tests/spdx/writer/rdf/test_file_writer.py
+++ b/tests/spdx/writer/rdf/test_file_writer.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2023 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2023 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 from rdflib import RDF, RDFS, Graph, Literal, URIRef
 
 from spdx.rdfschema.namespace import LICENSE_NAMESPACE, SPDX_NAMESPACE

--- a/tests/spdx/writer/rdf/test_license_expression_writer.py
+++ b/tests/spdx/writer/rdf/test_license_expression_writer.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2023 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2023 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 import pytest
 from license_expression import get_spdx_licensing
 from rdflib import RDF, Graph, Literal, URIRef

--- a/tests/spdx/writer/rdf/test_package_writer.py
+++ b/tests/spdx/writer/rdf/test_package_writer.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2023 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2023 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 import pytest
 from rdflib import DOAP, RDF, RDFS, XSD, Graph, Literal, URIRef
 

--- a/tests/spdx/writer/rdf/test_rdf_writer.py
+++ b/tests/spdx/writer/rdf/test_rdf_writer.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2023 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2023 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 import os
 
 import pytest

--- a/tests/spdx/writer/rdf/test_relationship_writer.py
+++ b/tests/spdx/writer/rdf/test_relationship_writer.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2023 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2023 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 from rdflib import RDFS, Graph, Literal, URIRef
 
 from spdx.rdfschema.namespace import SPDX_NAMESPACE

--- a/tests/spdx/writer/rdf/test_snippet_writer.py
+++ b/tests/spdx/writer/rdf/test_snippet_writer.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2023 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2023 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 import pytest
 from rdflib import RDF, RDFS, Graph, Literal, URIRef
 

--- a/tests/spdx/writer/rdf/test_writer_utils.py
+++ b/tests/spdx/writer/rdf/test_writer_utils.py
@@ -1,13 +1,6 @@
-# Copyright (c) 2023 spdx contributors
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: 2023 spdx contributors
+
+# SPDX-License-Identifier: Apache-2.0
 import pytest
 
 from spdx.writer.rdf.writer_utils import add_namespace_to_spdx_id


### PR DESCRIPTION
fixes #511
I replaced all license texts with the Apache-2.0 License Identifier, except for those not written by @meretp, @nicoweidner, @maxhbr or myself.