### PR TITLE
[issue-593] expose model classes in model package init

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,4 +1,4 @@
 [flake8]
 max-line-length = 119
-exclude = src/spdx_tools/spdx/parser/tagvalue/parsetab.py
+exclude = src/spdx_tools/spdx/parser/tagvalue/parsetab.py, src/spdx_tools/spdx/model/__init__.py
 extend-ignore = E203

--- a/README.md
+++ b/README.md
@@ -94,13 +94,13 @@ instead of `bin`.
 
 ## Library usage
 1. **DATA MODEL**
-  * The `src.spdx.model` package constitutes the internal SPDX v2.3 data model (v2.2 is a simply a subset of this).
+  * The `spdx_tools.spdx.model` package constitutes the internal SPDX v2.3 data model (v2.2 is a simply a subset of this). All relevant classes for SPDX document creation are exposed in the [__init__.py](src%2Fspdx_tools%2Fspdx%2Fmodel%2F__init__.py).
   * SPDX objects are implemented via `@dataclass_with_properties`, a custom extension of `@dataclass`.
     * Each class starts with a list of its properties and their possible types. When no default value is provided, the property is mandatory and must be set during initialization.
     * Using the type hints, type checking is enforced when initializing a new instance or setting/getting a property on an instance
       (wrong types will raise `ConstructorTypeError` or `TypeError`, respectively). This makes it easy to catch invalid properties early and only construct valid documents.
     * Note: in-place manipulations like `list.append(item)` will circumvent the type checking (a `TypeError` will still be raised when reading `list` again). We recommend using `list = list + [item]` instead.
