### PR TITLE
[issue-558] add test for optional feature to GitHub Action

### DIFF
--- a/.github/workflows/install_and_test.yml
+++ b/.github/workflows/install_and_test.yml
@@ -33,3 +33,8 @@ jobs:
         run: pytest
       - name: Run CLI
         run: pyspdxtools -i ./tests/spdx/data/formats/SPDXJSONExample-v2.3.spdx.json
+
+      - name: Install optional dependencies
+        run: python -m pip install networkx
+      - name: Run tests for graph generation
+        run: pytest tests/spdx/test_graph_generation.py

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,8 +34,10 @@ Here's the process to make changes to the codebase:
    git checkout -b fix-or-improve-something
    python -m venv ./venv
    ./venv/bin/activate
-   pip install -e .
+   pip install -e ".[development]"
    ```
+   Note: By using the group `[development]` for the installation, all dependencies (including optional ones) will be 
+   installed. This way we make sure that all tests are executed. 
 5. Make some changes and commit them to the branch:
    ```sh
    git commit --signoff -m 'description of my changes'
@@ -49,14 +51,12 @@ Here's the process to make changes to the codebase:
    retroactively signs a range of past commits.
 6. Test your changes:
    ```sh
-   pip install pytest
    pytest -vvs # in the repo root
    ```
 
 7. Check your code style. When opening a pull request, your changes will automatically be checked with `isort`, `black` 
    and `flake8` to make sure your changes fit with the rest of the code style. 
     ```sh
-   pip install .[code_style]
    # run the following commands in the repo root
    isort src tests 
    black src tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dynamic = ["version"]
 test = ["pytest"]
 code_style = ["isort", "black", "flake8"]
 graph_generation = ["pygraphviz", "networkx"]
+development = ["black", "flake8", "isort", "networkx", "pytest"]
 
 [project.scripts]
 pyspdxtools = "spdx.clitools.pyspdxtools:main"

--- a/tests/spdx/test_graph_generation.py
+++ b/tests/spdx/test_graph_generation.py
@@ -15,7 +15,6 @@ from tests.spdx.fixtures import document_fixture, file_fixture, package_fixture
 
 try:
     import networkx  # noqa: F401
-    import pygraphviz  # noqa: F401
 except ImportError:
     pytest.skip("Skip this module as the tests need optional dependencies to run.", allow_module_level=True)
 
@@ -44,7 +43,7 @@ except ImportError:
         (
             "SPDXRdfExample-v2.2.spdx.rdf.xml",
             20,
-            17,
+            19,
             ["SPDXRef-Package_DYNAMIC_LINK", "SPDXRef-JenaLib_CONTAINS"],
         ),
         (


### PR DESCRIPTION
I decided to add the installation of the optional dependency and the test as additional steps to the GitHub Action so that we ensure on the one hand that the source installation is successful und all tests pass (resp. are skipped) and on the other hand also run the tests for the optional feature. 

addition to #562, fixes #558

Edit: I updated the test to only be skipped if `networkx` is not installed and install this package manually in the GitHub Action, as this is the only package needed for the tests. `pygraphviz` requires an installation of `graphviz` on the operating system. This seems to be more involving for Windows so I decided not to add this for the moment, as this is only an optional feature.