### PR TITLE
[SPDX-3.0] add creation_info comment

### DIFF
--- a/src/spdx3/bump_from_spdx2/creation_information.py
+++ b/src/spdx3/bump_from_spdx2/creation_information.py
@@ -28,8 +28,7 @@ def bump_creation_information(spdx2_creation_info: Spdx2_CreationInfo, payload: 
     print_missing_conversion("creation_info.document_namespace", 0)
 
     created: datetime = spdx2_creation_info.created
-    # creation_info.creator_comment -> ?
-    print_missing_conversion("creation_info.creator_comment", 0)
+    comment = spdx2_creation_info.document_comment
     data_license = spdx2_creation_info.data_license
     # creation_info.external_document_refs -> spdx_document.imports
     imports = [
@@ -41,7 +40,7 @@ def bump_creation_information(spdx2_creation_info: Spdx2_CreationInfo, payload: 
     # creation_info.document_comment -> spdx_document.comment
     document_comment = spdx2_creation_info.document_comment
     creation_information = CreationInformation(
-        Version("3.0.0"), created, [], [], ["core", "software", "licensing"], data_license
+        Version("3.0.0"), created, [], [], ["core", "software", "licensing"], data_license, comment
     )
 
     # due to creators having a creation_information themselves which inherits from the document's one,

--- a/src/spdx3/model/creation_information.py
+++ b/src/spdx3/model/creation_information.py
@@ -2,7 +2,7 @@
 
 # SPDX-License-Identifier: Apache-2.0
 from datetime import datetime
-from typing import List
+from typing import List, Optional
 
 from semantic_version import Version
 
@@ -18,6 +18,7 @@ class CreationInformation:
     created_using: List[str]  # SPDXID of Tools
     profile: List[str]  # or create an Enum for ProfileIdentifier?
     data_license: str
+    comment: Optional[str] = None
 
     def __init__(
         self,
@@ -27,5 +28,6 @@ class CreationInformation:
         created_using: List[str],
         profile: List[str],
         data_license: str = "CC0",
+        comment: Optional[str] = None,
     ):
         check_types_and_set_values(self, locals())

--- a/src/spdx3/writer/console/creation_information_writer.py
+++ b/src/spdx3/writer/console/creation_information_writer.py
@@ -18,3 +18,4 @@ def write_creation_info(creation_info: CreationInformation, text_output: TextIO,
         write_value("created using", created_using, text_output, indent)
     write_value("profile", ", ".join(creation_info.profile), text_output, indent)
     write_value("data license", creation_info.data_license, text_output, indent)
+    write_value("comment", creation_info.comment, text_output, indent)

--- a/tests/spdx3/model/test_creation_information.py
+++ b/tests/spdx3/model/test_creation_information.py
@@ -11,7 +11,7 @@ from spdx3.model.creation_information import CreationInformation
 
 def test_correct_initialization():
     creation_information = CreationInformation(
-        Version("3.0.0"), datetime(2023, 1, 11, 16, 21), [], [], ["core", "software"], "CC0"
+        Version("3.0.0"), datetime(2023, 1, 11, 16, 21), [], [], ["core", "software"], "CC0", "some comment"
     )
 
     assert creation_information.spec_version == Version("3.0.0")
@@ -20,11 +20,12 @@ def test_correct_initialization():
     assert creation_information.created_using == []
     assert creation_information.profile == ["core", "software"]
     assert creation_information.data_license == "CC0"
+    assert creation_information.comment == "some comment"
 
 
 def test_invalid_initialization():
     with pytest.raises(TypeError) as err:
-        CreationInformation("2.3", "2012-01-01", [], [], "core", 3)
+        CreationInformation("2.3", "2012-01-01", [], [], "core", 3, [])
 
     assert err.value.args[0] == [
         'SetterError CreationInformation: type of argument "spec_version" must be '
@@ -33,6 +34,8 @@ def test_invalid_initialization():
         "datetime.datetime; got str instead: 2012-01-01",
         'SetterError CreationInformation: type of argument "profile" must be a list; ' "got str instead: core",
         'SetterError CreationInformation: type of argument "data_license" must be ' "str; got int instead: 3",
+        'SetterError CreationInformation: type of argument "comment" must be'
+        " one of (str, NoneType); got list instead: []",
     ]
 
 


### PR DESCRIPTION
As seen in https://github.com/spdx/spdx-3-model/blob/main/model/Core/Classes/CreationInformation.md.
`spdx2_creation_info.document_comment` converts into this.