### PR TITLE
[issue-540] change DESCRIBES validation

### DIFF
--- a/src/spdx/validation/document_validator.py
+++ b/src/spdx/validation/document_validator.py
@@ -70,11 +70,12 @@ def validate_full_spdx_document(document: Document, spdx_version: str = None) ->
         document.relationships, RelationshipType.DESCRIBED_BY, document_id
     )
 
-    if not document_describes_relationships + described_by_document_relationships:
+    only_a_single_package = len(document.packages) == 1 and not document.files and not document.snippets
+    if not only_a_single_package and not document_describes_relationships + described_by_document_relationships:
         validation_messages.append(
             ValidationMessage(
                 f'there must be at least one relationship "{document_id} DESCRIBES ..." or "... DESCRIBED_BY '
-                f'{document_id}"',
+                f'{document_id}" when there is not only a single package present',
                 ValidationContext(spdx_id=document_id, element_type=SpdxElementType.DOCUMENT),
             )
         )

--- a/tests/spdx/validation/test_document_validator.py
+++ b/tests/spdx/validation/test_document_validator.py
@@ -94,7 +94,20 @@ def test_document_describes_at_least_one_element(relationships):
     assert validation_messages == []
 
 
-def test_document_does_not_describe_an_element():
+def test_document_does_not_describe_an_element_with_only_one_package():
+    document = document_fixture(
+        packages=[package_fixture()],
+        files=[],
+        snippets=[],
+        relationships=[],
+        annotations=[],
+    )
+    validation_messages: List[ValidationMessage] = validate_full_spdx_document(document)
+
+    assert validation_messages == []
+
+
+def test_document_does_not_describe_an_element_with_multiple_elements():
     document = document_fixture(
         relationships=[Relationship("SPDXRef-Package", RelationshipType.DESCRIBES, "SPDXRef-File")]
     )
@@ -103,7 +116,7 @@ def test_document_does_not_describe_an_element():
     assert validation_messages == [
         ValidationMessage(
             f'there must be at least one relationship "{DOCUMENT_SPDX_ID} DESCRIBES ..." or "... DESCRIBED_BY '
-            f'{DOCUMENT_SPDX_ID}"',
+            f'{DOCUMENT_SPDX_ID}" when there is not only a single package present',
             ValidationContext(spdx_id=DOCUMENT_SPDX_ID, element_type=SpdxElementType.DOCUMENT),
         )
     ]


### PR DESCRIPTION
The new logic is now: 
A `DESCRIBES` relationship is not mandatory if there is only a single SPDX element present which is a package.