### PR TITLE
[issue-427] add purl special case with comment distinction

### DIFF
--- a/src/spdx3/bump_from_spdx2/package.py
+++ b/src/spdx3/bump_from_spdx2/package.py
@@ -52,12 +52,12 @@ def bump_package(
     purl_refs = [
         external_ref for external_ref in spdx2_package.external_references if external_ref.reference_type == "purl"
     ]
-    exactly_one_purl = len(purl_refs) == 1
+    exactly_one_purl_without_comment = len(purl_refs) == 1 and purl_refs[0].comment is None
     package_url = None
-    if exactly_one_purl:
+    if exactly_one_purl_without_comment:
         package_url = purl_refs[0].locator
     for spdx2_external_ref in spdx2_package.external_references:
-        if exactly_one_purl and spdx2_external_ref.reference_type == "purl":
+        if exactly_one_purl_without_comment and spdx2_external_ref.reference_type == "purl":
             continue
         id_or_ref = bump_external_package_ref(spdx2_external_ref)
         if isinstance(id_or_ref, ExternalReference):

--- a/tests/spdx3/bump/test_package_bump.py
+++ b/tests/spdx3/bump/test_package_bump.py
@@ -42,12 +42,12 @@ def test_bump_package(creation_information):
 
 
 @mock.patch("spdx3.model.creation_information.CreationInformation")
-def test_bump_of_single_purl(creation_information):
+def test_bump_of_single_purl_without_comment(creation_information):
     payload = Payload()
     document_namespace = "https://doc.namespace"
     spdx2_package: Spdx2_Package = package_fixture(
         external_references=[
-            ExternalPackageRef(ExternalPackageRefCategory.PACKAGE_MANAGER, "purl", "purl_locator", "purl_comment"),
+            ExternalPackageRef(ExternalPackageRefCategory.PACKAGE_MANAGER, "purl", "purl_locator", None),
         ]
     )
     expected_new_package_id = f"{document_namespace}#{spdx2_package.spdx_id}"
@@ -61,13 +61,34 @@ def test_bump_of_single_purl(creation_information):
 
 
 @mock.patch("spdx3.model.creation_information.CreationInformation")
-def test_bump_of_multiple_purls(creation_information):
+def test_bump_of_single_purl_with_comment(creation_information):
     payload = Payload()
     document_namespace = "https://doc.namespace"
     spdx2_package: Spdx2_Package = package_fixture(
         external_references=[
             ExternalPackageRef(ExternalPackageRefCategory.PACKAGE_MANAGER, "purl", "purl_locator", "purl_comment"),
-            ExternalPackageRef(ExternalPackageRefCategory.PACKAGE_MANAGER, "purl", "purl_locator2", "purl_comment2"),
+        ]
+    )
+    expected_new_package_id = f"{document_namespace}#{spdx2_package.spdx_id}"
+
+    bump_package(spdx2_package, payload, creation_information, document_namespace)
+    package = payload.get_element(expected_new_package_id)
+
+    assert package.package_url is None
+    assert package.external_references == []
+    assert package.external_identifier == [
+        ExternalIdentifier(ExternalIdentifierType.PURL, "purl_locator", "purl_comment")
+    ]
+
+
+@mock.patch("spdx3.model.creation_information.CreationInformation")
+def test_bump_of_multiple_purls(creation_information):
+    payload = Payload()
+    document_namespace = "https://doc.namespace"
+    spdx2_package: Spdx2_Package = package_fixture(
+        external_references=[
+            ExternalPackageRef(ExternalPackageRefCategory.PACKAGE_MANAGER, "purl", "purl_locator", "comment"),
+            ExternalPackageRef(ExternalPackageRefCategory.PACKAGE_MANAGER, "purl", "purl_locator2", None),
         ]
     )
     expected_new_package_id = f"{document_namespace}#{spdx2_package.spdx_id}"
@@ -80,7 +101,7 @@ def test_bump_of_multiple_purls(creation_information):
     TestCase().assertCountEqual(
         package.external_identifier,
         [
-            ExternalIdentifier(ExternalIdentifierType.PURL, "purl_locator", "purl_comment"),
-            ExternalIdentifier(ExternalIdentifierType.PURL, "purl_locator2", "purl_comment2"),
+            ExternalIdentifier(ExternalIdentifierType.PURL, "purl_locator", "comment"),
+            ExternalIdentifier(ExternalIdentifierType.PURL, "purl_locator2", None),
         ],
     )


### PR DESCRIPTION
The package URL migration become even more complex, [see here](https://docs.google.com/document/d/1-olHRnX1CssUS67Psv_sAq9Vd-pc81HF8MM0hA7M0hg/edit#heading=h.r889hoh0obeu).

That is, a purl is converted to the new SPDX3 packageUrl property iff it is the only purl and has no comment.