### PR TITLE
[issue-402] change `write_document()` to `write_document_to_file()`

### DIFF
--- a/src/spdx/writer/json/json_writer.py
+++ b/src/spdx/writer/json/json_writer.py
@@ -10,7 +10,9 @@ from spdx.validation.document_validator import validate_full_spdx_document
 from spdx.validation.validation_message import ValidationMessage
 
 
-def write_document(document: Document, file_name: str, validate: bool = True, converter: DocumentConverter = None):
+def write_document_to_file(
+    document: Document, file_name: str, validate: bool = True, converter: DocumentConverter = None
+):
     """
     Serializes the provided document to json and writes it to a file with the provided name. Unless validate is set
     to False, validates the document before serialization. Unless a DocumentConverter instance is provided,

--- a/src/spdx/writer/write_anything.py
+++ b/src/spdx/writer/write_anything.py
@@ -13,7 +13,7 @@ from spdx.writer.yaml import yaml_writer
 def write_file(document: Document, file_name: str, validate: bool = True):
     output_format = file_name_to_format(file_name)
     if output_format == FileFormat.JSON:
-        json_writer.write_document(document, file_name, validate)
+        json_writer.write_document_to_file(document, file_name, validate)
     elif output_format == FileFormat.YAML:
         yaml_writer.write_document_to_file(document, file_name, validate)
     elif output_format == FileFormat.XML:

--- a/tests/spdx/writer/json/test_json_writer.py
+++ b/tests/spdx/writer/json/test_json_writer.py
@@ -6,7 +6,7 @@ import os
 
 import pytest
 
-from spdx.writer.json.json_writer import write_document
+from spdx.writer.json.json_writer import write_document_to_file
 from tests.spdx.fixtures import document_fixture
 
 
@@ -19,7 +19,7 @@ def temporary_file_path() -> str:
 
 def test_write_json(temporary_file_path: str):
     document = document_fixture()
-    write_document(document, temporary_file_path, validate=True)
+    write_document_to_file(document, temporary_file_path, validate=True)
 
     with open(temporary_file_path) as written_file:
         written_json = json.load(written_file)
@@ -35,7 +35,7 @@ def test_document_is_validated():
     document.creation_info.spdx_id = "InvalidId"
 
     with pytest.raises(ValueError) as error:
-        write_document(document, "dummy_path")
+        write_document_to_file(document, "dummy_path")
     assert "Document is not valid" in error.value.args[0]
 
 
@@ -43,4 +43,4 @@ def test_document_validation_can_be_overridden(temporary_file_path: str):
     document = document_fixture()
     document.creation_info.spdx_id = "InvalidId"
 
-    write_document(document, temporary_file_path, validate=False)
+    write_document_to_file(document, temporary_file_path, validate=False)


### PR DESCRIPTION
part of #402 
This will make it consistent with the other functions of other formats.