-  * The main entry point of an SPDX document is the `Document` class, which links to all other classes.
+  * The main entry point of an SPDX document is the `Document` class from the [document.py](src%2Fspdx_tools%2Fspdx%2Fmodel%2Fdocument.py) module, which links to all other classes.
   * For license handling, the [license_expression](https://github.com/nexB/license-expression) library is used.
   * Note on `documentDescribes` and `hasFiles`: These fields will be converted to relationships in the internal data model. As they are deprecated, these fields will not be written in the output.
 2. **PARSING**
@@ -123,9 +123,9 @@ import logging
 
 from license_expression import get_spdx_licensing
 
-from spdx_tools.spdx.model.checksum import Checksum, ChecksumAlgorithm
-from spdx_tools.spdx.model.file import File, FileType
-from spdx_tools.spdx.model.relationship import Relationship, RelationshipType
+from spdx_tools.spdx.model import Checksum, ChecksumAlgorithm
+from spdx_tools.spdx.model import File, FileType
+from spdx_tools.spdx.model import Relationship, RelationshipType
 from spdx_tools.spdx.parser.parse_anything import parse_file
 from spdx_tools.spdx.validation.document_validator import validate_full_spdx_document
 from spdx_tools.spdx.writer.write_anything import write_file

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,3 +61,4 @@ include = "(^/src/.*.py|^/tests/.*.py)"
 [tool.isort]
 profile = "black"
 line_length = 119
+skip = ["__init__.py"]

--- a/src/spdx_tools/spdx/clitools/pyspdxtools.py
+++ b/src/spdx_tools/spdx/clitools/pyspdxtools.py
@@ -19,7 +19,7 @@ from typing import List
 import click
 
 from spdx_tools.spdx.graph_generation import export_graph_from_document
-from spdx_tools.spdx.model.document import Document
+from spdx_tools.spdx.model import Document
 from spdx_tools.spdx.parser.error import SPDXParsingError
 from spdx_tools.spdx.parser.parse_anything import parse_file
 from spdx_tools.spdx.validation.document_validator import validate_full_spdx_document

--- a/src/spdx_tools/spdx/document_utils.py
+++ b/src/spdx_tools/spdx/document_utils.py
@@ -4,10 +4,7 @@
 from copy import deepcopy
 from typing import Any, Dict, List, Union
 
-from spdx_tools.spdx.model.document import Document
-from spdx_tools.spdx.model.file import File
-from spdx_tools.spdx.model.package import Package
-from spdx_tools.spdx.model.snippet import Snippet
+from spdx_tools.spdx.model import Document, File, Package, Snippet
 
 
 def get_contained_spdx_element_ids(document: Document) -> List[str]:

--- a/src/spdx_tools/spdx/graph_generation.py
+++ b/src/spdx_tools/spdx/graph_generation.py
@@ -3,17 +3,14 @@
 # SPDX-License-Identifier: Apache-2.0
 from typing import Dict, List, Union
 
-from spdx_tools.spdx.model.file import File
-from spdx_tools.spdx.model.package import Package
-from spdx_tools.spdx.model.snippet import Snippet
+from spdx_tools.spdx.model import File, Package, Snippet
 
 try:
     from networkx import DiGraph
 except ImportError:
     DiGraph = None
 from spdx_tools.spdx.document_utils import get_contained_spdx_elements
-from spdx_tools.spdx.model.document import Document
-from spdx_tools.spdx.model.relationship import Relationship
+from spdx_tools.spdx.model import Document, Relationship
 
 
 def export_graph_from_document(document: Document, file_name: str) -> None:

--- a/src/spdx_tools/spdx/jsonschema/annotation_converter.py
+++ b/src/spdx_tools/spdx/jsonschema/annotation_converter.py
@@ -7,8 +7,7 @@ from spdx_tools.spdx.datetime_conversions import datetime_to_iso_string
 from spdx_tools.spdx.jsonschema.annotation_properties import AnnotationProperty
 from spdx_tools.spdx.jsonschema.converter import TypedConverter
 from spdx_tools.spdx.jsonschema.json_property import JsonProperty
-from spdx_tools.spdx.model.annotation import Annotation
-from spdx_tools.spdx.model.document import Document
+from spdx_tools.spdx.model import Annotation, Document
 
 
 class AnnotationConverter(TypedConverter[Annotation]):

--- a/src/spdx_tools/spdx/jsonschema/checksum_converter.py
+++ b/src/spdx_tools/spdx/jsonschema/checksum_converter.py
@@ -6,8 +6,7 @@ from typing import Type
 from spdx_tools.spdx.jsonschema.checksum_properties import ChecksumProperty
 from spdx_tools.spdx.jsonschema.converter import TypedConverter
 from spdx_tools.spdx.jsonschema.json_property import JsonProperty
-from spdx_tools.spdx.model.checksum import Checksum, ChecksumAlgorithm
-from spdx_tools.spdx.model.document import Document
+from spdx_tools.spdx.model import Checksum, ChecksumAlgorithm, Document
 
 
 class ChecksumConverter(TypedConverter[Checksum]):

--- a/src/spdx_tools/spdx/jsonschema/converter.py
+++ b/src/spdx_tools/spdx/jsonschema/converter.py
@@ -6,7 +6,7 @@ from typing import Any, Dict, Generic, Type, TypeVar
 
 from spdx_tools.spdx.casing_tools import snake_case_to_camel_case
 from spdx_tools.spdx.jsonschema.json_property import JsonProperty
-from spdx_tools.spdx.model.document import Document
+from spdx_tools.spdx.model import Document
 
 MISSING_IMPLEMENTATION_MESSAGE = "Must be implemented"
 

--- a/src/spdx_tools/spdx/jsonschema/creation_info_converter.py
+++ b/src/spdx_tools/spdx/jsonschema/creation_info_converter.py
@@ -8,7 +8,7 @@ from spdx_tools.spdx.jsonschema.converter import TypedConverter
 from spdx_tools.spdx.jsonschema.creation_info_properties import CreationInfoProperty
 from spdx_tools.spdx.jsonschema.json_property import JsonProperty
 from spdx_tools.spdx.jsonschema.optional_utils import apply_if_present
-from spdx_tools.spdx.model.document import CreationInfo, Document
+from spdx_tools.spdx.model import CreationInfo, Document
 
 
 class CreationInfoConverter(TypedConverter[CreationInfo]):

--- a/src/spdx_tools/spdx/jsonschema/document_converter.py
+++ b/src/spdx_tools/spdx/jsonschema/document_converter.py
@@ -15,7 +15,7 @@ from spdx_tools.spdx.jsonschema.json_property import JsonProperty
 from spdx_tools.spdx.jsonschema.package_converter import PackageConverter
 from spdx_tools.spdx.jsonschema.relationship_converter import RelationshipConverter
 from spdx_tools.spdx.jsonschema.snippet_converter import SnippetConverter
-from spdx_tools.spdx.model.document import Document
+from spdx_tools.spdx.model import Document
 
 
 class DocumentConverter(TypedConverter[Document]):

--- a/src/spdx_tools/spdx/jsonschema/external_document_ref_converter.py
+++ b/src/spdx_tools/spdx/jsonschema/external_document_ref_converter.py
@@ -7,8 +7,7 @@ from spdx_tools.spdx.jsonschema.checksum_converter import ChecksumConverter
 from spdx_tools.spdx.jsonschema.converter import TypedConverter
 from spdx_tools.spdx.jsonschema.external_document_ref_properties import ExternalDocumentRefProperty
 from spdx_tools.spdx.jsonschema.json_property import JsonProperty
-from spdx_tools.spdx.model.document import Document
-from spdx_tools.spdx.model.external_document_ref import ExternalDocumentRef
+from spdx_tools.spdx.model import Document, ExternalDocumentRef
 
 
 class ExternalDocumentRefConverter(TypedConverter[ExternalDocumentRef]):

--- a/src/spdx_tools/spdx/jsonschema/external_package_ref_converter.py
+++ b/src/spdx_tools/spdx/jsonschema/external_package_ref_converter.py
@@ -6,8 +6,7 @@ from typing import Any, Type
 from spdx_tools.spdx.jsonschema.converter import TypedConverter
 from spdx_tools.spdx.jsonschema.external_package_ref_properties import ExternalPackageRefProperty
 from spdx_tools.spdx.jsonschema.json_property import JsonProperty
-from spdx_tools.spdx.model.document import Document
-from spdx_tools.spdx.model.package import ExternalPackageRef
+from spdx_tools.spdx.model import Document, ExternalPackageRef
 
 
 class ExternalPackageRefConverter(TypedConverter[ExternalPackageRef]):

--- a/src/spdx_tools/spdx/jsonschema/extracted_licensing_info_converter.py
+++ b/src/spdx_tools/spdx/jsonschema/extracted_licensing_info_converter.py
@@ -7,8 +7,7 @@ from spdx_tools.spdx.jsonschema.converter import TypedConverter
 from spdx_tools.spdx.jsonschema.extracted_licensing_info_properties import ExtractedLicensingInfoProperty
 from spdx_tools.spdx.jsonschema.json_property import JsonProperty
 from spdx_tools.spdx.jsonschema.optional_utils import apply_if_present
-from spdx_tools.spdx.model.document import Document
-from spdx_tools.spdx.model.extracted_licensing_info import ExtractedLicensingInfo
+from spdx_tools.spdx.model import Document, ExtractedLicensingInfo
 
 
 class ExtractedLicensingInfoConverter(TypedConverter[ExtractedLicensingInfo]):

--- a/src/spdx_tools/spdx/jsonschema/file_converter.py
+++ b/src/spdx_tools/spdx/jsonschema/file_converter.py
@@ -9,8 +9,7 @@ from spdx_tools.spdx.jsonschema.converter import TypedConverter
 from spdx_tools.spdx.jsonschema.file_properties import FileProperty
 from spdx_tools.spdx.jsonschema.json_property import JsonProperty
 from spdx_tools.spdx.jsonschema.optional_utils import apply_if_present
-from spdx_tools.spdx.model.document import Document
-from spdx_tools.spdx.model.file import File
+from spdx_tools.spdx.model import Document, File
 
 
 class FileConverter(TypedConverter[File]):

--- a/src/spdx_tools/spdx/jsonschema/package_converter.py
+++ b/src/spdx_tools/spdx/jsonschema/package_converter.py
@@ -12,9 +12,7 @@ from spdx_tools.spdx.jsonschema.json_property import JsonProperty
 from spdx_tools.spdx.jsonschema.optional_utils import apply_if_present
 from spdx_tools.spdx.jsonschema.package_properties import PackageProperty
 from spdx_tools.spdx.jsonschema.package_verification_code_converter import PackageVerificationCodeConverter
-from spdx_tools.spdx.model.actor import Actor
-from spdx_tools.spdx.model.document import Document
-from spdx_tools.spdx.model.package import Package
+from spdx_tools.spdx.model import Actor, Document, Package
 
 
 class PackageConverter(TypedConverter[Package]):

--- a/src/spdx_tools/spdx/jsonschema/package_verification_code_converter.py
+++ b/src/spdx_tools/spdx/jsonschema/package_verification_code_converter.py
@@ -6,8 +6,7 @@ from typing import Any, Type
 from spdx_tools.spdx.jsonschema.converter import TypedConverter
 from spdx_tools.spdx.jsonschema.json_property import JsonProperty
 from spdx_tools.spdx.jsonschema.package_verification_code_properties import PackageVerificationCodeProperty
-from spdx_tools.spdx.model.document import Document
-from spdx_tools.spdx.model.package import PackageVerificationCode
+from spdx_tools.spdx.model import Document, PackageVerificationCode
 
 
 class PackageVerificationCodeConverter(TypedConverter[PackageVerificationCode]):

--- a/src/spdx_tools/spdx/jsonschema/relationship_converter.py
+++ b/src/spdx_tools/spdx/jsonschema/relationship_converter.py
@@ -6,8 +6,7 @@ from typing import Any, Type
 from spdx_tools.spdx.jsonschema.converter import TypedConverter
 from spdx_tools.spdx.jsonschema.json_property import JsonProperty
 from spdx_tools.spdx.jsonschema.relationship_properties import RelationshipProperty
-from spdx_tools.spdx.model.document import Document
-from spdx_tools.spdx.model.relationship import Relationship
+from spdx_tools.spdx.model import Document, Relationship
 
 
 class RelationshipConverter(TypedConverter[Relationship]):

--- a/src/spdx_tools/spdx/jsonschema/snippet_converter.py
+++ b/src/spdx_tools/spdx/jsonschema/snippet_converter.py
@@ -8,8 +8,7 @@ from spdx_tools.spdx.jsonschema.converter import TypedConverter
 from spdx_tools.spdx.jsonschema.json_property import JsonProperty
 from spdx_tools.spdx.jsonschema.optional_utils import apply_if_present
 from spdx_tools.spdx.jsonschema.snippet_properties import SnippetProperty
-from spdx_tools.spdx.model.document import Document
-from spdx_tools.spdx.model.snippet import Snippet
+from spdx_tools.spdx.model import Document, Snippet
 
 
 class SnippetConverter(TypedConverter[Snippet]):

--- a/src/spdx_tools/spdx/model/__init__.py
+++ b/src/spdx_tools/spdx/model/__init__.py
@@ -1,0 +1,19 @@
+from spdx_tools.spdx.model.spdx_no_assertion import SpdxNoAssertion
+from spdx_tools.spdx.model.spdx_none import SpdxNone
+from spdx_tools.spdx.model.version import Version
+from spdx_tools.spdx.model.actor import Actor, ActorType
+from spdx_tools.spdx.model.annotation import Annotation, AnnotationType
+from spdx_tools.spdx.model.checksum import Checksum, ChecksumAlgorithm
+from spdx_tools.spdx.model.external_document_ref import ExternalDocumentRef
+from spdx_tools.spdx.model.extracted_licensing_info import ExtractedLicensingInfo
+from spdx_tools.spdx.model.file import File, FileType
+from spdx_tools.spdx.model.package import (
+    ExternalPackageRef,
+    ExternalPackageRefCategory,
+    Package,
+    PackagePurpose,
+    PackageVerificationCode,
+)
+from spdx_tools.spdx.model.relationship import Relationship, RelationshipType
+from spdx_tools.spdx.model.snippet import Snippet
+from spdx_tools.spdx.model.document import CreationInfo, Document

--- a/src/spdx_tools/spdx/model/annotation.py
+++ b/src/spdx_tools/spdx/model/annotation.py
@@ -6,7 +6,7 @@ from enum import Enum, auto
 
 from spdx_tools.common.typing.dataclass_with_properties import dataclass_with_properties
 from spdx_tools.common.typing.type_checks import check_types_and_set_values
-from spdx_tools.spdx.model.actor import Actor
+from spdx_tools.spdx.model import Actor
 
 
 class AnnotationType(Enum):

--- a/src/spdx_tools/spdx/model/document.py
+++ b/src/spdx_tools/spdx/model/document.py
@@ -7,15 +7,17 @@ from typing import List, Optional
 
 from spdx_tools.common.typing.dataclass_with_properties import dataclass_with_properties
 from spdx_tools.common.typing.type_checks import check_types_and_set_values
-from spdx_tools.spdx.model.actor import Actor
-from spdx_tools.spdx.model.annotation import Annotation
-from spdx_tools.spdx.model.external_document_ref import ExternalDocumentRef
-from spdx_tools.spdx.model.extracted_licensing_info import ExtractedLicensingInfo
-from spdx_tools.spdx.model.file import File
-from spdx_tools.spdx.model.package import Package
-from spdx_tools.spdx.model.relationship import Relationship
-from spdx_tools.spdx.model.snippet import Snippet
-from spdx_tools.spdx.model.version import Version
+from spdx_tools.spdx.model import (
+    Actor,
+    Annotation,
+    ExternalDocumentRef,
+    ExtractedLicensingInfo,
+    File,
+    Package,
+    Relationship,
+    Snippet,
+    Version,
+)
 
 
 @dataclass_with_properties

--- a/src/spdx_tools/spdx/model/external_document_ref.py
+++ b/src/spdx_tools/spdx/model/external_document_ref.py
@@ -4,7 +4,7 @@
 
 from spdx_tools.common.typing.dataclass_with_properties import dataclass_with_properties
 from spdx_tools.common.typing.type_checks import check_types_and_set_values
-from spdx_tools.spdx.model.checksum import Checksum
+from spdx_tools.spdx.model import Checksum
 
 
 @dataclass_with_properties

--- a/src/spdx_tools/spdx/model/extracted_licensing_info.py
+++ b/src/spdx_tools/spdx/model/extracted_licensing_info.py
@@ -6,7 +6,7 @@ from typing import List, Optional, Union
 
 from spdx_tools.common.typing.dataclass_with_properties import dataclass_with_properties
 from spdx_tools.common.typing.type_checks import check_types_and_set_values
-from spdx_tools.spdx.model.spdx_no_assertion import SpdxNoAssertion
+from spdx_tools.spdx.model import SpdxNoAssertion
 
 
 @dataclass_with_properties

--- a/src/spdx_tools/spdx/model/file.py
+++ b/src/spdx_tools/spdx/model/file.py
@@ -9,9 +9,7 @@ from license_expression import LicenseExpression
 
 from spdx_tools.common.typing.dataclass_with_properties import dataclass_with_properties
 from spdx_tools.common.typing.type_checks import check_types_and_set_values
-from spdx_tools.spdx.model.checksum import Checksum
-from spdx_tools.spdx.model.spdx_no_assertion import SpdxNoAssertion
-from spdx_tools.spdx.model.spdx_none import SpdxNone
+from spdx_tools.spdx.model import Checksum, SpdxNoAssertion, SpdxNone
 
 
 class FileType(Enum):

--- a/src/spdx_tools/spdx/model/package.py
+++ b/src/spdx_tools/spdx/model/package.py
@@ -10,10 +10,7 @@ from license_expression import LicenseExpression
 
 from spdx_tools.common.typing.dataclass_with_properties import dataclass_with_properties
 from spdx_tools.common.typing.type_checks import check_types_and_set_values
-from spdx_tools.spdx.model.actor import Actor
-from spdx_tools.spdx.model.checksum import Checksum
-from spdx_tools.spdx.model.spdx_no_assertion import SpdxNoAssertion
-from spdx_tools.spdx.model.spdx_none import SpdxNone
+from spdx_tools.spdx.model import Actor, Checksum, SpdxNoAssertion, SpdxNone
 
 
 class PackagePurpose(Enum):

--- a/src/spdx_tools/spdx/model/relationship.py
+++ b/src/spdx_tools/spdx/model/relationship.py
@@ -6,8 +6,7 @@ from typing import Optional, Union
 
 from spdx_tools.common.typing.dataclass_with_properties import dataclass_with_properties
 from spdx_tools.common.typing.type_checks import check_types_and_set_values
-from spdx_tools.spdx.model.spdx_no_assertion import SpdxNoAssertion
-from spdx_tools.spdx.model.spdx_none import SpdxNone
+from spdx_tools.spdx.model import SpdxNoAssertion, SpdxNone
 
 
 class RelationshipType(Enum):

--- a/src/spdx_tools/spdx/model/relationship_filters.py
+++ b/src/spdx_tools/spdx/model/relationship_filters.py
@@ -3,9 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 from typing import List
 
-from spdx_tools.spdx.model.document import Document
-from spdx_tools.spdx.model.package import Package
-from spdx_tools.spdx.model.relationship import Relationship, RelationshipType
+from spdx_tools.spdx.model import Document, Package, Relationship, RelationshipType
 
 
 def find_package_contains_file_relationships(document: Document, package: Package) -> List[Relationship]:

--- a/src/spdx_tools/spdx/model/snippet.py
+++ b/src/spdx_tools/spdx/model/snippet.py
@@ -8,8 +8,7 @@ from license_expression import LicenseExpression
 
 from spdx_tools.common.typing.dataclass_with_properties import dataclass_with_properties
 from spdx_tools.common.typing.type_checks import check_types_and_set_values
-from spdx_tools.spdx.model.spdx_no_assertion import SpdxNoAssertion
-from spdx_tools.spdx.model.spdx_none import SpdxNone
+from spdx_tools.spdx.model import SpdxNoAssertion, SpdxNone
 
 
 @dataclass_with_properties

--- a/src/spdx_tools/spdx/parser/actor_parser.py
+++ b/src/spdx_tools/spdx/parser/actor_parser.py
@@ -4,7 +4,7 @@
 import re
 from typing import Match, Optional, Pattern
 
-from spdx_tools.spdx.model.actor import Actor, ActorType
+from spdx_tools.spdx.model import Actor, ActorType
 from spdx_tools.spdx.parser.error import SPDXParsingError
 from spdx_tools.spdx.parser.parsing_functions import construct_or_raise_parsing_error
 

--- a/src/spdx_tools/spdx/parser/json/json_parser.py
+++ b/src/spdx_tools/spdx/parser/json/json_parser.py
@@ -4,7 +4,7 @@
 import json
 from typing import Dict
 
-from spdx_tools.spdx.model.document import Document
+from spdx_tools.spdx.model import Document
 from spdx_tools.spdx.parser.jsonlikedict.json_like_dict_parser import JsonLikeDictParser
 
 

--- a/src/spdx_tools/spdx/parser/jsonlikedict/annotation_parser.py
+++ b/src/spdx_tools/spdx/parser/jsonlikedict/annotation_parser.py
@@ -5,8 +5,7 @@ from datetime import datetime
 from typing import Dict, List, Optional
 
 from spdx_tools.spdx.datetime_conversions import datetime_from_str
-from spdx_tools.spdx.model.actor import Actor
-from spdx_tools.spdx.model.annotation import Annotation, AnnotationType
+from spdx_tools.spdx.model import Actor, Annotation, AnnotationType
 from spdx_tools.spdx.parser.actor_parser import ActorParser
 from spdx_tools.spdx.parser.error import SPDXParsingError
 from spdx_tools.spdx.parser.jsonlikedict.dict_parsing_functions import (

--- a/src/spdx_tools/spdx/parser/jsonlikedict/checksum_parser.py
+++ b/src/spdx_tools/spdx/parser/jsonlikedict/checksum_parser.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 from typing import Dict, Optional
 
-from spdx_tools.spdx.model.checksum import Checksum, ChecksumAlgorithm
+from spdx_tools.spdx.model import Checksum, ChecksumAlgorithm
 from spdx_tools.spdx.parser.jsonlikedict.dict_parsing_functions import json_str_to_enum_name
 from spdx_tools.spdx.parser.logger import Logger
 from spdx_tools.spdx.parser.parsing_functions import (

--- a/src/spdx_tools/spdx/parser/jsonlikedict/creation_info_parser.py
+++ b/src/spdx_tools/spdx/parser/jsonlikedict/creation_info_parser.py
@@ -5,11 +5,7 @@ from datetime import datetime
 from typing import Dict, List, Optional
 
 from spdx_tools.spdx.datetime_conversions import datetime_from_str
-from spdx_tools.spdx.model.actor import Actor
-from spdx_tools.spdx.model.checksum import Checksum
-from spdx_tools.spdx.model.document import CreationInfo
-from spdx_tools.spdx.model.external_document_ref import ExternalDocumentRef
-from spdx_tools.spdx.model.version import Version
+from spdx_tools.spdx.model import Actor, Checksum, CreationInfo, ExternalDocumentRef, Version
 from spdx_tools.spdx.parser.actor_parser import ActorParser
 from spdx_tools.spdx.parser.error import SPDXParsingError
 from spdx_tools.spdx.parser.jsonlikedict.checksum_parser import ChecksumParser

--- a/src/spdx_tools/spdx/parser/jsonlikedict/dict_parsing_functions.py
+++ b/src/spdx_tools/spdx/parser/jsonlikedict/dict_parsing_functions.py
@@ -3,8 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 from typing import Any, Callable, Dict, List, Optional
 
-from spdx_tools.spdx.model.spdx_no_assertion import SpdxNoAssertion
-from spdx_tools.spdx.model.spdx_none import SpdxNone
+from spdx_tools.spdx.model import SpdxNoAssertion, SpdxNone
 from spdx_tools.spdx.parser.error import SPDXParsingError
 from spdx_tools.spdx.parser.logger import Logger
 from spdx_tools.spdx.parser.parsing_functions import raise_parsing_error_if_logger_has_messages

--- a/src/spdx_tools/spdx/parser/jsonlikedict/extracted_licensing_info_parser.py
+++ b/src/spdx_tools/spdx/parser/jsonlikedict/extracted_licensing_info_parser.py
@@ -3,8 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 from typing import Dict, List, Optional, Union
 
-from spdx_tools.spdx.model.extracted_licensing_info import ExtractedLicensingInfo
-from spdx_tools.spdx.model.spdx_no_assertion import SpdxNoAssertion
+from spdx_tools.spdx.model import ExtractedLicensingInfo, SpdxNoAssertion
 from spdx_tools.spdx.parser.jsonlikedict.dict_parsing_functions import parse_field_or_no_assertion
 from spdx_tools.spdx.parser.logger import Logger
 from spdx_tools.spdx.parser.parsing_functions import construct_or_raise_parsing_error

--- a/src/spdx_tools/spdx/parser/jsonlikedict/file_parser.py
+++ b/src/spdx_tools/spdx/parser/jsonlikedict/file_parser.py
@@ -5,10 +5,7 @@ from typing import Dict, List, Optional, Union
 
 from license_expression import LicenseExpression
 
-from spdx_tools.spdx.model.checksum import Checksum
-from spdx_tools.spdx.model.file import File, FileType
-from spdx_tools.spdx.model.spdx_no_assertion import SpdxNoAssertion
-from spdx_tools.spdx.model.spdx_none import SpdxNone
+from spdx_tools.spdx.model import Checksum, File, FileType, SpdxNoAssertion, SpdxNone
 from spdx_tools.spdx.parser.jsonlikedict.checksum_parser import ChecksumParser
 from spdx_tools.spdx.parser.jsonlikedict.dict_parsing_functions import (
     parse_field_or_log_error,

--- a/src/spdx_tools/spdx/parser/jsonlikedict/json_like_dict_parser.py
+++ b/src/spdx_tools/spdx/parser/jsonlikedict/json_like_dict_parser.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 from typing import Dict
 
-from spdx_tools.spdx.model.document import Document
+from spdx_tools.spdx.model import Document
 from spdx_tools.spdx.parser.error import SPDXParsingError
 from spdx_tools.spdx.parser.jsonlikedict.annotation_parser import AnnotationParser
 from spdx_tools.spdx.parser.jsonlikedict.creation_info_parser import CreationInfoParser

--- a/src/spdx_tools/spdx/parser/jsonlikedict/license_expression_parser.py
+++ b/src/spdx_tools/spdx/parser/jsonlikedict/license_expression_parser.py
@@ -5,8 +5,7 @@ from typing import Union
 
 from license_expression import ExpressionError, LicenseExpression, Licensing
 
-from spdx_tools.spdx.model.spdx_no_assertion import SpdxNoAssertion
-from spdx_tools.spdx.model.spdx_none import SpdxNone
+from spdx_tools.spdx.model import SpdxNoAssertion, SpdxNone
 from spdx_tools.spdx.parser.error import SPDXParsingError
 
 

--- a/src/spdx_tools/spdx/parser/jsonlikedict/package_parser.py
+++ b/src/spdx_tools/spdx/parser/jsonlikedict/package_parser.py
@@ -7,16 +7,16 @@ from typing import Dict, List, Optional, Union
 from license_expression import LicenseExpression
 
 from spdx_tools.spdx.datetime_conversions import datetime_from_str
-from spdx_tools.spdx.model.actor import Actor
-from spdx_tools.spdx.model.package import (
+from spdx_tools.spdx.model import (
+    Actor,
     ExternalPackageRef,
     ExternalPackageRefCategory,
     Package,
     PackagePurpose,
     PackageVerificationCode,
+    SpdxNoAssertion,
+    SpdxNone,
 )
-from spdx_tools.spdx.model.spdx_no_assertion import SpdxNoAssertion
-from spdx_tools.spdx.model.spdx_none import SpdxNone
 from spdx_tools.spdx.parser.actor_parser import ActorParser
 from spdx_tools.spdx.parser.error import SPDXParsingError
 from spdx_tools.spdx.parser.jsonlikedict.checksum_parser import ChecksumParser

--- a/src/spdx_tools/spdx/parser/jsonlikedict/relationship_parser.py
+++ b/src/spdx_tools/spdx/parser/jsonlikedict/relationship_parser.py
@@ -4,7 +4,7 @@
 from typing import Dict, List, Optional
 
 from spdx_tools.common.typing.constructor_type_errors import ConstructorTypeErrors
-from spdx_tools.spdx.model.relationship import Relationship, RelationshipType
+from spdx_tools.spdx.model import Relationship, RelationshipType
 from spdx_tools.spdx.parser.error import SPDXParsingError
 from spdx_tools.spdx.parser.jsonlikedict.dict_parsing_functions import (
     delete_duplicates_from_list,

--- a/src/spdx_tools/spdx/parser/jsonlikedict/snippet_parser.py
+++ b/src/spdx_tools/spdx/parser/jsonlikedict/snippet_parser.py
@@ -6,9 +6,7 @@ from typing import Dict, List, Optional, Tuple, Union
 
 from license_expression import LicenseExpression
 
-from spdx_tools.spdx.model.snippet import Snippet
-from spdx_tools.spdx.model.spdx_no_assertion import SpdxNoAssertion
-from spdx_tools.spdx.model.spdx_none import SpdxNone
+from spdx_tools.spdx.model import Snippet, SpdxNoAssertion, SpdxNone
 from spdx_tools.spdx.parser.error import SPDXParsingError
 from spdx_tools.spdx.parser.jsonlikedict.dict_parsing_functions import (
     parse_field_or_log_error,

--- a/src/spdx_tools/spdx/parser/rdf/annotation_parser.py
+++ b/src/spdx_tools/spdx/parser/rdf/annotation_parser.py
@@ -4,7 +4,7 @@
 from rdflib import RDFS, BNode, Graph, URIRef
 
 from spdx_tools.spdx.datetime_conversions import datetime_from_str
-from spdx_tools.spdx.model.annotation import Annotation, AnnotationType
+from spdx_tools.spdx.model import Annotation, AnnotationType
 from spdx_tools.spdx.parser.actor_parser import ActorParser
 from spdx_tools.spdx.parser.logger import Logger
 from spdx_tools.spdx.parser.parsing_functions import (

--- a/src/spdx_tools/spdx/parser/rdf/checksum_parser.py
+++ b/src/spdx_tools/spdx/parser/rdf/checksum_parser.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 from rdflib import BNode, Graph
 
-from spdx_tools.spdx.model.checksum import Checksum, ChecksumAlgorithm
+from spdx_tools.spdx.model import Checksum, ChecksumAlgorithm
 from spdx_tools.spdx.parser.error import SPDXParsingError
 from spdx_tools.spdx.parser.logger import Logger
 from spdx_tools.spdx.parser.parsing_functions import (

--- a/src/spdx_tools/spdx/parser/rdf/creation_info_parser.py
+++ b/src/spdx_tools/spdx/parser/rdf/creation_info_parser.py
@@ -12,9 +12,7 @@ from rdflib.term import URIRef
 
 from spdx_tools.spdx.constants import DOCUMENT_SPDX_ID
 from spdx_tools.spdx.datetime_conversions import datetime_from_str
-from spdx_tools.spdx.model.document import CreationInfo
-from spdx_tools.spdx.model.external_document_ref import ExternalDocumentRef
-from spdx_tools.spdx.model.version import Version
+from spdx_tools.spdx.model import CreationInfo, ExternalDocumentRef, Version
 from spdx_tools.spdx.parser.actor_parser import ActorParser
 from spdx_tools.spdx.parser.error import SPDXParsingError
 from spdx_tools.spdx.parser.logger import Logger

--- a/src/spdx_tools/spdx/parser/rdf/extracted_licensing_info_parser.py
+++ b/src/spdx_tools/spdx/parser/rdf/extracted_licensing_info_parser.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 from rdflib import RDFS, Graph, URIRef
 
-from spdx_tools.spdx.model.extracted_licensing_info import ExtractedLicensingInfo
+from spdx_tools.spdx.model import ExtractedLicensingInfo
 from spdx_tools.spdx.parser.logger import Logger
 from spdx_tools.spdx.parser.parsing_functions import (
     construct_or_raise_parsing_error,

--- a/src/spdx_tools/spdx/parser/rdf/file_parser.py
+++ b/src/spdx_tools/spdx/parser/rdf/file_parser.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 from rdflib import RDFS, Graph, URIRef
 
-from spdx_tools.spdx.model.file import File, FileType
+from spdx_tools.spdx.model import File, FileType
 from spdx_tools.spdx.parser.logger import Logger
 from spdx_tools.spdx.parser.parsing_functions import (
     construct_or_raise_parsing_error,

--- a/src/spdx_tools/spdx/parser/rdf/graph_parsing_functions.py
+++ b/src/spdx_tools/spdx/parser/rdf/graph_parsing_functions.py
@@ -10,8 +10,9 @@ from rdflib.namespace import NamespaceManager
 from rdflib.term import BNode, Literal, Node
 
 from spdx_tools.spdx.casing_tools import camel_case_to_snake_case
-from spdx_tools.spdx.model.spdx_no_assertion import SPDX_NO_ASSERTION_STRING, SpdxNoAssertion
-from spdx_tools.spdx.model.spdx_none import SPDX_NONE_STRING, SpdxNone
+from spdx_tools.spdx.model import SpdxNoAssertion, SpdxNone
+from spdx_tools.spdx.model.spdx_no_assertion import SPDX_NO_ASSERTION_STRING
+from spdx_tools.spdx.model.spdx_none import SPDX_NONE_STRING
 from spdx_tools.spdx.parser.error import SPDXParsingError
 from spdx_tools.spdx.parser.logger import Logger
 from spdx_tools.spdx.rdfschema.namespace import SPDX_NAMESPACE

--- a/src/spdx_tools/spdx/parser/rdf/package_parser.py
+++ b/src/spdx_tools/spdx/parser/rdf/package_parser.py
@@ -7,7 +7,7 @@ from rdflib import DOAP, RDFS, Graph, URIRef
 from rdflib.term import BNode
 
 from spdx_tools.spdx.datetime_conversions import datetime_from_str
-from spdx_tools.spdx.model.package import (
+from spdx_tools.spdx.model import (
     ExternalPackageRef,
     ExternalPackageRefCategory,
     Package,

--- a/src/spdx_tools/spdx/parser/rdf/rdf_parser.py
+++ b/src/spdx_tools/spdx/parser/rdf/rdf_parser.py
@@ -5,8 +5,7 @@ from typing import Any, Dict
 
 from rdflib import RDF, Graph
 
-from spdx_tools.spdx.model.document import Document
-from spdx_tools.spdx.model.relationship import RelationshipType
+from spdx_tools.spdx.model import Document, RelationshipType
 from spdx_tools.spdx.parser.error import SPDXParsingError
 from spdx_tools.spdx.parser.logger import Logger
 from spdx_tools.spdx.parser.parsing_functions import (

--- a/src/spdx_tools/spdx/parser/rdf/relationship_parser.py
+++ b/src/spdx_tools/spdx/parser/rdf/relationship_parser.py
@@ -4,7 +4,7 @@
 from rdflib import RDFS, Graph, URIRef
 from rdflib.term import Node
 
-from spdx_tools.spdx.model.relationship import Relationship, RelationshipType
+from spdx_tools.spdx.model import Relationship, RelationshipType
 from spdx_tools.spdx.parser.logger import Logger
 from spdx_tools.spdx.parser.parsing_functions import (
     construct_or_raise_parsing_error,

--- a/src/spdx_tools/spdx/parser/rdf/snippet_parser.py
+++ b/src/spdx_tools/spdx/parser/rdf/snippet_parser.py
@@ -7,7 +7,7 @@ from rdflib import RDF, RDFS, Graph
 from rdflib.exceptions import UniquenessError
 from rdflib.term import BNode, Node, URIRef
 
-from spdx_tools.spdx.model.snippet import Snippet
+from spdx_tools.spdx.model import Snippet
 from spdx_tools.spdx.parser.error import SPDXParsingError
 from spdx_tools.spdx.parser.logger import Logger
 from spdx_tools.spdx.parser.parsing_functions import (

--- a/src/spdx_tools/spdx/parser/tagvalue/helper_methods.py
+++ b/src/spdx_tools/spdx/parser/tagvalue/helper_methods.py
@@ -7,13 +7,16 @@ from typing import Any, Callable, Dict, Optional
 from ply.yacc import YaccProduction
 
 from spdx_tools.spdx.casing_tools import camel_case_to_snake_case
-from spdx_tools.spdx.model.annotation import Annotation
-from spdx_tools.spdx.model.checksum import Checksum, ChecksumAlgorithm
-from spdx_tools.spdx.model.document import CreationInfo
-from spdx_tools.spdx.model.extracted_licensing_info import ExtractedLicensingInfo
-from spdx_tools.spdx.model.file import File
-from spdx_tools.spdx.model.package import Package
-from spdx_tools.spdx.model.snippet import Snippet
+from spdx_tools.spdx.model import (
+    Annotation,
+    Checksum,
+    ChecksumAlgorithm,
+    CreationInfo,
+    ExtractedLicensingInfo,
+    File,
+    Package,
+    Snippet,
+)
 from spdx_tools.spdx.parser.error import SPDXParsingError
 
 

--- a/src/spdx_tools/spdx/parser/tagvalue/parser.py
+++ b/src/spdx_tools/spdx/parser/tagvalue/parser.py
@@ -19,23 +19,27 @@ from ply import yacc
 from ply.yacc import LRParser
 
 from spdx_tools.spdx.datetime_conversions import datetime_from_str
-from spdx_tools.spdx.model.annotation import Annotation, AnnotationType
-from spdx_tools.spdx.model.document import CreationInfo, Document
-from spdx_tools.spdx.model.external_document_ref import ExternalDocumentRef
-from spdx_tools.spdx.model.extracted_licensing_info import ExtractedLicensingInfo
-from spdx_tools.spdx.model.file import File, FileType
-from spdx_tools.spdx.model.package import (
+from spdx_tools.spdx.model import (
+    Annotation,
+    AnnotationType,
+    CreationInfo,
+    Document,
+    ExternalDocumentRef,
     ExternalPackageRef,
     ExternalPackageRefCategory,
+    ExtractedLicensingInfo,
+    File,
+    FileType,
     Package,
     PackagePurpose,
     PackageVerificationCode,
+    Relationship,
+    RelationshipType,
+    Snippet,
+    SpdxNoAssertion,
+    SpdxNone,
+    Version,
 )
-from spdx_tools.spdx.model.relationship import Relationship, RelationshipType
-from spdx_tools.spdx.model.snippet import Snippet
-from spdx_tools.spdx.model.spdx_no_assertion import SpdxNoAssertion
-from spdx_tools.spdx.model.spdx_none import SpdxNone
-from spdx_tools.spdx.model.version import Version
 from spdx_tools.spdx.parser.actor_parser import ActorParser
 from spdx_tools.spdx.parser.error import SPDXParsingError
 from spdx_tools.spdx.parser.logger import Logger

--- a/src/spdx_tools/spdx/parser/tagvalue/tagvalue_parser.py
+++ b/src/spdx_tools/spdx/parser/tagvalue/tagvalue_parser.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2023 spdx contributors
 #
 # SPDX-License-Identifier: Apache-2.0
-from spdx_tools.spdx.model.document import Document
+from spdx_tools.spdx.model import Document
 from spdx_tools.spdx.parser.tagvalue.parser import Parser
 
 

--- a/src/spdx_tools/spdx/parser/xml/xml_parser.py
+++ b/src/spdx_tools/spdx/parser/xml/xml_parser.py
@@ -5,7 +5,7 @@ from typing import Any, Dict
 
 import xmltodict
 
-from spdx_tools.spdx.model.document import Document
+from spdx_tools.spdx.model import Document
 from spdx_tools.spdx.parser.error import SPDXParsingError
 from spdx_tools.spdx.parser.jsonlikedict.json_like_dict_parser import JsonLikeDictParser
 

--- a/src/spdx_tools/spdx/parser/yaml/yaml_parser.py
+++ b/src/spdx_tools/spdx/parser/yaml/yaml_parser.py
@@ -5,7 +5,7 @@ from typing import Dict
 
 import yaml
 
-from spdx_tools.spdx.model.document import Document
+from spdx_tools.spdx.model import Document
 from spdx_tools.spdx.parser.jsonlikedict.json_like_dict_parser import JsonLikeDictParser
 
 

--- a/src/spdx_tools/spdx/validation/actor_validator.py
+++ b/src/spdx_tools/spdx/validation/actor_validator.py
@@ -4,7 +4,7 @@
 
 from typing import List
 
-from spdx_tools.spdx.model.actor import Actor, ActorType
+from spdx_tools.spdx.model import Actor, ActorType
 from spdx_tools.spdx.validation.validation_message import SpdxElementType, ValidationContext, ValidationMessage
 
 

--- a/src/spdx_tools/spdx/validation/annotation_validator.py
+++ b/src/spdx_tools/spdx/validation/annotation_validator.py
@@ -4,8 +4,7 @@
 
 from typing import List
 
-from spdx_tools.spdx.model.annotation import Annotation
-from spdx_tools.spdx.model.document import Document
+from spdx_tools.spdx.model import Annotation, Document
 from spdx_tools.spdx.validation.actor_validator import validate_actor
 from spdx_tools.spdx.validation.spdx_id_validators import validate_spdx_id
 from spdx_tools.spdx.validation.validation_message import SpdxElementType, ValidationContext, ValidationMessage

--- a/src/spdx_tools/spdx/validation/checksum_validator.py
+++ b/src/spdx_tools/spdx/validation/checksum_validator.py
@@ -5,7 +5,7 @@
 import re
 from typing import Dict, List
 
-from spdx_tools.spdx.model.checksum import Checksum, ChecksumAlgorithm
+from spdx_tools.spdx.model import Checksum, ChecksumAlgorithm
 from spdx_tools.spdx.validation.validation_message import SpdxElementType, ValidationContext, ValidationMessage
 
 # in hexadecimal digits

--- a/src/spdx_tools/spdx/validation/creation_info_validator.py
+++ b/src/spdx_tools/spdx/validation/creation_info_validator.py
@@ -5,7 +5,7 @@
 from typing import List
 
 from spdx_tools.spdx.constants import DOCUMENT_SPDX_ID
-from spdx_tools.spdx.model.document import CreationInfo
+from spdx_tools.spdx.model import CreationInfo
 from spdx_tools.spdx.validation.actor_validator import validate_actors
 from spdx_tools.spdx.validation.external_document_ref_validator import validate_external_document_refs
 from spdx_tools.spdx.validation.uri_validators import validate_uri

--- a/src/spdx_tools/spdx/validation/document_validator.py
+++ b/src/spdx_tools/spdx/validation/document_validator.py
@@ -3,8 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 from typing import List
 
-from spdx_tools.spdx.model.document import Document
-from spdx_tools.spdx.model.relationship import RelationshipType
+from spdx_tools.spdx.model import Document, RelationshipType
 from spdx_tools.spdx.model.relationship_filters import filter_by_type_and_origin, filter_by_type_and_target
 from spdx_tools.spdx.validation.annotation_validator import validate_annotations
 from spdx_tools.spdx.validation.creation_info_validator import validate_creation_info

--- a/src/spdx_tools/spdx/validation/external_document_ref_validator.py
+++ b/src/spdx_tools/spdx/validation/external_document_ref_validator.py
@@ -4,7 +4,7 @@
 
 from typing import List
 
-from spdx_tools.spdx.model.external_document_ref import ExternalDocumentRef
+from spdx_tools.spdx.model import ExternalDocumentRef
 from spdx_tools.spdx.validation.checksum_validator import validate_checksum
 from spdx_tools.spdx.validation.spdx_id_validators import is_valid_external_doc_ref_id
 from spdx_tools.spdx.validation.uri_validators import validate_uri

--- a/src/spdx_tools/spdx/validation/external_package_ref_validator.py
+++ b/src/spdx_tools/spdx/validation/external_package_ref_validator.py
@@ -6,11 +6,8 @@ from typing import Dict, List
 
 import uritools
 
-from spdx_tools.spdx.model.package import (
-    CATEGORY_TO_EXTERNAL_PACKAGE_REF_TYPES,
-    ExternalPackageRef,
-    ExternalPackageRefCategory,
-)
+from spdx_tools.spdx.model import ExternalPackageRef, ExternalPackageRefCategory
+from spdx_tools.spdx.model.package import CATEGORY_TO_EXTERNAL_PACKAGE_REF_TYPES
 from spdx_tools.spdx.validation.uri_validators import validate_url
 from spdx_tools.spdx.validation.validation_message import SpdxElementType, ValidationContext, ValidationMessage
 

--- a/src/spdx_tools/spdx/validation/extracted_licensing_info_validator.py
+++ b/src/spdx_tools/spdx/validation/extracted_licensing_info_validator.py
@@ -5,7 +5,7 @@
 import re
 from typing import List, Optional
 
-from spdx_tools.spdx.model.extracted_licensing_info import ExtractedLicensingInfo
+from spdx_tools.spdx.model import ExtractedLicensingInfo
 from spdx_tools.spdx.validation.uri_validators import validate_url
 from spdx_tools.spdx.validation.validation_message import SpdxElementType, ValidationContext, ValidationMessage
 

--- a/src/spdx_tools/spdx/validation/file_validator.py
+++ b/src/spdx_tools/spdx/validation/file_validator.py
@@ -4,9 +4,7 @@
 
 from typing import List, Optional
 
-from spdx_tools.spdx.model.checksum import ChecksumAlgorithm
-from spdx_tools.spdx.model.document import Document
-from spdx_tools.spdx.model.file import File
+from spdx_tools.spdx.model import ChecksumAlgorithm, Document, File
 from spdx_tools.spdx.validation.checksum_validator import validate_checksums
 from spdx_tools.spdx.validation.license_expression_validator import (
     validate_license_expression,

--- a/src/spdx_tools/spdx/validation/license_expression_validator.py
+++ b/src/spdx_tools/spdx/validation/license_expression_validator.py
@@ -6,9 +6,7 @@ from typing import List, Optional, Union
 
 from license_expression import ExpressionError, ExpressionParseError, LicenseExpression, get_spdx_licensing
 
-from spdx_tools.spdx.model.document import Document
-from spdx_tools.spdx.model.spdx_no_assertion import SpdxNoAssertion
-from spdx_tools.spdx.model.spdx_none import SpdxNone
+from spdx_tools.spdx.model import Document, SpdxNoAssertion, SpdxNone
 from spdx_tools.spdx.validation.validation_message import SpdxElementType, ValidationContext, ValidationMessage
 
 

--- a/src/spdx_tools/spdx/validation/package_validator.py
+++ b/src/spdx_tools/spdx/validation/package_validator.py
@@ -4,9 +4,7 @@
 
 from typing import List, Optional
 
-from spdx_tools.spdx.model.document import Document
-from spdx_tools.spdx.model.package import Package
-from spdx_tools.spdx.model.relationship import Relationship, RelationshipType
+from spdx_tools.spdx.model import Document, Package, Relationship, RelationshipType
 from spdx_tools.spdx.model.relationship_filters import filter_by_type_and_origin, filter_by_type_and_target
 from spdx_tools.spdx.validation.checksum_validator import validate_checksums
 from spdx_tools.spdx.validation.external_package_ref_validator import validate_external_package_refs

--- a/src/spdx_tools/spdx/validation/package_verification_code_validator.py
+++ b/src/spdx_tools/spdx/validation/package_verification_code_validator.py
@@ -5,7 +5,7 @@
 import re
 from typing import List
 
-from spdx_tools.spdx.model.package import PackageVerificationCode
+from spdx_tools.spdx.model import PackageVerificationCode
 from spdx_tools.spdx.validation.validation_message import SpdxElementType, ValidationContext, ValidationMessage
 
 

--- a/src/spdx_tools/spdx/validation/relationship_validator.py
+++ b/src/spdx_tools/spdx/validation/relationship_validator.py
@@ -4,10 +4,7 @@
 
 from typing import List
 
-from spdx_tools.spdx.model.document import Document
-from spdx_tools.spdx.model.relationship import Relationship, RelationshipType
-from spdx_tools.spdx.model.spdx_no_assertion import SpdxNoAssertion
-from spdx_tools.spdx.model.spdx_none import SpdxNone
+from spdx_tools.spdx.model import Document, Relationship, RelationshipType, SpdxNoAssertion, SpdxNone
 from spdx_tools.spdx.validation.spdx_id_validators import validate_spdx_id
 from spdx_tools.spdx.validation.validation_message import SpdxElementType, ValidationContext, ValidationMessage
 

--- a/src/spdx_tools/spdx/validation/snippet_validator.py
+++ b/src/spdx_tools/spdx/validation/snippet_validator.py
@@ -4,8 +4,7 @@
 
 from typing import List, Optional
 
-from spdx_tools.spdx.model.document import Document
-from spdx_tools.spdx.model.snippet import Snippet
+from spdx_tools.spdx.model import Document, Snippet
 from spdx_tools.spdx.validation.license_expression_validator import (
     validate_license_expression,
     validate_license_expressions,

--- a/src/spdx_tools/spdx/validation/spdx_id_validators.py
+++ b/src/spdx_tools/spdx/validation/spdx_id_validators.py
@@ -6,8 +6,7 @@ import re
 from typing import List
 
 from spdx_tools.spdx.document_utils import get_contained_spdx_element_ids
-from spdx_tools.spdx.model.document import Document
-from spdx_tools.spdx.model.file import File
+from spdx_tools.spdx.model import Document, File
 
 
 def is_valid_internal_spdx_id(spdx_id: str) -> bool:

--- a/src/spdx_tools/spdx/writer/json/json_writer.py
+++ b/src/spdx_tools/spdx/writer/json/json_writer.py
@@ -6,7 +6,7 @@ from typing import List
 
 from spdx_tools.spdx.document_utils import create_document_without_duplicates
 from spdx_tools.spdx.jsonschema.document_converter import DocumentConverter
-from spdx_tools.spdx.model.document import Document
+from spdx_tools.spdx.model import Document
 from spdx_tools.spdx.validation.document_validator import validate_full_spdx_document
 from spdx_tools.spdx.validation.validation_message import ValidationMessage
 

--- a/src/spdx_tools/spdx/writer/rdf/annotation_writer.py
+++ b/src/spdx_tools/spdx/writer/rdf/annotation_writer.py
@@ -7,7 +7,7 @@ from rdflib import RDF, RDFS, BNode, Graph, Literal, URIRef
 
 from spdx_tools.spdx.casing_tools import snake_case_to_camel_case
 from spdx_tools.spdx.datetime_conversions import datetime_to_iso_string
-from spdx_tools.spdx.model.annotation import Annotation
+from spdx_tools.spdx.model import Annotation
 from spdx_tools.spdx.rdfschema.namespace import SPDX_NAMESPACE
 from spdx_tools.spdx.writer.rdf.writer_utils import add_namespace_to_spdx_id
 

--- a/src/spdx_tools/spdx/writer/rdf/checksum_writer.py
+++ b/src/spdx_tools/spdx/writer/rdf/checksum_writer.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 from rdflib import RDF, BNode, Graph, Literal, URIRef
 
-from spdx_tools.spdx.model.checksum import Checksum, ChecksumAlgorithm
+from spdx_tools.spdx.model import Checksum, ChecksumAlgorithm
 from spdx_tools.spdx.rdfschema.namespace import SPDX_NAMESPACE
 
 

--- a/src/spdx_tools/spdx/writer/rdf/creation_info_writer.py
+++ b/src/spdx_tools/spdx/writer/rdf/creation_info_writer.py
@@ -4,7 +4,7 @@
 from rdflib import RDF, RDFS, BNode, Graph, Literal, URIRef
 
 from spdx_tools.spdx.datetime_conversions import datetime_to_iso_string
-from spdx_tools.spdx.model.document import CreationInfo
+from spdx_tools.spdx.model import CreationInfo
 from spdx_tools.spdx.rdfschema.namespace import LICENSE_NAMESPACE, SPDX_NAMESPACE
 from spdx_tools.spdx.writer.rdf.external_document_ref_writer import add_external_document_ref_to_graph
 from spdx_tools.spdx.writer.rdf.writer_utils import add_optional_literal

--- a/src/spdx_tools/spdx/writer/rdf/external_document_ref_writer.py
+++ b/src/spdx_tools/spdx/writer/rdf/external_document_ref_writer.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 from rdflib import RDF, Graph, URIRef
 
-from spdx_tools.spdx.model.external_document_ref import ExternalDocumentRef
+from spdx_tools.spdx.model import ExternalDocumentRef
 from spdx_tools.spdx.rdfschema.namespace import SPDX_NAMESPACE
 from spdx_tools.spdx.writer.rdf.checksum_writer import add_checksum_to_graph
 

--- a/src/spdx_tools/spdx/writer/rdf/extracted_licensing_info_writer.py
+++ b/src/spdx_tools/spdx/writer/rdf/extracted_licensing_info_writer.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 from rdflib import RDF, RDFS, BNode, Graph, Literal, URIRef
 
-from spdx_tools.spdx.model.extracted_licensing_info import ExtractedLicensingInfo
+from spdx_tools.spdx.model import ExtractedLicensingInfo
 from spdx_tools.spdx.rdfschema.namespace import SPDX_NAMESPACE
 from spdx_tools.spdx.writer.rdf.writer_utils import add_literal_or_no_assertion, add_optional_literal
 

--- a/src/spdx_tools/spdx/writer/rdf/file_writer.py
+++ b/src/spdx_tools/spdx/writer/rdf/file_writer.py
@@ -6,7 +6,7 @@ from typing import Dict
 from rdflib import RDF, RDFS, Graph, Literal, URIRef
 
 from spdx_tools.spdx.casing_tools import snake_case_to_camel_case
-from spdx_tools.spdx.model.file import File
+from spdx_tools.spdx.model import File
 from spdx_tools.spdx.rdfschema.namespace import SPDX_NAMESPACE
 from spdx_tools.spdx.writer.rdf.checksum_writer import add_checksum_to_graph
 from spdx_tools.spdx.writer.rdf.license_expression_writer import add_license_expression_or_none_or_no_assertion

--- a/src/spdx_tools/spdx/writer/rdf/license_expression_writer.py
+++ b/src/spdx_tools/spdx/writer/rdf/license_expression_writer.py
@@ -16,8 +16,7 @@ from license_expression import (
 from rdflib import RDF, BNode, Graph, URIRef
 from rdflib.term import Literal, Node
 
-from spdx_tools.spdx.model.spdx_no_assertion import SpdxNoAssertion
-from spdx_tools.spdx.model.spdx_none import SpdxNone
+from spdx_tools.spdx.model import SpdxNoAssertion, SpdxNone
 from spdx_tools.spdx.rdfschema.namespace import LICENSE_NAMESPACE, SPDX_NAMESPACE
 
 

--- a/src/spdx_tools/spdx/writer/rdf/package_writer.py
+++ b/src/spdx_tools/spdx/writer/rdf/package_writer.py
@@ -6,12 +6,8 @@ from typing import Dict
 from rdflib import DOAP, RDF, RDFS, XSD, BNode, Graph, Literal, URIRef
 
 from spdx_tools.spdx.casing_tools import snake_case_to_camel_case
-from spdx_tools.spdx.model.package import (
-    CATEGORY_TO_EXTERNAL_PACKAGE_REF_TYPES,
-    ExternalPackageRef,
-    Package,
-    PackageVerificationCode,
-)
+from spdx_tools.spdx.model import ExternalPackageRef, Package, PackageVerificationCode
+from spdx_tools.spdx.model.package import CATEGORY_TO_EXTERNAL_PACKAGE_REF_TYPES
 from spdx_tools.spdx.rdfschema.namespace import REFERENCE_NAMESPACE, SPDX_NAMESPACE
 from spdx_tools.spdx.writer.rdf.checksum_writer import add_checksum_to_graph
 from spdx_tools.spdx.writer.rdf.license_expression_writer import add_license_expression_or_none_or_no_assertion

--- a/src/spdx_tools/spdx/writer/rdf/rdf_writer.py
+++ b/src/spdx_tools/spdx/writer/rdf/rdf_writer.py
@@ -7,7 +7,7 @@ from rdflib import DOAP, Graph
 from rdflib.compare import to_isomorphic
 
 from spdx_tools.spdx.document_utils import create_document_without_duplicates
-from spdx_tools.spdx.model.document import Document
+from spdx_tools.spdx.model import Document
 from spdx_tools.spdx.rdfschema.namespace import POINTER_NAMESPACE, SPDX_NAMESPACE
 from spdx_tools.spdx.validation.document_validator import validate_full_spdx_document
 from spdx_tools.spdx.validation.validation_message import ValidationMessage

--- a/src/spdx_tools/spdx/writer/rdf/relationship_writer.py
+++ b/src/spdx_tools/spdx/writer/rdf/relationship_writer.py
@@ -6,9 +6,7 @@ from typing import Dict
 from rdflib import RDF, RDFS, BNode, Graph, Literal, URIRef
 
 from spdx_tools.spdx.casing_tools import snake_case_to_camel_case
-from spdx_tools.spdx.model.relationship import Relationship
-from spdx_tools.spdx.model.spdx_no_assertion import SpdxNoAssertion
-from spdx_tools.spdx.model.spdx_none import SpdxNone
+from spdx_tools.spdx.model import Relationship, SpdxNoAssertion, SpdxNone
 from spdx_tools.spdx.rdfschema.namespace import SPDX_NAMESPACE
 from spdx_tools.spdx.writer.rdf.writer_utils import add_namespace_to_spdx_id
 

--- a/src/spdx_tools/spdx/writer/rdf/snippet_writer.py
+++ b/src/spdx_tools/spdx/writer/rdf/snippet_writer.py
@@ -5,7 +5,7 @@ from typing import Dict, Optional, Tuple
 
 from rdflib import RDF, RDFS, BNode, Graph, Literal, URIRef
 
-from spdx_tools.spdx.model.snippet import Snippet
+from spdx_tools.spdx.model import Snippet
 from spdx_tools.spdx.rdfschema.namespace import POINTER_NAMESPACE, SPDX_NAMESPACE
 from spdx_tools.spdx.writer.rdf.license_expression_writer import add_license_expression_or_none_or_no_assertion
 from spdx_tools.spdx.writer.rdf.writer_utils import add_namespace_to_spdx_id, add_optional_literal

--- a/src/spdx_tools/spdx/writer/rdf/writer_utils.py
+++ b/src/spdx_tools/spdx/writer/rdf/writer_utils.py
@@ -9,8 +9,7 @@ from rdflib import Graph, Literal
 from rdflib.term import Node
 
 from spdx_tools.spdx.datetime_conversions import datetime_to_iso_string
-from spdx_tools.spdx.model.spdx_no_assertion import SpdxNoAssertion
-from spdx_tools.spdx.model.spdx_none import SpdxNone
+from spdx_tools.spdx.model import SpdxNoAssertion, SpdxNone
 from spdx_tools.spdx.rdfschema.namespace import SPDX_NAMESPACE
 from spdx_tools.spdx.validation.spdx_id_validators import is_valid_internal_spdx_id
 

--- a/src/spdx_tools/spdx/writer/tagvalue/annotation_writer.py
+++ b/src/spdx_tools/spdx/writer/tagvalue/annotation_writer.py
@@ -11,7 +11,7 @@
 from typing import TextIO
 
 from spdx_tools.spdx.datetime_conversions import datetime_to_iso_string
-from spdx_tools.spdx.model.annotation import Annotation
+from spdx_tools.spdx.model import Annotation
 from spdx_tools.spdx.writer.tagvalue.tagvalue_writer_helper_functions import write_text_value, write_value
 
 

--- a/src/spdx_tools/spdx/writer/tagvalue/checksum_writer.py
+++ b/src/spdx_tools/spdx/writer/tagvalue/checksum_writer.py
@@ -8,7 +8,7 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-from spdx_tools.spdx.model.checksum import Checksum, ChecksumAlgorithm
+from spdx_tools.spdx.model import Checksum, ChecksumAlgorithm
 
 
 def write_checksum_to_tag_value(checksum: Checksum) -> str:

--- a/src/spdx_tools/spdx/writer/tagvalue/creation_info_writer.py
+++ b/src/spdx_tools/spdx/writer/tagvalue/creation_info_writer.py
@@ -11,7 +11,7 @@
 from typing import TextIO
 
 from spdx_tools.spdx.datetime_conversions import datetime_to_iso_string
-from spdx_tools.spdx.model.document import CreationInfo
+from spdx_tools.spdx.model import CreationInfo
 from spdx_tools.spdx.writer.tagvalue.tagvalue_writer_helper_functions import (
     write_optional_heading,
     write_separator,

--- a/src/spdx_tools/spdx/writer/tagvalue/extracted_licensing_info_writer.py
+++ b/src/spdx_tools/spdx/writer/tagvalue/extracted_licensing_info_writer.py
@@ -10,7 +10,7 @@
 #  limitations under the License.
 from typing import TextIO
 
-from spdx_tools.spdx.model.extracted_licensing_info import ExtractedLicensingInfo
+from spdx_tools.spdx.model import ExtractedLicensingInfo
 from spdx_tools.spdx.writer.tagvalue.tagvalue_writer_helper_functions import write_text_value, write_value
 
 

--- a/src/spdx_tools/spdx/writer/tagvalue/file_writer.py
+++ b/src/spdx_tools/spdx/writer/tagvalue/file_writer.py
@@ -10,7 +10,7 @@
 #  limitations under the License.
 from typing import TextIO
 
-from spdx_tools.spdx.model.file import File
+from spdx_tools.spdx.model import File
 from spdx_tools.spdx.writer.tagvalue.checksum_writer import write_checksum_to_tag_value
 from spdx_tools.spdx.writer.tagvalue.tagvalue_writer_helper_functions import write_text_value, write_value
 

--- a/src/spdx_tools/spdx/writer/tagvalue/package_writer.py
+++ b/src/spdx_tools/spdx/writer/tagvalue/package_writer.py
@@ -11,7 +11,7 @@
 from typing import TextIO
 
 from spdx_tools.spdx.datetime_conversions import datetime_to_iso_string
-from spdx_tools.spdx.model.package import Package, PackageVerificationCode
+from spdx_tools.spdx.model import Package, PackageVerificationCode
 from spdx_tools.spdx.writer.tagvalue.checksum_writer import write_checksum_to_tag_value
 from spdx_tools.spdx.writer.tagvalue.tagvalue_writer_helper_functions import (
     transform_enum_name_to_tv,

--- a/src/spdx_tools/spdx/writer/tagvalue/relationship_writer.py
+++ b/src/spdx_tools/spdx/writer/tagvalue/relationship_writer.py
@@ -10,7 +10,7 @@
 #  limitations under the License.
 from typing import TextIO
 
-from spdx_tools.spdx.model.relationship import Relationship
+from spdx_tools.spdx.model import Relationship
 from spdx_tools.spdx.writer.tagvalue.tagvalue_writer_helper_functions import write_text_value, write_value
 
 

--- a/src/spdx_tools/spdx/writer/tagvalue/snippet_writer.py
+++ b/src/spdx_tools/spdx/writer/tagvalue/snippet_writer.py
@@ -10,7 +10,7 @@
 #  limitations under the License.
 from typing import TextIO
 
-from spdx_tools.spdx.model.snippet import Snippet
+from spdx_tools.spdx.model import Snippet
 from spdx_tools.spdx.writer.tagvalue.tagvalue_writer_helper_functions import write_range, write_text_value, write_value
 
 

--- a/src/spdx_tools/spdx/writer/tagvalue/tagvalue_writer.py
+++ b/src/spdx_tools/spdx/writer/tagvalue/tagvalue_writer.py
@@ -11,7 +11,7 @@
 from typing import List, TextIO
 
 from spdx_tools.spdx.document_utils import create_document_without_duplicates
-from spdx_tools.spdx.model.document import Document
+from spdx_tools.spdx.model import Document
 from spdx_tools.spdx.validation.document_validator import validate_full_spdx_document
 from spdx_tools.spdx.validation.validation_message import ValidationMessage
 from spdx_tools.spdx.writer.tagvalue.annotation_writer import write_annotation

--- a/src/spdx_tools/spdx/writer/tagvalue/tagvalue_writer_helper_functions.py
+++ b/src/spdx_tools/spdx/writer/tagvalue/tagvalue_writer_helper_functions.py
@@ -12,13 +12,16 @@ from typing import Any, Callable, Dict, List, Optional, TextIO, Tuple, Union
 
 from license_expression import LicenseExpression
 
-from spdx_tools.spdx.model.actor import Actor
-from spdx_tools.spdx.model.file import File
-from spdx_tools.spdx.model.package import Package
-from spdx_tools.spdx.model.relationship import Relationship, RelationshipType
-from spdx_tools.spdx.model.snippet import Snippet
-from spdx_tools.spdx.model.spdx_no_assertion import SpdxNoAssertion
-from spdx_tools.spdx.model.spdx_none import SpdxNone
+from spdx_tools.spdx.model import (
+    Actor,
+    File,
+    Package,
+    Relationship,
+    RelationshipType,
+    Snippet,
+    SpdxNoAssertion,
+    SpdxNone,
+)
 
 
 def write_separator(out: TextIO):

--- a/src/spdx_tools/spdx/writer/write_anything.py
+++ b/src/spdx_tools/spdx/writer/write_anything.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from spdx_tools.spdx.formats import FileFormat, file_name_to_format
-from spdx_tools.spdx.model.document import Document
+from spdx_tools.spdx.model import Document
 from spdx_tools.spdx.writer.json import json_writer
 from spdx_tools.spdx.writer.rdf import rdf_writer
 from spdx_tools.spdx.writer.tagvalue import tagvalue_writer

--- a/src/spdx_tools/spdx/writer/xml/xml_writer.py
+++ b/src/spdx_tools/spdx/writer/xml/xml_writer.py
@@ -7,7 +7,7 @@ import xmltodict
 
 from spdx_tools.spdx.document_utils import create_document_without_duplicates
 from spdx_tools.spdx.jsonschema.document_converter import DocumentConverter
-from spdx_tools.spdx.model.document import Document
+from spdx_tools.spdx.model import Document
 from spdx_tools.spdx.validation.document_validator import validate_full_spdx_document
 from spdx_tools.spdx.validation.validation_message import ValidationMessage
 

--- a/src/spdx_tools/spdx/writer/yaml/yaml_writer.py
+++ b/src/spdx_tools/spdx/writer/yaml/yaml_writer.py
@@ -7,7 +7,7 @@ import yaml
 
 from spdx_tools.spdx.document_utils import create_document_without_duplicates
 from spdx_tools.spdx.jsonschema.document_converter import DocumentConverter
-from spdx_tools.spdx.model.document import Document
+from spdx_tools.spdx.model import Document
 from spdx_tools.spdx.validation.document_validator import validate_full_spdx_document
 from spdx_tools.spdx.validation.validation_message import ValidationMessage
 

--- a/tests/spdx/fixtures.py
+++ b/tests/spdx/fixtures.py
@@ -6,25 +6,31 @@ from datetime import datetime
 from license_expression import get_spdx_licensing
 
 from spdx_tools.spdx.constants import DOCUMENT_SPDX_ID
-from spdx_tools.spdx.model.actor import Actor, ActorType
-from spdx_tools.spdx.model.annotation import Annotation, AnnotationType
-from spdx_tools.spdx.model.checksum import Checksum, ChecksumAlgorithm
-from spdx_tools.spdx.model.document import CreationInfo, Document
-from spdx_tools.spdx.model.external_document_ref import ExternalDocumentRef
-from spdx_tools.spdx.model.extracted_licensing_info import ExtractedLicensingInfo
-from spdx_tools.spdx.model.file import File, FileType
-from spdx_tools.spdx.model.package import (
+from spdx_tools.spdx.model import (
+    Actor,
+    ActorType,
+    Annotation,
+    AnnotationType,
+    Checksum,
+    ChecksumAlgorithm,
+    CreationInfo,
+    Document,
+    ExternalDocumentRef,
     ExternalPackageRef,
     ExternalPackageRefCategory,
+    ExtractedLicensingInfo,
+    File,
+    FileType,
     Package,
     PackagePurpose,
     PackageVerificationCode,
+    Relationship,
+    RelationshipType,
+    Snippet,
+    SpdxNoAssertion,
+    SpdxNone,
+    Version,
 )
-from spdx_tools.spdx.model.relationship import Relationship, RelationshipType
-from spdx_tools.spdx.model.snippet import Snippet
-from spdx_tools.spdx.model.spdx_no_assertion import SpdxNoAssertion
-from spdx_tools.spdx.model.spdx_none import SpdxNone
-from spdx_tools.spdx.model.version import Version
 
 # Utility methods to create data model instances. All properties have valid defaults, so they don't need to be
 # specified unless relevant for the test.

--- a/tests/spdx/jsonschema/test_annotation_converter.py
+++ b/tests/spdx/jsonschema/test_annotation_converter.py
@@ -8,8 +8,7 @@ import pytest
 from spdx_tools.spdx.datetime_conversions import datetime_to_iso_string
 from spdx_tools.spdx.jsonschema.annotation_converter import AnnotationConverter
 from spdx_tools.spdx.jsonschema.annotation_properties import AnnotationProperty
-from spdx_tools.spdx.model.actor import Actor, ActorType
-from spdx_tools.spdx.model.annotation import Annotation, AnnotationType
+from spdx_tools.spdx.model import Actor, ActorType, Annotation, AnnotationType
 
 
 @pytest.fixture

--- a/tests/spdx/jsonschema/test_checksum_converter.py
+++ b/tests/spdx/jsonschema/test_checksum_converter.py
@@ -5,7 +5,7 @@ import pytest
 
 from spdx_tools.spdx.jsonschema.checksum_converter import ChecksumConverter
 from spdx_tools.spdx.jsonschema.checksum_properties import ChecksumProperty
-from spdx_tools.spdx.model.checksum import Checksum, ChecksumAlgorithm
+from spdx_tools.spdx.model import Checksum, ChecksumAlgorithm
 
 
 @pytest.fixture

--- a/tests/spdx/jsonschema/test_converter.py
+++ b/tests/spdx/jsonschema/test_converter.py
@@ -10,8 +10,7 @@ from spdx_tools.common.typing.dataclass_with_properties import dataclass_with_pr
 from spdx_tools.common.typing.type_checks import check_types_and_set_values
 from spdx_tools.spdx.jsonschema.converter import TypedConverter
 from spdx_tools.spdx.jsonschema.json_property import JsonProperty
-from spdx_tools.spdx.model.checksum import Checksum, ChecksumAlgorithm
-from spdx_tools.spdx.model.document import Document
+from spdx_tools.spdx.model import Checksum, ChecksumAlgorithm, Document
 
 
 class TestPropertyType(JsonProperty):

--- a/tests/spdx/jsonschema/test_creation_info_converter.py
+++ b/tests/spdx/jsonschema/test_creation_info_converter.py
@@ -8,9 +8,7 @@ import pytest
 from spdx_tools.spdx.datetime_conversions import datetime_to_iso_string
 from spdx_tools.spdx.jsonschema.creation_info_converter import CreationInfoConverter
 from spdx_tools.spdx.jsonschema.creation_info_properties import CreationInfoProperty
-from spdx_tools.spdx.model.actor import Actor, ActorType
-from spdx_tools.spdx.model.document import CreationInfo
-from spdx_tools.spdx.model.version import Version
+from spdx_tools.spdx.model import Actor, ActorType, CreationInfo, Version
 from tests.spdx.fixtures import creation_info_fixture
 
 

--- a/tests/spdx/jsonschema/test_document_converter.py
+++ b/tests/spdx/jsonschema/test_document_converter.py
@@ -11,11 +11,16 @@ import pytest
 from spdx_tools.spdx.jsonschema.annotation_converter import AnnotationConverter
 from spdx_tools.spdx.jsonschema.document_converter import DocumentConverter
 from spdx_tools.spdx.jsonschema.document_properties import DocumentProperty
-from spdx_tools.spdx.model.actor import Actor, ActorType
-from spdx_tools.spdx.model.annotation import Annotation, AnnotationType
-from spdx_tools.spdx.model.document import Document
-from spdx_tools.spdx.model.extracted_licensing_info import ExtractedLicensingInfo
-from spdx_tools.spdx.model.relationship import Relationship, RelationshipType
+from spdx_tools.spdx.model import (
+    Actor,
+    ActorType,
+    Annotation,
+    AnnotationType,
+    Document,
+    ExtractedLicensingInfo,
+    Relationship,
+    RelationshipType,
+)
 from tests.spdx.fixtures import (
     annotation_fixture,
     creation_info_fixture,

--- a/tests/spdx/jsonschema/test_external_document_ref_converter.py
+++ b/tests/spdx/jsonschema/test_external_document_ref_converter.py
@@ -8,8 +8,7 @@ import pytest
 
 from spdx_tools.spdx.jsonschema.external_document_ref_converter import ExternalDocumentRefConverter
 from spdx_tools.spdx.jsonschema.external_document_ref_properties import ExternalDocumentRefProperty
-from spdx_tools.spdx.model.checksum import Checksum, ChecksumAlgorithm
-from spdx_tools.spdx.model.external_document_ref import ExternalDocumentRef
+from spdx_tools.spdx.model import Checksum, ChecksumAlgorithm, ExternalDocumentRef
 
 
 @pytest.fixture

--- a/tests/spdx/jsonschema/test_external_package_ref_converter.py
+++ b/tests/spdx/jsonschema/test_external_package_ref_converter.py
@@ -5,7 +5,7 @@ import pytest
 
 from spdx_tools.spdx.jsonschema.external_package_ref_converter import ExternalPackageRefConverter
 from spdx_tools.spdx.jsonschema.external_package_ref_properties import ExternalPackageRefProperty
-from spdx_tools.spdx.model.package import ExternalPackageRef, ExternalPackageRefCategory
+from spdx_tools.spdx.model import ExternalPackageRef, ExternalPackageRefCategory
 
 
 @pytest.fixture

--- a/tests/spdx/jsonschema/test_extracted_licensing_info_converter.py
+++ b/tests/spdx/jsonschema/test_extracted_licensing_info_converter.py
@@ -5,8 +5,8 @@ import pytest
 
 from spdx_tools.spdx.jsonschema.extracted_licensing_info_converter import ExtractedLicensingInfoConverter
 from spdx_tools.spdx.jsonschema.extracted_licensing_info_properties import ExtractedLicensingInfoProperty
-from spdx_tools.spdx.model.extracted_licensing_info import ExtractedLicensingInfo
-from spdx_tools.spdx.model.spdx_no_assertion import SPDX_NO_ASSERTION_STRING, SpdxNoAssertion
+from spdx_tools.spdx.model import ExtractedLicensingInfo, SpdxNoAssertion
+from spdx_tools.spdx.model.spdx_no_assertion import SPDX_NO_ASSERTION_STRING
 from tests.spdx.fixtures import extracted_licensing_info_fixture
 
 

--- a/tests/spdx/jsonschema/test_file_converter.py
+++ b/tests/spdx/jsonschema/test_file_converter.py
@@ -12,13 +12,21 @@ from license_expression import Licensing
 from spdx_tools.spdx.jsonschema.annotation_converter import AnnotationConverter
 from spdx_tools.spdx.jsonschema.file_converter import FileConverter
 from spdx_tools.spdx.jsonschema.file_properties import FileProperty
-from spdx_tools.spdx.model.actor import Actor, ActorType
-from spdx_tools.spdx.model.annotation import Annotation, AnnotationType
-from spdx_tools.spdx.model.checksum import Checksum, ChecksumAlgorithm
-from spdx_tools.spdx.model.document import Document
-from spdx_tools.spdx.model.file import File, FileType
-from spdx_tools.spdx.model.spdx_no_assertion import SPDX_NO_ASSERTION_STRING, SpdxNoAssertion
-from spdx_tools.spdx.model.spdx_none import SPDX_NONE_STRING, SpdxNone
+from spdx_tools.spdx.model import (
+    Actor,
+    ActorType,
+    Annotation,
+    AnnotationType,
+    Checksum,
+    ChecksumAlgorithm,
+    Document,
+    File,
+    FileType,
+    SpdxNoAssertion,
+    SpdxNone,
+)
+from spdx_tools.spdx.model.spdx_no_assertion import SPDX_NO_ASSERTION_STRING
+from spdx_tools.spdx.model.spdx_none import SPDX_NONE_STRING
 from tests.spdx.fixtures import annotation_fixture, creation_info_fixture, document_fixture, file_fixture
 from tests.spdx.mock_utils import assert_mock_method_called_with_arguments
 

--- a/tests/spdx/jsonschema/test_package_converter.py
+++ b/tests/spdx/jsonschema/test_package_converter.py
@@ -12,13 +12,22 @@ from license_expression import Licensing
 from spdx_tools.spdx.jsonschema.annotation_converter import AnnotationConverter
 from spdx_tools.spdx.jsonschema.package_converter import PackageConverter
 from spdx_tools.spdx.jsonschema.package_properties import PackageProperty
-from spdx_tools.spdx.model.actor import Actor, ActorType
-from spdx_tools.spdx.model.annotation import Annotation, AnnotationType
-from spdx_tools.spdx.model.checksum import Checksum, ChecksumAlgorithm
-from spdx_tools.spdx.model.document import Document
-from spdx_tools.spdx.model.package import Package, PackagePurpose, PackageVerificationCode
-from spdx_tools.spdx.model.spdx_no_assertion import SPDX_NO_ASSERTION_STRING, SpdxNoAssertion
-from spdx_tools.spdx.model.spdx_none import SPDX_NONE_STRING, SpdxNone
+from spdx_tools.spdx.model import (
+    Actor,
+    ActorType,
+    Annotation,
+    AnnotationType,
+    Checksum,
+    ChecksumAlgorithm,
+    Document,
+    Package,
+    PackagePurpose,
+    PackageVerificationCode,
+    SpdxNoAssertion,
+    SpdxNone,
+)
+from spdx_tools.spdx.model.spdx_no_assertion import SPDX_NO_ASSERTION_STRING
+from spdx_tools.spdx.model.spdx_none import SPDX_NONE_STRING
 from tests.spdx.fixtures import (
     annotation_fixture,
     creation_info_fixture,

--- a/tests/spdx/jsonschema/test_package_verification_code_converter.py
+++ b/tests/spdx/jsonschema/test_package_verification_code_converter.py
@@ -5,7 +5,7 @@ import pytest
 
 from spdx_tools.spdx.jsonschema.package_verification_code_converter import PackageVerificationCodeConverter
 from spdx_tools.spdx.jsonschema.package_verification_code_properties import PackageVerificationCodeProperty
-from spdx_tools.spdx.model.package import PackageVerificationCode
+from spdx_tools.spdx.model import PackageVerificationCode
 
 
 @pytest.fixture

--- a/tests/spdx/jsonschema/test_relationship_converter.py
+++ b/tests/spdx/jsonschema/test_relationship_converter.py
@@ -5,9 +5,9 @@ import pytest
 
 from spdx_tools.spdx.jsonschema.relationship_converter import RelationshipConverter
 from spdx_tools.spdx.jsonschema.relationship_properties import RelationshipProperty
-from spdx_tools.spdx.model.relationship import Relationship, RelationshipType
-from spdx_tools.spdx.model.spdx_no_assertion import SPDX_NO_ASSERTION_STRING, SpdxNoAssertion
-from spdx_tools.spdx.model.spdx_none import SPDX_NONE_STRING, SpdxNone
+from spdx_tools.spdx.model import Relationship, RelationshipType, SpdxNoAssertion, SpdxNone
+from spdx_tools.spdx.model.spdx_no_assertion import SPDX_NO_ASSERTION_STRING
+from spdx_tools.spdx.model.spdx_none import SPDX_NONE_STRING
 from tests.spdx.fixtures import relationship_fixture
 
 

--- a/tests/spdx/jsonschema/test_snippet_converter.py
+++ b/tests/spdx/jsonschema/test_snippet_converter.py
@@ -12,12 +12,18 @@ from license_expression import Licensing
 from spdx_tools.spdx.jsonschema.annotation_converter import AnnotationConverter
 from spdx_tools.spdx.jsonschema.snippet_converter import SnippetConverter
 from spdx_tools.spdx.jsonschema.snippet_properties import SnippetProperty
-from spdx_tools.spdx.model.actor import Actor, ActorType
-from spdx_tools.spdx.model.annotation import Annotation, AnnotationType
-from spdx_tools.spdx.model.document import Document
-from spdx_tools.spdx.model.snippet import Snippet
-from spdx_tools.spdx.model.spdx_no_assertion import SPDX_NO_ASSERTION_STRING, SpdxNoAssertion
-from spdx_tools.spdx.model.spdx_none import SPDX_NONE_STRING, SpdxNone
+from spdx_tools.spdx.model import (
+    Actor,
+    ActorType,
+    Annotation,
+    AnnotationType,
+    Document,
+    Snippet,
+    SpdxNoAssertion,
+    SpdxNone,
+)
+from spdx_tools.spdx.model.spdx_no_assertion import SPDX_NO_ASSERTION_STRING
+from spdx_tools.spdx.model.spdx_none import SPDX_NONE_STRING
 from tests.spdx.fixtures import annotation_fixture, creation_info_fixture, document_fixture, snippet_fixture
 from tests.spdx.mock_utils import assert_mock_method_called_with_arguments
 

--- a/tests/spdx/model/test_actor.py
+++ b/tests/spdx/model/test_actor.py
@@ -4,7 +4,7 @@
 
 import pytest
 
-from spdx_tools.spdx.model.actor import Actor, ActorType
+from spdx_tools.spdx.model import Actor, ActorType
 
 
 def test_correct_initialization():

--- a/tests/spdx/model/test_annotation.py
+++ b/tests/spdx/model/test_annotation.py
@@ -7,10 +7,10 @@ from unittest import mock
 
 import pytest
 
-from spdx_tools.spdx.model.annotation import Annotation, AnnotationType
+from spdx_tools.spdx.model import Annotation, AnnotationType
 
 
-@mock.patch("spdx_tools.spdx.model.actor.Actor", autospec=True)
+@mock.patch("spdx_tools.spdx.model.Actor", autospec=True)
 def test_correct_initialization(actor):
     annotation = Annotation("id", AnnotationType.OTHER, actor, datetime(2022, 1, 1), "comment")
     assert annotation.spdx_id == "id"
@@ -20,31 +20,31 @@ def test_correct_initialization(actor):
     assert annotation.annotation_comment == "comment"
 
 
-@mock.patch("spdx_tools.spdx.model.actor.Actor", autospec=True)
+@mock.patch("spdx_tools.spdx.model.Actor", autospec=True)
 def test_wrong_type_in_spdx_id(actor):
     with pytest.raises(TypeError):
         Annotation(42, AnnotationType.OTHER, actor, datetime(2022, 1, 1), "comment")
 
 
-@mock.patch("spdx_tools.spdx.model.actor.Actor", autospec=True)
+@mock.patch("spdx_tools.spdx.model.Actor", autospec=True)
 def test_wrong_type_in_annotation_type(actor):
     with pytest.raises(TypeError):
         Annotation("id", 42, actor, datetime(2022, 1, 1), "comment")
 
 
-@mock.patch("spdx_tools.spdx.model.actor.Actor", autospec=True)
+@mock.patch("spdx_tools.spdx.model.Actor", autospec=True)
 def test_wrong_type_in_annotator(actor):
     with pytest.raises(TypeError):
         Annotation("id", AnnotationType.OTHER, 42, datetime(2022, 1, 1), "comment")
 
 
-@mock.patch("spdx_tools.spdx.model.actor.Actor", autospec=True)
+@mock.patch("spdx_tools.spdx.model.Actor", autospec=True)
 def test_wrong_type_in_annotation_date(actor):
     with pytest.raises(TypeError):
         Annotation("id", AnnotationType.OTHER, actor, 42, "comment")
 
 
-@mock.patch("spdx_tools.spdx.model.actor.Actor", autospec=True)
+@mock.patch("spdx_tools.spdx.model.Actor", autospec=True)
 def test_wrong_type_in_annotation_comment(actor):
     with pytest.raises(TypeError):
         Annotation("id", AnnotationType.OTHER, actor, datetime(2022, 1, 1), 42)

--- a/tests/spdx/model/test_checksum.py
+++ b/tests/spdx/model/test_checksum.py
@@ -4,7 +4,7 @@
 
 import pytest
 
-from spdx_tools.spdx.model.checksum import Checksum, ChecksumAlgorithm
+from spdx_tools.spdx.model import Checksum, ChecksumAlgorithm
 
 
 def test_correct_initialization():

--- a/tests/spdx/model/test_creation_info.py
+++ b/tests/spdx/model/test_creation_info.py
@@ -7,12 +7,11 @@ from unittest import mock
 
 import pytest
 
-from spdx_tools.spdx.model.document import CreationInfo
-from spdx_tools.spdx.model.version import Version
+from spdx_tools.spdx.model import CreationInfo, Version
 
 
-@mock.patch("spdx_tools.spdx.model.external_document_ref.ExternalDocumentRef", autospec=True)
-@mock.patch("spdx_tools.spdx.model.actor.Actor", autospec=True)
+@mock.patch("spdx_tools.spdx.model.ExternalDocumentRef", autospec=True)
+@mock.patch("spdx_tools.spdx.model.Actor", autospec=True)
 def test_correct_initialization(actor, ext_ref):
     creation_info = CreationInfo(
         "version",
@@ -40,25 +39,25 @@ def test_correct_initialization(actor, ext_ref):
     assert creation_info.document_comment == "doc_comment"
 
 
-@mock.patch("spdx_tools.spdx.model.actor.Actor", autospec=True)
+@mock.patch("spdx_tools.spdx.model.Actor", autospec=True)
 def test_wrong_type_in_spdx_version(actor):
     with pytest.raises(TypeError):
         CreationInfo(42, "id", "name", "namespace", [actor, actor], datetime(2022, 1, 1))
 
 
-@mock.patch("spdx_tools.spdx.model.actor.Actor", autospec=True)
+@mock.patch("spdx_tools.spdx.model.Actor", autospec=True)
 def test_wrong_type_in_spdx_id(actor):
     with pytest.raises(TypeError):
         CreationInfo("version", 42, "name", "namespace", [actor, actor], datetime(2022, 1, 1))
 
 
-@mock.patch("spdx_tools.spdx.model.actor.Actor", autospec=True)
+@mock.patch("spdx_tools.spdx.model.Actor", autospec=True)
 def test_wrong_type_in_name(actor):
     with pytest.raises(TypeError):
         CreationInfo("version", "id", 42, "namespace", [actor, actor], datetime(2022, 1, 1))
 
 
-@mock.patch("spdx_tools.spdx.model.actor.Actor", autospec=True)
+@mock.patch("spdx_tools.spdx.model.Actor", autospec=True)
 def test_wrong_type_in_document_namespace(actor):
     with pytest.raises(TypeError):
         CreationInfo("version", "id", "name", 42, [actor, actor], datetime(2022, 1, 1))
@@ -69,13 +68,13 @@ def test_wrong_type_in_creators():
         CreationInfo("version", "id", "name", "namespace", ["person"], datetime(2022, 1, 1))
 
 
-@mock.patch("spdx_tools.spdx.model.actor.Actor", autospec=True)
+@mock.patch("spdx_tools.spdx.model.Actor", autospec=True)
 def test_wrong_type_in_created(actor):
     with pytest.raises(TypeError):
         CreationInfo("version", "id", "name", "namespace", [actor, actor], "2022-01-01")
 
 
-@mock.patch("spdx_tools.spdx.model.actor.Actor", autospec=True)
+@mock.patch("spdx_tools.spdx.model.Actor", autospec=True)
 def test_wrong_type_in_creator_comment(actor):
     with pytest.raises(TypeError):
         CreationInfo(
@@ -83,13 +82,13 @@ def test_wrong_type_in_creator_comment(actor):
         )
 
 
-@mock.patch("spdx_tools.spdx.model.actor.Actor", autospec=True)
+@mock.patch("spdx_tools.spdx.model.Actor", autospec=True)
 def test_wrong_type_in_data_license(actor):
     with pytest.raises(TypeError):
         CreationInfo("version", "id", "name", "namespace", [actor, actor], datetime(2022, 1, 1), data_license=42)
 
 
-@mock.patch("spdx_tools.spdx.model.actor.Actor", autospec=True)
+@mock.patch("spdx_tools.spdx.model.Actor", autospec=True)
 def test_wrong_type_in_external_document_refs(actor):
     with pytest.raises(TypeError):
         CreationInfo(
@@ -97,7 +96,7 @@ def test_wrong_type_in_external_document_refs(actor):
         )
 
 
-@mock.patch("spdx_tools.spdx.model.actor.Actor", autospec=True)
+@mock.patch("spdx_tools.spdx.model.Actor", autospec=True)
 def test_wrong_type_in_license_list_version(actor):
     with pytest.raises(TypeError):
         CreationInfo(
@@ -105,7 +104,7 @@ def test_wrong_type_in_license_list_version(actor):
         )
 
 
-@mock.patch("spdx_tools.spdx.model.actor.Actor", autospec=True)
+@mock.patch("spdx_tools.spdx.model.Actor", autospec=True)
 def test_wrong_type_in_document_comment(actor):
     with pytest.raises(TypeError):
         CreationInfo(

--- a/tests/spdx/model/test_document.py
+++ b/tests/spdx/model/test_document.py
@@ -6,16 +6,16 @@ from unittest import mock
 
 import pytest
 
-from spdx_tools.spdx.model.document import Document
+from spdx_tools.spdx.model import Document
 
 
-@mock.patch("spdx_tools.spdx.model.extracted_licensing_info.ExtractedLicensingInfo", autospec=True)
-@mock.patch("spdx_tools.spdx.model.relationship.Relationship", autospec=True)
-@mock.patch("spdx_tools.spdx.model.annotation.Annotation", autospec=True)
-@mock.patch("spdx_tools.spdx.model.snippet.Snippet", autospec=True)
-@mock.patch("spdx_tools.spdx.model.file.File", autospec=True)
-@mock.patch("spdx_tools.spdx.model.package.Package", autospec=True)
-@mock.patch("spdx_tools.spdx.model.document.CreationInfo", autospec=True)
+@mock.patch("spdx_tools.spdx.model.ExtractedLicensingInfo", autospec=True)
+@mock.patch("spdx_tools.spdx.model.Relationship", autospec=True)
+@mock.patch("spdx_tools.spdx.model.Annotation", autospec=True)
+@mock.patch("spdx_tools.spdx.model.Snippet", autospec=True)
+@mock.patch("spdx_tools.spdx.model.File", autospec=True)
+@mock.patch("spdx_tools.spdx.model.Package", autospec=True)
+@mock.patch("spdx_tools.spdx.model.CreationInfo", autospec=True)
 def test_correct_initialization(creation_info, package, file, snippet, annotation, relationship, extracted_lic):
     document = Document(
         creation_info,
@@ -35,7 +35,7 @@ def test_correct_initialization(creation_info, package, file, snippet, annotatio
     assert document.extracted_licensing_info == [extracted_lic, extracted_lic]
 
 
-@mock.patch("spdx_tools.spdx.model.document.CreationInfo", autospec=True)
+@mock.patch("spdx_tools.spdx.model.CreationInfo", autospec=True)
 def test_correct_initialization_with_default_values(creation_info):
     document = Document(creation_info)
     assert document.creation_info == creation_info
@@ -52,37 +52,37 @@ def test_wrong_type_in_creation_info():
         Document("string")
 
 
-@mock.patch("spdx_tools.spdx.model.document.CreationInfo", autospec=True)
+@mock.patch("spdx_tools.spdx.model.CreationInfo", autospec=True)
 def test_wrong_type_in_packages(creation_info):
     with pytest.raises(TypeError):
         Document(creation_info, packages=["string"])
 
 
-@mock.patch("spdx_tools.spdx.model.document.CreationInfo", autospec=True)
+@mock.patch("spdx_tools.spdx.model.CreationInfo", autospec=True)
 def test_wrong_type_in_files(creation_info):
     with pytest.raises(TypeError):
         Document(creation_info, files={})
 
 
-@mock.patch("spdx_tools.spdx.model.document.CreationInfo", autospec=True)
+@mock.patch("spdx_tools.spdx.model.CreationInfo", autospec=True)
 def test_wrong_type_in_snippets(creation_info):
     with pytest.raises(TypeError):
         Document(creation_info, snippets=())
 
 
-@mock.patch("spdx_tools.spdx.model.document.CreationInfo", autospec=True)
+@mock.patch("spdx_tools.spdx.model.CreationInfo", autospec=True)
 def test_wrong_type_in_annotations(creation_info):
     with pytest.raises(TypeError):
         Document(creation_info, annotations=["string"])
 
 
-@mock.patch("spdx_tools.spdx.model.document.CreationInfo", autospec=True)
+@mock.patch("spdx_tools.spdx.model.CreationInfo", autospec=True)
 def test_wrong_type_in_relationships(creation_info):
     with pytest.raises(TypeError):
         Document(creation_info, relationships="string")
 
 
-@mock.patch("spdx_tools.spdx.model.document.CreationInfo", autospec=True)
+@mock.patch("spdx_tools.spdx.model.CreationInfo", autospec=True)
 def test_wrong_type_in_extracted_licensing_info(creation_info):
     with pytest.raises(TypeError):
         Document(creation_info, extracted_licensing_info=42)

--- a/tests/spdx/model/test_external_document_ref.py
+++ b/tests/spdx/model/test_external_document_ref.py
@@ -6,10 +6,10 @@ from unittest import mock
 
 import pytest
 
-from spdx_tools.spdx.model.external_document_ref import ExternalDocumentRef
+from spdx_tools.spdx.model import ExternalDocumentRef
 
 
-@mock.patch("spdx_tools.spdx.model.checksum.Checksum", autospec=True)
+@mock.patch("spdx_tools.spdx.model.Checksum", autospec=True)
 def test_correct_initialization(checksum):
     external_document_ref = ExternalDocumentRef("id", "uri", checksum)
     assert external_document_ref.document_ref_id == "id"
@@ -17,13 +17,13 @@ def test_correct_initialization(checksum):
     assert external_document_ref.checksum == checksum
 
 
-@mock.patch("spdx_tools.spdx.model.checksum.Checksum", autospec=True)
+@mock.patch("spdx_tools.spdx.model.Checksum", autospec=True)
 def test_wrong_type_in_spdx_id(checksum):
     with pytest.raises(TypeError):
         ExternalDocumentRef(42, "uri", checksum)
 
 
-@mock.patch("spdx_tools.spdx.model.checksum.Checksum", autospec=True)
+@mock.patch("spdx_tools.spdx.model.Checksum", autospec=True)
 def test_wrong_type_in_document_uri(checksum):
     with pytest.raises(TypeError):
         ExternalDocumentRef("id", 42, checksum)

--- a/tests/spdx/model/test_external_package_reference.py
+++ b/tests/spdx/model/test_external_package_reference.py
@@ -4,7 +4,7 @@
 
 import pytest
 
-from spdx_tools.spdx.model.package import ExternalPackageRef, ExternalPackageRefCategory
+from spdx_tools.spdx.model import ExternalPackageRef, ExternalPackageRefCategory
 
 
 def test_correct_initialization():

--- a/tests/spdx/model/test_extracted_licensing_info.py
+++ b/tests/spdx/model/test_extracted_licensing_info.py
@@ -4,7 +4,7 @@
 
 import pytest
 
-from spdx_tools.spdx.model.extracted_licensing_info import ExtractedLicensingInfo
+from spdx_tools.spdx.model import ExtractedLicensingInfo
 
 
 def test_correct_initialization():

--- a/tests/spdx/model/test_file.py
+++ b/tests/spdx/model/test_file.py
@@ -6,13 +6,10 @@ from unittest import mock
 
 import pytest
 
-from spdx_tools.spdx.model.checksum import Checksum, ChecksumAlgorithm
-from spdx_tools.spdx.model.file import File, FileType
-from spdx_tools.spdx.model.spdx_no_assertion import SpdxNoAssertion
-from spdx_tools.spdx.model.spdx_none import SpdxNone
+from spdx_tools.spdx.model import Checksum, ChecksumAlgorithm, File, FileType, SpdxNoAssertion, SpdxNone
 
 
-@mock.patch("spdx_tools.spdx.model.checksum.Checksum", autospec=True)
+@mock.patch("spdx_tools.spdx.model.Checksum", autospec=True)
 def test_correct_initialization(checksum):
     file = File(
         "name",
@@ -42,7 +39,7 @@ def test_correct_initialization(checksum):
     assert file.attribution_texts == ["attribution"]
 
 
-@mock.patch("spdx_tools.spdx.model.checksum.Checksum", autospec=True)
+@mock.patch("spdx_tools.spdx.model.Checksum", autospec=True)
 def test_correct_initialization_with_default_values(checksum):
     file = File("name", "id", [checksum, checksum])
     assert file.name == "name"
@@ -59,13 +56,13 @@ def test_correct_initialization_with_default_values(checksum):
     assert file.attribution_texts == []
 
 
-@mock.patch("spdx_tools.spdx.model.checksum.Checksum", autospec=True)
+@mock.patch("spdx_tools.spdx.model.Checksum", autospec=True)
 def test_wrong_type_in_name(checksum):
     with pytest.raises(TypeError):
         File(42, "id", [checksum])
 
 
-@mock.patch("spdx_tools.spdx.model.checksum.Checksum", autospec=True)
+@mock.patch("spdx_tools.spdx.model.Checksum", autospec=True)
 def test_wrong_type_in_spdx_id(checksum):
     with pytest.raises(TypeError):
         File("name", 42, [checksum])
@@ -77,55 +74,55 @@ def test_wrong_type_in_checksum():
         File("name", "id", checksum)
 
 
-@mock.patch("spdx_tools.spdx.model.checksum.Checksum", autospec=True)
+@mock.patch("spdx_tools.spdx.model.Checksum", autospec=True)
 def test_wrong_type_in_file_type(checksum):
     with pytest.raises(TypeError):
         File("name", "id", [checksum], file_types=FileType.OTHER)
 
 
-@mock.patch("spdx_tools.spdx.model.checksum.Checksum", autospec=True)
+@mock.patch("spdx_tools.spdx.model.Checksum", autospec=True)
 def test_wrong_type_in_license_concluded(checksum):
     with pytest.raises(TypeError):
         File("name", "id", [checksum], license_concluded="NONE")
 
 
-@mock.patch("spdx_tools.spdx.model.checksum.Checksum", autospec=True)
+@mock.patch("spdx_tools.spdx.model.Checksum", autospec=True)
 def test_wrong_type_in_license_info_in_file(checksum):
     with pytest.raises(TypeError):
         File("name", "id", [checksum], license_info_in_file=[SpdxNone])
 
 
-@mock.patch("spdx_tools.spdx.model.checksum.Checksum", autospec=True)
+@mock.patch("spdx_tools.spdx.model.Checksum", autospec=True)
 def test_wrong_type_in_license_comment(checksum):
     with pytest.raises(TypeError):
         File("name", "id", [checksum], license_comment=42)
 
 
-@mock.patch("spdx_tools.spdx.model.checksum.Checksum", autospec=True)
+@mock.patch("spdx_tools.spdx.model.Checksum", autospec=True)
 def test_wrong_type_in_copyright_text(checksum):
     with pytest.raises(TypeError):
         File("name", "id", [checksum], copyright_text=[SpdxNone()])
 
 
-@mock.patch("spdx_tools.spdx.model.checksum.Checksum", autospec=True)
+@mock.patch("spdx_tools.spdx.model.Checksum", autospec=True)
 def test_wrong_type_in_comment(checksum):
     with pytest.raises(TypeError):
         File("name", "id", [checksum], comment=42)
 
 
-@mock.patch("spdx_tools.spdx.model.checksum.Checksum", autospec=True)
+@mock.patch("spdx_tools.spdx.model.Checksum", autospec=True)
 def test_wrong_type_in_notice(checksum):
     with pytest.raises(TypeError):
         File("name", "id", [checksum], notice=["notice"])
 
 
-@mock.patch("spdx_tools.spdx.model.checksum.Checksum", autospec=True)
+@mock.patch("spdx_tools.spdx.model.Checksum", autospec=True)
 def test_wrong_type_in_contributors(checksum):
     with pytest.raises(TypeError):
         File("name", "id", [checksum], contributors="contributor")
 
 
-@mock.patch("spdx_tools.spdx.model.checksum.Checksum", autospec=True)
+@mock.patch("spdx_tools.spdx.model.Checksum", autospec=True)
 def test_wrong_type_in_attribution_texts(checksum):
     with pytest.raises(TypeError):
         File("name", "id", [checksum], attribution_texts=["attribution", 42])

--- a/tests/spdx/model/test_package.py
+++ b/tests/spdx/model/test_package.py
@@ -8,16 +8,13 @@ from unittest import mock
 import pytest
 from license_expression import LicenseExpression, Licensing
 
-from spdx_tools.spdx.model.checksum import Checksum, ChecksumAlgorithm
-from spdx_tools.spdx.model.package import Package, PackagePurpose
-from spdx_tools.spdx.model.spdx_no_assertion import SpdxNoAssertion
-from spdx_tools.spdx.model.spdx_none import SpdxNone
+from spdx_tools.spdx.model import Checksum, ChecksumAlgorithm, Package, PackagePurpose, SpdxNoAssertion, SpdxNone
 
 
-@mock.patch("spdx_tools.spdx.model.package.ExternalPackageRef", autospec=True)
-@mock.patch("spdx_tools.spdx.model.checksum.Checksum", autospec=True)
-@mock.patch("spdx_tools.spdx.model.package.PackageVerificationCode", autospec=True)
-@mock.patch("spdx_tools.spdx.model.actor.Actor", autospec=True)
+@mock.patch("spdx_tools.spdx.model.ExternalPackageRef", autospec=True)
+@mock.patch("spdx_tools.spdx.model.Checksum", autospec=True)
+@mock.patch("spdx_tools.spdx.model.PackageVerificationCode", autospec=True)
+@mock.patch("spdx_tools.spdx.model.Actor", autospec=True)
 def test_correct_initialization(actor, verif_code, checksum, ext_ref):
     package = Package(
         "id",

--- a/tests/spdx/model/test_package_verification_code.py
+++ b/tests/spdx/model/test_package_verification_code.py
@@ -4,7 +4,7 @@
 
 import pytest
 
-from spdx_tools.spdx.model.package import PackageVerificationCode
+from spdx_tools.spdx.model import PackageVerificationCode
 
 
 def test_correct_initialization():

--- a/tests/spdx/model/test_relationship.py
+++ b/tests/spdx/model/test_relationship.py
@@ -4,8 +4,7 @@
 
 import pytest
 
-from spdx_tools.spdx.model.relationship import Relationship, RelationshipType
-from spdx_tools.spdx.model.spdx_no_assertion import SpdxNoAssertion
+from spdx_tools.spdx.model import Relationship, RelationshipType, SpdxNoAssertion
 
 
 def test_correct_initialization():

--- a/tests/spdx/model/test_snippet.py
+++ b/tests/spdx/model/test_snippet.py
@@ -4,9 +4,7 @@
 
 import pytest
 
-from spdx_tools.spdx.model.snippet import Snippet
-from spdx_tools.spdx.model.spdx_no_assertion import SpdxNoAssertion
-from spdx_tools.spdx.model.spdx_none import SpdxNone
+from spdx_tools.spdx.model import Snippet, SpdxNoAssertion, SpdxNone
 
 
 def test_correct_initialization():

--- a/tests/spdx/model/test_version.py
+++ b/tests/spdx/model/test_version.py
@@ -4,7 +4,7 @@
 
 import pytest
 
-from spdx_tools.spdx.model.version import Version
+from spdx_tools.spdx.model import Version
 
 
 @pytest.mark.parametrize("input_string,expected", [("1.2", Version(1, 2)), ("12.345", Version(12, 345))])

--- a/tests/spdx/parser/all_formats/test_parse_from_file.py
+++ b/tests/spdx/parser/all_formats/test_parse_from_file.py
@@ -6,7 +6,7 @@ import os
 
 import pytest
 
-from spdx_tools.spdx.model.document import Document
+from spdx_tools.spdx.model import Document
 from spdx_tools.spdx.parser.json import json_parser
 from spdx_tools.spdx.parser.rdf import rdf_parser
 from spdx_tools.spdx.parser.tagvalue import tagvalue_parser

--- a/tests/spdx/parser/jsonlikedict/test_annotation_parser.py
+++ b/tests/spdx/parser/jsonlikedict/test_annotation_parser.py
@@ -7,8 +7,7 @@ from unittest import TestCase
 import pytest
 
 from spdx_tools.spdx.constants import DOCUMENT_SPDX_ID
-from spdx_tools.spdx.model.actor import Actor, ActorType
-from spdx_tools.spdx.model.annotation import Annotation, AnnotationType
+from spdx_tools.spdx.model import Actor, ActorType, Annotation, AnnotationType
 from spdx_tools.spdx.parser.error import SPDXParsingError
 from spdx_tools.spdx.parser.jsonlikedict.annotation_parser import AnnotationParser
 

--- a/tests/spdx/parser/jsonlikedict/test_checksum_parser.py
+++ b/tests/spdx/parser/jsonlikedict/test_checksum_parser.py
@@ -5,7 +5,7 @@ from unittest import TestCase
 
 import pytest
 
-from spdx_tools.spdx.model.checksum import ChecksumAlgorithm
+from spdx_tools.spdx.model import ChecksumAlgorithm
 from spdx_tools.spdx.parser.error import SPDXParsingError
 from spdx_tools.spdx.parser.jsonlikedict.checksum_parser import ChecksumParser
 

--- a/tests/spdx/parser/jsonlikedict/test_creation_info_parser.py
+++ b/tests/spdx/parser/jsonlikedict/test_creation_info_parser.py
@@ -7,10 +7,7 @@ from unittest import TestCase
 import pytest
 
 from spdx_tools.spdx.constants import DOCUMENT_SPDX_ID
-from spdx_tools.spdx.model.actor import Actor, ActorType
-from spdx_tools.spdx.model.checksum import Checksum, ChecksumAlgorithm
-from spdx_tools.spdx.model.external_document_ref import ExternalDocumentRef
-from spdx_tools.spdx.model.version import Version
+from spdx_tools.spdx.model import Actor, ActorType, Checksum, ChecksumAlgorithm, ExternalDocumentRef, Version
 from spdx_tools.spdx.parser.error import SPDXParsingError
 from spdx_tools.spdx.parser.jsonlikedict.creation_info_parser import CreationInfoParser
 

--- a/tests/spdx/parser/jsonlikedict/test_dict_parsing_functions.py
+++ b/tests/spdx/parser/jsonlikedict/test_dict_parsing_functions.py
@@ -5,8 +5,7 @@ from unittest import TestCase
 
 import pytest
 
-from spdx_tools.spdx.model.spdx_no_assertion import SpdxNoAssertion
-from spdx_tools.spdx.model.spdx_none import SpdxNone
+from spdx_tools.spdx.model import SpdxNoAssertion, SpdxNone
 from spdx_tools.spdx.parser.error import SPDXParsingError
 from spdx_tools.spdx.parser.jsonlikedict.dict_parsing_functions import (
     json_str_to_enum_name,

--- a/tests/spdx/parser/jsonlikedict/test_file_parser.py
+++ b/tests/spdx/parser/jsonlikedict/test_file_parser.py
@@ -6,10 +6,7 @@ from unittest import TestCase
 import pytest
 from license_expression import Licensing
 
-from spdx_tools.spdx.model.checksum import Checksum, ChecksumAlgorithm
-from spdx_tools.spdx.model.file import FileType
-from spdx_tools.spdx.model.spdx_no_assertion import SpdxNoAssertion
-from spdx_tools.spdx.model.spdx_none import SpdxNone
+from spdx_tools.spdx.model import Checksum, ChecksumAlgorithm, FileType, SpdxNoAssertion, SpdxNone
 from spdx_tools.spdx.parser.error import SPDXParsingError
 from spdx_tools.spdx.parser.jsonlikedict.dict_parsing_functions import parse_list_of_elements
 from spdx_tools.spdx.parser.jsonlikedict.file_parser import FileParser

--- a/tests/spdx/parser/jsonlikedict/test_license_expression_parser.py
+++ b/tests/spdx/parser/jsonlikedict/test_license_expression_parser.py
@@ -6,8 +6,7 @@ from unittest import TestCase
 import pytest
 from license_expression import get_spdx_licensing
 
-from spdx_tools.spdx.model.spdx_no_assertion import SpdxNoAssertion
-from spdx_tools.spdx.model.spdx_none import SpdxNone
+from spdx_tools.spdx.model import SpdxNoAssertion, SpdxNone
 from spdx_tools.spdx.parser.error import SPDXParsingError
 from spdx_tools.spdx.parser.jsonlikedict.license_expression_parser import LicenseExpressionParser
 

--- a/tests/spdx/parser/jsonlikedict/test_package_parser.py
+++ b/tests/spdx/parser/jsonlikedict/test_package_parser.py
@@ -7,16 +7,18 @@ from unittest import TestCase
 import pytest
 from license_expression import Licensing
 
-from spdx_tools.spdx.model.actor import Actor, ActorType
-from spdx_tools.spdx.model.checksum import Checksum, ChecksumAlgorithm
-from spdx_tools.spdx.model.package import (
+from spdx_tools.spdx.model import (
+    Actor,
+    ActorType,
+    Checksum,
+    ChecksumAlgorithm,
     ExternalPackageRef,
     ExternalPackageRefCategory,
     PackagePurpose,
     PackageVerificationCode,
+    SpdxNoAssertion,
+    SpdxNone,
 )
-from spdx_tools.spdx.model.spdx_no_assertion import SpdxNoAssertion
-from spdx_tools.spdx.model.spdx_none import SpdxNone
 from spdx_tools.spdx.parser.error import SPDXParsingError
 from spdx_tools.spdx.parser.jsonlikedict.dict_parsing_functions import parse_list_of_elements
 from spdx_tools.spdx.parser.jsonlikedict.package_parser import PackageParser

--- a/tests/spdx/parser/jsonlikedict/test_relationship_parser.py
+++ b/tests/spdx/parser/jsonlikedict/test_relationship_parser.py
@@ -6,8 +6,7 @@ from unittest import TestCase
 import pytest
 
 from spdx_tools.spdx.constants import DOCUMENT_SPDX_ID
-from spdx_tools.spdx.model.relationship import Relationship, RelationshipType
-from spdx_tools.spdx.model.spdx_no_assertion import SpdxNoAssertion
+from spdx_tools.spdx.model import Relationship, RelationshipType, SpdxNoAssertion
 from spdx_tools.spdx.parser.error import SPDXParsingError
 from spdx_tools.spdx.parser.jsonlikedict.relationship_parser import RelationshipParser
 

--- a/tests/spdx/parser/jsonlikedict/test_snippet_parser.py
+++ b/tests/spdx/parser/jsonlikedict/test_snippet_parser.py
@@ -6,8 +6,7 @@ from unittest import TestCase
 import pytest
 from license_expression import Licensing
 
-from spdx_tools.spdx.model.spdx_no_assertion import SpdxNoAssertion
-from spdx_tools.spdx.model.spdx_none import SpdxNone
+from spdx_tools.spdx.model import SpdxNoAssertion, SpdxNone
 from spdx_tools.spdx.parser.error import SPDXParsingError
 from spdx_tools.spdx.parser.jsonlikedict.snippet_parser import SnippetParser
 

--- a/tests/spdx/parser/rdf/test_annotation_parser.py
+++ b/tests/spdx/parser/rdf/test_annotation_parser.py
@@ -6,8 +6,7 @@ from datetime import datetime
 
 from rdflib import BNode, Graph, URIRef
 
-from spdx_tools.spdx.model.actor import Actor, ActorType
-from spdx_tools.spdx.model.annotation import AnnotationType
+from spdx_tools.spdx.model import Actor, ActorType, AnnotationType
 from spdx_tools.spdx.parser.rdf.annotation_parser import parse_annotation
 from spdx_tools.spdx.rdfschema.namespace import SPDX_NAMESPACE
 

--- a/tests/spdx/parser/rdf/test_checksum_parser.py
+++ b/tests/spdx/parser/rdf/test_checksum_parser.py
@@ -6,7 +6,7 @@ import os
 import pytest
 from rdflib import BNode, Graph, URIRef
 
-from spdx_tools.spdx.model.checksum import ChecksumAlgorithm
+from spdx_tools.spdx.model import ChecksumAlgorithm
 from spdx_tools.spdx.parser.error import SPDXParsingError
 from spdx_tools.spdx.parser.rdf.checksum_parser import convert_rdf_to_algorithm, parse_checksum
 from spdx_tools.spdx.rdfschema.namespace import SPDX_NAMESPACE

--- a/tests/spdx/parser/rdf/test_creation_info_parser.py
+++ b/tests/spdx/parser/rdf/test_creation_info_parser.py
@@ -10,9 +10,7 @@ from rdflib import RDF, Graph, URIRef
 from rdflib.term import Node
 
 from spdx_tools.spdx.constants import DOCUMENT_SPDX_ID
-from spdx_tools.spdx.model.actor import Actor, ActorType
-from spdx_tools.spdx.model.checksum import Checksum, ChecksumAlgorithm
-from spdx_tools.spdx.model.version import Version
+from spdx_tools.spdx.model import Actor, ActorType, Checksum, ChecksumAlgorithm, Version
 from spdx_tools.spdx.parser.rdf.creation_info_parser import (
     parse_creation_info,
     parse_external_document_refs,

--- a/tests/spdx/parser/rdf/test_file_parser.py
+++ b/tests/spdx/parser/rdf/test_file_parser.py
@@ -7,9 +7,7 @@ from unittest import TestCase
 from license_expression import get_spdx_licensing
 from rdflib import RDF, Graph, URIRef
 
-from spdx_tools.spdx.model.checksum import Checksum, ChecksumAlgorithm
-from spdx_tools.spdx.model.file import FileType
-from spdx_tools.spdx.model.spdx_no_assertion import SpdxNoAssertion
+from spdx_tools.spdx.model import Checksum, ChecksumAlgorithm, FileType, SpdxNoAssertion
 from spdx_tools.spdx.parser.rdf.file_parser import parse_file
 from spdx_tools.spdx.rdfschema.namespace import SPDX_NAMESPACE
 

--- a/tests/spdx/parser/rdf/test_package_parser.py
+++ b/tests/spdx/parser/rdf/test_package_parser.py
@@ -8,10 +8,16 @@ import pytest
 from license_expression import get_spdx_licensing
 from rdflib import RDF, BNode, Graph, Literal, URIRef
 
-from spdx_tools.spdx.model.actor import Actor, ActorType
-from spdx_tools.spdx.model.checksum import Checksum, ChecksumAlgorithm
-from spdx_tools.spdx.model.package import ExternalPackageRefCategory, PackagePurpose, PackageVerificationCode
-from spdx_tools.spdx.model.spdx_no_assertion import SpdxNoAssertion
+from spdx_tools.spdx.model import (
+    Actor,
+    ActorType,
+    Checksum,
+    ChecksumAlgorithm,
+    ExternalPackageRefCategory,
+    PackagePurpose,
+    PackageVerificationCode,
+    SpdxNoAssertion,
+)
 from spdx_tools.spdx.parser.rdf.package_parser import parse_external_package_ref, parse_package
 from spdx_tools.spdx.rdfschema.namespace import SPDX_NAMESPACE
 

--- a/tests/spdx/parser/rdf/test_relationship_parser.py
+++ b/tests/spdx/parser/rdf/test_relationship_parser.py
@@ -7,7 +7,7 @@ import pytest
 from rdflib import RDF, Graph, URIRef
 
 from spdx_tools.spdx.constants import DOCUMENT_SPDX_ID
-from spdx_tools.spdx.model.relationship import RelationshipType
+from spdx_tools.spdx.model import RelationshipType
 from spdx_tools.spdx.parser.rdf.relationship_parser import parse_implicit_relationship, parse_relationship
 from spdx_tools.spdx.rdfschema.namespace import SPDX_NAMESPACE
 

--- a/tests/spdx/parser/rdf/test_snippet_parser.py
+++ b/tests/spdx/parser/rdf/test_snippet_parser.py
@@ -8,7 +8,7 @@ import pytest
 from license_expression import get_spdx_licensing
 from rdflib import RDF, BNode, Graph, Literal, URIRef
 
-from spdx_tools.spdx.model.spdx_no_assertion import SpdxNoAssertion
+from spdx_tools.spdx.model import SpdxNoAssertion
 from spdx_tools.spdx.parser.error import SPDXParsingError
 from spdx_tools.spdx.parser.rdf.snippet_parser import parse_ranges, parse_snippet
 from spdx_tools.spdx.rdfschema.namespace import POINTER_NAMESPACE, SPDX_NAMESPACE

--- a/tests/spdx/parser/tagvalue/test_annotation_parser.py
+++ b/tests/spdx/parser/tagvalue/test_annotation_parser.py
@@ -6,7 +6,7 @@ from datetime import datetime
 import pytest
 
 from spdx_tools.spdx.constants import DOCUMENT_SPDX_ID
-from spdx_tools.spdx.model.annotation import AnnotationType
+from spdx_tools.spdx.model import AnnotationType
 from spdx_tools.spdx.parser.error import SPDXParsingError
 from spdx_tools.spdx.parser.tagvalue.parser import Parser
 from tests.spdx.parser.tagvalue.test_creation_info_parser import DOCUMENT_STR

--- a/tests/spdx/parser/tagvalue/test_creation_info_parser.py
+++ b/tests/spdx/parser/tagvalue/test_creation_info_parser.py
@@ -7,10 +7,7 @@ from unittest import TestCase
 import pytest
 
 from spdx_tools.spdx.constants import DOCUMENT_SPDX_ID
-from spdx_tools.spdx.model.actor import Actor, ActorType
-from spdx_tools.spdx.model.checksum import Checksum, ChecksumAlgorithm
-from spdx_tools.spdx.model.external_document_ref import ExternalDocumentRef
-from spdx_tools.spdx.model.version import Version
+from spdx_tools.spdx.model import Actor, ActorType, Checksum, ChecksumAlgorithm, ExternalDocumentRef, Version
 from spdx_tools.spdx.parser.error import SPDXParsingError
 from spdx_tools.spdx.parser.tagvalue.parser import Parser
 

--- a/tests/spdx/parser/tagvalue/test_file_parser.py
+++ b/tests/spdx/parser/tagvalue/test_file_parser.py
@@ -4,8 +4,7 @@
 import pytest
 from license_expression import get_spdx_licensing
 
-from spdx_tools.spdx.model.file import FileType
-from spdx_tools.spdx.model.spdx_no_assertion import SpdxNoAssertion
+from spdx_tools.spdx.model import FileType, SpdxNoAssertion
 from spdx_tools.spdx.parser.error import SPDXParsingError
 from spdx_tools.spdx.parser.tagvalue.parser import Parser
 from tests.spdx.parser.tagvalue.test_creation_info_parser import DOCUMENT_STR

--- a/tests/spdx/parser/tagvalue/test_helper_methods.py
+++ b/tests/spdx/parser/tagvalue/test_helper_methods.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 import pytest
 
-from spdx_tools.spdx.model.checksum import ChecksumAlgorithm
+from spdx_tools.spdx.model import ChecksumAlgorithm
 from spdx_tools.spdx.parser.tagvalue.helper_methods import parse_checksum
 
 

--- a/tests/spdx/parser/tagvalue/test_package_parser.py
+++ b/tests/spdx/parser/tagvalue/test_package_parser.py
@@ -8,8 +8,7 @@ import pytest
 from license_expression import get_spdx_licensing
 
 from spdx_tools.spdx.constants import DOCUMENT_SPDX_ID
-from spdx_tools.spdx.model.package import ExternalPackageRef, ExternalPackageRefCategory, PackagePurpose
-from spdx_tools.spdx.model.spdx_none import SpdxNone
+from spdx_tools.spdx.model import ExternalPackageRef, ExternalPackageRefCategory, PackagePurpose, SpdxNone
 from spdx_tools.spdx.parser.error import SPDXParsingError
 from spdx_tools.spdx.parser.tagvalue.parser import Parser
 from tests.spdx.parser.tagvalue.test_creation_info_parser import DOCUMENT_STR

--- a/tests/spdx/parser/tagvalue/test_relationship_parser.py
+++ b/tests/spdx/parser/tagvalue/test_relationship_parser.py
@@ -4,9 +4,7 @@
 import pytest
 
 from spdx_tools.spdx.constants import DOCUMENT_SPDX_ID
-from spdx_tools.spdx.model.relationship import Relationship, RelationshipType
-from spdx_tools.spdx.model.spdx_no_assertion import SpdxNoAssertion
-from spdx_tools.spdx.model.spdx_none import SpdxNone
+from spdx_tools.spdx.model import Relationship, RelationshipType, SpdxNoAssertion, SpdxNone
 from spdx_tools.spdx.parser.error import SPDXParsingError
 from spdx_tools.spdx.parser.tagvalue.parser import Parser
 from tests.spdx.parser.tagvalue.test_creation_info_parser import DOCUMENT_STR

--- a/tests/spdx/parser/tagvalue/test_snippet_parser.py
+++ b/tests/spdx/parser/tagvalue/test_snippet_parser.py
@@ -6,7 +6,7 @@ from unittest import TestCase
 import pytest
 from license_expression import get_spdx_licensing
 
-from spdx_tools.spdx.model.spdx_no_assertion import SpdxNoAssertion
+from spdx_tools.spdx.model import SpdxNoAssertion
 from spdx_tools.spdx.parser.error import SPDXParsingError
 from spdx_tools.spdx.parser.tagvalue.parser import Parser
 from tests.spdx.parser.tagvalue.test_creation_info_parser import DOCUMENT_STR

--- a/tests/spdx/parser/tagvalue/test_tag_value_parser.py
+++ b/tests/spdx/parser/tagvalue/test_tag_value_parser.py
@@ -6,7 +6,7 @@
 import pytest
 
 from spdx_tools.spdx.constants import DOCUMENT_SPDX_ID
-from spdx_tools.spdx.model.relationship import Relationship, RelationshipType
+from spdx_tools.spdx.model import Relationship, RelationshipType
 from spdx_tools.spdx.parser.error import SPDXParsingError
 from spdx_tools.spdx.parser.tagvalue.parser import Parser
 from tests.spdx.parser.tagvalue.test_creation_info_parser import DOCUMENT_STR

--- a/tests/spdx/test_actor_parser.py
+++ b/tests/spdx/test_actor_parser.py
@@ -5,7 +5,7 @@ from unittest import TestCase
 
 import pytest
 
-from spdx_tools.spdx.model.actor import ActorType
+from spdx_tools.spdx.model import ActorType
 from spdx_tools.spdx.parser.actor_parser import ActorParser
 from spdx_tools.spdx.parser.error import SPDXParsingError
 

--- a/tests/spdx/test_document_utils.py
+++ b/tests/spdx/test_document_utils.py
@@ -12,9 +12,7 @@ from spdx_tools.spdx.document_utils import (
     get_contained_spdx_elements,
     get_element_from_spdx_id,
 )
-from spdx_tools.spdx.model.file import FileType
-from spdx_tools.spdx.model.spdx_no_assertion import SpdxNoAssertion
-from spdx_tools.spdx.model.spdx_none import SpdxNone
+from spdx_tools.spdx.model import FileType, SpdxNoAssertion, SpdxNone
 from tests.spdx.fixtures import (
     actor_fixture,
     checksum_fixture,

--- a/tests/spdx/test_graph_generation.py
+++ b/tests/spdx/test_graph_generation.py
@@ -8,8 +8,7 @@ from unittest import TestCase
 import pytest
 
 from spdx_tools.spdx.graph_generation import generate_relationship_graph_from_spdx
-from spdx_tools.spdx.model.document import Document
-from spdx_tools.spdx.model.relationship import Relationship, RelationshipType
+from spdx_tools.spdx.model import Document, Relationship, RelationshipType
 from spdx_tools.spdx.parser.parse_anything import parse_file
 from tests.spdx.fixtures import document_fixture, file_fixture, package_fixture
 

--- a/tests/spdx/validation/test_actor_validator.py
+++ b/tests/spdx/validation/test_actor_validator.py
@@ -7,7 +7,7 @@ from typing import List
 import pytest
 
 from spdx_tools.spdx.constants import DOCUMENT_SPDX_ID
-from spdx_tools.spdx.model.actor import ActorType
+from spdx_tools.spdx.model import ActorType
 from spdx_tools.spdx.validation.actor_validator import validate_actor
 from spdx_tools.spdx.validation.validation_message import SpdxElementType, ValidationContext, ValidationMessage
 from tests.spdx.fixtures import actor_fixture

--- a/tests/spdx/validation/test_annotation_validator.py
+++ b/tests/spdx/validation/test_annotation_validator.py
@@ -6,8 +6,7 @@ from typing import List
 
 import pytest
 
-from spdx_tools.spdx.model.annotation import Annotation
-from spdx_tools.spdx.model.document import Document
+from spdx_tools.spdx.model import Annotation, Document
 from spdx_tools.spdx.validation.annotation_validator import validate_annotation
 from spdx_tools.spdx.validation.validation_message import SpdxElementType, ValidationContext, ValidationMessage
 from tests.spdx.fixtures import annotation_fixture, document_fixture, file_fixture

--- a/tests/spdx/validation/test_checksum_validator.py
+++ b/tests/spdx/validation/test_checksum_validator.py
@@ -6,7 +6,7 @@ from typing import List
 
 import pytest
 
-from spdx_tools.spdx.model.checksum import Checksum, ChecksumAlgorithm
+from spdx_tools.spdx.model import Checksum, ChecksumAlgorithm
 from spdx_tools.spdx.validation.checksum_validator import validate_checksum
 from spdx_tools.spdx.validation.validation_message import SpdxElementType, ValidationContext, ValidationMessage
 from tests.spdx.fixtures import checksum_fixture

--- a/tests/spdx/validation/test_document_validator.py
+++ b/tests/spdx/validation/test_document_validator.py
@@ -7,8 +7,7 @@ from typing import List, Optional
 import pytest
 
 from spdx_tools.spdx.constants import DOCUMENT_SPDX_ID
-from spdx_tools.spdx.model.document import CreationInfo, Document
-from spdx_tools.spdx.model.relationship import Relationship, RelationshipType
+from spdx_tools.spdx.model import CreationInfo, Document, Relationship, RelationshipType
 from spdx_tools.spdx.parser.parse_anything import parse_file
 from spdx_tools.spdx.validation.document_validator import validate_full_spdx_document
 from spdx_tools.spdx.validation.validation_message import SpdxElementType, ValidationContext, ValidationMessage

--- a/tests/spdx/validation/test_external_package_ref_validator.py
+++ b/tests/spdx/validation/test_external_package_ref_validator.py
@@ -6,7 +6,7 @@ from typing import List
 
 import pytest
 
-from spdx_tools.spdx.model.package import ExternalPackageRef, ExternalPackageRefCategory
+from spdx_tools.spdx.model import ExternalPackageRef, ExternalPackageRefCategory
 from spdx_tools.spdx.validation.external_package_ref_validator import (
     BOWER_REGEX,
     CPE22TYPE_REGEX,

--- a/tests/spdx/validation/test_file_validator.py
+++ b/tests/spdx/validation/test_file_validator.py
@@ -7,7 +7,7 @@ from unittest import TestCase
 
 import pytest
 
-from spdx_tools.spdx.model.checksum import Checksum, ChecksumAlgorithm
+from spdx_tools.spdx.model import Checksum, ChecksumAlgorithm
 from spdx_tools.spdx.validation.file_validator import validate_file, validate_file_within_document
 from spdx_tools.spdx.validation.validation_message import SpdxElementType, ValidationContext, ValidationMessage
 from tests.spdx.fixtures import document_fixture, file_fixture

--- a/tests/spdx/validation/test_license_expression_validator.py
+++ b/tests/spdx/validation/test_license_expression_validator.py
@@ -8,9 +8,7 @@ from unittest import TestCase
 import pytest
 from license_expression import LicenseExpression, get_spdx_licensing
 
-from spdx_tools.spdx.model.document import Document
-from spdx_tools.spdx.model.spdx_no_assertion import SpdxNoAssertion
-from spdx_tools.spdx.model.spdx_none import SpdxNone
+from spdx_tools.spdx.model import Document, SpdxNoAssertion, SpdxNone
 from spdx_tools.spdx.validation.license_expression_validator import (
     validate_license_expression,
     validate_license_expressions,

--- a/tests/spdx/validation/test_package_validator.py
+++ b/tests/spdx/validation/test_package_validator.py
@@ -9,9 +9,7 @@ import pytest
 from license_expression import Licensing
 
 from spdx_tools.spdx.constants import DOCUMENT_SPDX_ID
-from spdx_tools.spdx.model.relationship import Relationship, RelationshipType
-from spdx_tools.spdx.model.spdx_no_assertion import SpdxNoAssertion
-from spdx_tools.spdx.model.spdx_none import SpdxNone
+from spdx_tools.spdx.model import Relationship, RelationshipType, SpdxNoAssertion, SpdxNone
 from spdx_tools.spdx.validation.package_validator import validate_package, validate_package_within_document
 from spdx_tools.spdx.validation.validation_message import SpdxElementType, ValidationContext, ValidationMessage
 from tests.spdx.fixtures import document_fixture, file_fixture, package_fixture, package_verification_code_fixture

--- a/tests/spdx/validation/test_package_verification_code_validator.py
+++ b/tests/spdx/validation/test_package_verification_code_validator.py
@@ -4,7 +4,7 @@
 
 import pytest
 
-from spdx_tools.spdx.model.package import PackageVerificationCode
+from spdx_tools.spdx.model import PackageVerificationCode
 from spdx_tools.spdx.validation.package_verification_code_validator import validate_verification_code
 from spdx_tools.spdx.validation.validation_message import SpdxElementType, ValidationContext, ValidationMessage
 

--- a/tests/spdx/validation/test_relationship_validator.py
+++ b/tests/spdx/validation/test_relationship_validator.py
@@ -7,10 +7,7 @@ from typing import List
 import pytest
 
 from spdx_tools.spdx.constants import DOCUMENT_SPDX_ID
-from spdx_tools.spdx.model.document import Document
-from spdx_tools.spdx.model.relationship import Relationship, RelationshipType
-from spdx_tools.spdx.model.spdx_no_assertion import SpdxNoAssertion
-from spdx_tools.spdx.model.spdx_none import SpdxNone
+from spdx_tools.spdx.model import Document, Relationship, RelationshipType, SpdxNoAssertion, SpdxNone
 from spdx_tools.spdx.validation.relationship_validator import validate_relationship
 from spdx_tools.spdx.validation.validation_message import SpdxElementType, ValidationContext, ValidationMessage
 from tests.spdx.fixtures import document_fixture, relationship_fixture

--- a/tests/spdx/writer/rdf/test_checksum_writer.py
+++ b/tests/spdx/writer/rdf/test_checksum_writer.py
@@ -4,7 +4,7 @@
 import pytest
 from rdflib import RDF, Graph, Literal, URIRef
 
-from spdx_tools.spdx.model.checksum import ChecksumAlgorithm
+from spdx_tools.spdx.model import ChecksumAlgorithm
 from spdx_tools.spdx.rdfschema.namespace import SPDX_NAMESPACE
 from spdx_tools.spdx.writer.rdf.checksum_writer import add_checksum_to_graph, algorithm_to_rdf_string
 from tests.spdx.fixtures import checksum_fixture

--- a/tests/spdx/writer/rdf/test_package_writer.py
+++ b/tests/spdx/writer/rdf/test_package_writer.py
@@ -5,7 +5,7 @@ import pytest
 from rdflib import DOAP, RDF, RDFS, XSD, Graph, Literal, URIRef
 
 from spdx_tools.spdx.datetime_conversions import datetime_to_iso_string
-from spdx_tools.spdx.model.package import ExternalPackageRefCategory
+from spdx_tools.spdx.model import ExternalPackageRefCategory
 from spdx_tools.spdx.rdfschema.namespace import LICENSE_NAMESPACE, SPDX_NAMESPACE
 from spdx_tools.spdx.writer.rdf.package_writer import (
     add_external_package_ref_to_graph,

--- a/tests/spdx/writer/rdf/test_rdf_writer.py
+++ b/tests/spdx/writer/rdf/test_rdf_writer.py
@@ -5,7 +5,7 @@ import os
 
 import pytest
 
-from spdx_tools.spdx.model.document import Document
+from spdx_tools.spdx.model import Document
 from spdx_tools.spdx.writer.rdf.rdf_writer import write_document_to_file
 from tests.spdx.fixtures import document_fixture
 

--- a/tests/spdx/writer/tagvalue/test_checksum_writer.py
+++ b/tests/spdx/writer/tagvalue/test_checksum_writer.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 import pytest
 
-from spdx_tools.spdx.model.checksum import ChecksumAlgorithm
+from spdx_tools.spdx.model import ChecksumAlgorithm
 from spdx_tools.spdx.writer.tagvalue.checksum_writer import write_checksum_to_tag_value
 from tests.spdx.fixtures import checksum_fixture
 

--- a/tests/spdx/writer/tagvalue/test_creation_info_writer.py
+++ b/tests/spdx/writer/tagvalue/test_creation_info_writer.py
@@ -7,7 +7,7 @@ from unittest.mock import MagicMock, call, mock_open, patch
 import pytest
 
 from spdx_tools.spdx.constants import DOCUMENT_SPDX_ID
-from spdx_tools.spdx.model.document import CreationInfo
+from spdx_tools.spdx.model import CreationInfo
 from spdx_tools.spdx.writer.tagvalue.creation_info_writer import write_creation_info
 from tests.spdx.fixtures import actor_fixture, creation_info_fixture
 

--- a/tests/spdx/writer/tagvalue/test_relationship_writer.py
+++ b/tests/spdx/writer/tagvalue/test_relationship_writer.py
@@ -5,8 +5,7 @@ from unittest.mock import MagicMock, call, mock_open, patch
 
 import pytest
 
-from spdx_tools.spdx.model.spdx_no_assertion import SpdxNoAssertion
-from spdx_tools.spdx.model.spdx_none import SpdxNone
+from spdx_tools.spdx.model import SpdxNoAssertion, SpdxNone
 from spdx_tools.spdx.writer.tagvalue.relationship_writer import write_relationship
 from tests.spdx.fixtures import relationship_fixture
 

--- a/tests/spdx/writer/tagvalue/test_tagvalue_writer.py
+++ b/tests/spdx/writer/tagvalue/test_tagvalue_writer.py
@@ -7,10 +7,7 @@ from unittest.mock import MagicMock, call, mock_open, patch
 
 import pytest
 
-from spdx_tools.spdx.model.file import File
-from spdx_tools.spdx.model.package import Package
-from spdx_tools.spdx.model.relationship import Relationship, RelationshipType
-from spdx_tools.spdx.model.snippet import Snippet
+from spdx_tools.spdx.model import File, Package, Relationship, RelationshipType, Snippet
 from spdx_tools.spdx.parser.tagvalue import tagvalue_parser
 from spdx_tools.spdx.writer.tagvalue.tagvalue_writer import write_document, write_document_to_file
 from tests.spdx.fixtures import checksum_fixture, document_fixture

--- a/tests/spdx/writer/tagvalue/test_tagvalue_writer_helper_functions.py
+++ b/tests/spdx/writer/tagvalue/test_tagvalue_writer_helper_functions.py
@@ -5,9 +5,7 @@ from unittest.mock import MagicMock, call, mock_open, patch
 
 import pytest
 
-from spdx_tools.spdx.model.actor import ActorType
-from spdx_tools.spdx.model.relationship import RelationshipType
-from spdx_tools.spdx.model.spdx_no_assertion import SpdxNoAssertion
+from spdx_tools.spdx.model import ActorType, RelationshipType, SpdxNoAssertion
 from spdx_tools.spdx.writer.tagvalue.tagvalue_writer_helper_functions import scan_relationships, write_actor
 from tests.spdx.fixtures import actor_fixture, file_fixture, package_fixture, relationship_fixture
 


### PR DESCRIPTION
I had to exclude the `__init__.py` from isort and flake8 because the order of the imports matters in that case.

part of #593