### PR TITLE
make flake8 ignore all __init__.py

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,4 +1,4 @@
 [flake8]
 max-line-length = 119
-exclude = src/spdx_tools/spdx/parser/tagvalue/parsetab.py, src/spdx_tools/spdx/model/__init__.py
+exclude = src/spdx_tools/spdx/parser/tagvalue/parsetab.py, __init__.py
 extend-ignore = E203


### PR DESCRIPTION
This matches isort skipping these files.