### PR TITLE
[spdx-3.0] add package_version

### DIFF
--- a/src/spdx3/README.md
+++ b/src/spdx3/README.md
@@ -1,1 +1,1 @@
-This implementation is mainly based on the descriptive markdown files and the model.png in the repository https://github.com/spdx/spdx-3-model (latest commit: 7d45c8040b2fa1f67d77ea244666c991c47c6a9d).
+This implementation is mainly based on the descriptive markdown files and the model.png in the repository https://github.com/spdx/spdx-3-model (latest commit: 01360996d37c1d913f3d15e2d5911ace182ed200).

--- a/src/spdx3/bump_from_spdx2/package.py
+++ b/src/spdx3/bump_from_spdx2/package.py
@@ -18,8 +18,7 @@ def bump_package(
     spdx_id = "#".join([document_namespace, spdx2_package.spdx_id])
     name = spdx2_package.name
     download_location = handle_no_assertion_or_none(spdx2_package.download_location, "package.download_location")
-    # package2.version -> ?
-    print_missing_conversion("package2.version", 0)
+    package_version = spdx2_package.version
     # package.file_name -> ?
     print_missing_conversion("package2.file_name", 0)
     # package.supplier -> Relationship, suppliedBy?
@@ -54,13 +53,14 @@ def bump_package(
             spdx_id,
             creation_information,
             name,
-            verified_using=integrity_methods,
-            download_location=download_location,
-            homepage=homepage,
             summary=summary,
             description=description,
             comment=comment,
+            verified_using=integrity_methods,
             originated_by=originated_by_spdx_id,
             package_purpose=package_purpose,
+            package_version=package_version,
+            download_location=download_location,
+            homepage=homepage,
         )
     )

--- a/src/spdx3/model/software/package.py
+++ b/src/spdx3/model/software/package.py
@@ -17,6 +17,7 @@ from spdx3.model.software.software_purpose import SoftwarePurpose
 class Package(Artifact):
     content_identifier: Optional[str] = None  # anyURI
     package_purpose: Optional[List[SoftwarePurpose]] = None
+    package_version: Optional[str] = None
     download_location: Optional[str] = None  # anyURI
     package_uri: Optional[str] = None  # anyURI
     homepage: Optional[str] = None  # anyURI
@@ -36,6 +37,7 @@ class Package(Artifact):
         originated_by: Optional[str] = None,
         content_identifier: Optional[str] = None,
         package_purpose: Optional[List[SoftwarePurpose]] = None,
+        package_version: Optional[str] = None,
         download_location: Optional[str] = None,
         package_uri: Optional[str] = None,
         homepage: Optional[str] = None,

--- a/src/spdx3/writer/console/software/package_writer.py
+++ b/src/spdx3/writer/console/software/package_writer.py
@@ -13,6 +13,7 @@ def write_package(package: Package, text_output: TextIO):
     write_artifact_properties(package, text_output)
     write_value("content_identifier", package.content_identifier, text_output)
     write_value("package_purpose", ", ".join([purpose.name for purpose in package.package_purpose]), text_output)
+    write_value("package_version", package.package_version, text_output)
     write_value("download_location", package.download_location, text_output)
     write_value("package_uri", package.package_uri, text_output)
     write_value("homepage", package.homepage, text_output)

--- a/tests/spdx3/bump/test_package_bump.py
+++ b/tests/spdx3/bump/test_package_bump.py
@@ -22,3 +22,4 @@ def test_bump_package(creation_information):
 
     assert isinstance(package, Package)
     assert package.spdx_id == expected_new_package_id
+    assert package.package_version == spdx2_package.version

--- a/tests/spdx3/model/software/test_package.py
+++ b/tests/spdx3/model/software/test_package.py
@@ -16,6 +16,7 @@ def test_correct_initialization(creation_information):
         creation_information,
         content_identifier="https://any.uri",
         package_purpose=[SoftwarePurpose.ARCHIVE, SoftwarePurpose.PATCH],
+        package_version="1:23a_bc",
         download_location="https://downloadlocation",
         package_uri="https://package.uri",
         homepage="https://homepage",
@@ -25,6 +26,7 @@ def test_correct_initialization(creation_information):
     assert package.creation_info == creation_information
     assert package.content_identifier == "https://any.uri"
     assert package.package_purpose == [SoftwarePurpose.ARCHIVE, SoftwarePurpose.PATCH]
+    assert package.package_version == "1:23a_bc"
     assert package.download_location == "https://downloadlocation"
     assert package.package_uri == "https://package.uri"
     assert package.homepage == "https://homepage"
@@ -38,6 +40,7 @@ def test_invalid_initialization(creation_information):
             creation_information,
             content_identifier=3,
             package_purpose=SoftwarePurpose.FILE,
+            package_version=42,
             download_location=4,
             package_uri=["uris"],
             homepage=True,
@@ -50,6 +53,8 @@ def test_invalid_initialization(creation_information):
         "(List[spdx3.model.software.software_purpose.SoftwarePurpose], NoneType); got "
         "spdx3.model.software.software_purpose.SoftwarePurpose instead: "
         "SoftwarePurpose.FILE",
+        'SetterError Package: type of argument "package_version" must be one of '
+        "(str, NoneType); got int instead: 42",
         'SetterError Package: type of argument "download_location" must be one of '
         "(str, NoneType); got int instead: 4",
         'SetterError Package: type of argument "package_uri" must be one of (str, '


### PR DESCRIPTION
As defined in https://github.com/spdx/spdx-3-model/blob/main/model/Software/Classes/Package.md.
During bumping, this will be filled with the content of `spdx2_package.version`.