### PR TITLE
refactor bumping modules

### DIFF
--- a/src/spdx_tools/spdx3/bump_from_spdx2/annotation.py
+++ b/src/spdx_tools/spdx3/bump_from_spdx2/annotation.py
@@ -33,7 +33,13 @@ def bump_annotation(
             " This case leads to an invalid SPDX3 document and is currently not supported."
         )
     annotation_type: AnnotationType = AnnotationType[spdx2_annotation.annotation_type.name]
-    subject: str = spdx2_annotation.spdx_id
-    statement: str = spdx2_annotation.annotation_comment
 
-    payload.add_element(Annotation(spdx_id, creation_info, annotation_type, subject, statement=statement))
+    payload.add_element(
+        Annotation(
+            spdx_id,
+            creation_info,
+            annotation_type,
+            subject=spdx2_annotation.spdx_id,
+            statement=spdx2_annotation.annotation_comment,
+        )
+    )

--- a/src/spdx_tools/spdx3/bump_from_spdx2/creation_information.py
+++ b/src/spdx_tools/spdx3/bump_from_spdx2/creation_information.py
@@ -1,7 +1,6 @@
 # SPDX-FileCopyrightText: 2023 spdx contributors
 #
 # SPDX-License-Identifier: Apache-2.0
-from datetime import datetime
 from typing import List
 
 from semantic_version import Version
@@ -20,15 +19,9 @@ def bump_creation_information(spdx2_creation_info: Spdx2_CreationInfo, payload: 
     document_namespace = spdx2_creation_info.document_namespace
     spdx_id = f"{document_namespace}#{spdx2_creation_info.spdx_id}"
 
-    # creation_info.name -> spdx_document.name
-    name = spdx2_creation_info.name
-
     # creation_info.document_namespace -> ?
     print_missing_conversion("creation_info.document_namespace", 0)
 
-    created: datetime = spdx2_creation_info.created
-    comment = spdx2_creation_info.document_comment
-    data_license = spdx2_creation_info.data_license
     # creation_info.external_document_refs -> spdx_document.imports
     imports = [
         bump_external_document_ref(external_document_ref)
@@ -39,7 +32,13 @@ def bump_creation_information(spdx2_creation_info: Spdx2_CreationInfo, payload: 
     # creation_info.document_comment -> spdx_document.comment
     document_comment = spdx2_creation_info.document_comment
     creation_information = CreationInformation(
-        Version("3.0.0"), created, [], [], ["core", "software", "licensing"], data_license, comment
+        spec_version=Version("3.0.0"),
+        created=spdx2_creation_info.created,
+        created_by=[],
+        created_using=[],
+        profile=["core", "software", "licensing"],
+        data_license=spdx2_creation_info.data_license,
+        comment=spdx2_creation_info.document_comment,
     )
 
     # due to creators having a creation_information themselves which inherits from the document's one,
@@ -62,14 +61,12 @@ def bump_creation_information(spdx2_creation_info: Spdx2_CreationInfo, payload: 
     creation_information.created_by = creator_ids
     creation_information.created_using = tool_ids
 
-    spdx_document = SpdxDocument(
+    return SpdxDocument(
         spdx_id=spdx_id,
         creation_info=creation_information,
-        name=name,
+        name=spdx2_creation_info.name,
         comment=document_comment,
         elements=[],
         root_elements=[],
         imports=imports,
     )
-
-    return spdx_document

--- a/src/spdx_tools/spdx3/bump_from_spdx2/external_document_ref.py
+++ b/src/spdx_tools/spdx3/bump_from_spdx2/external_document_ref.py
@@ -9,8 +9,10 @@ from spdx_tools.spdx.model.external_document_ref import ExternalDocumentRef
 
 
 def bump_external_document_ref(external_document_ref: ExternalDocumentRef) -> ExternalMap:
-    external_id: str = external_document_ref.document_ref_id
     verified_using: List[Hash] = [bump_checksum(external_document_ref.checksum)]
-    location_hint: str = external_document_ref.document_uri
 
-    return ExternalMap(external_id, verified_using, location_hint)
+    return ExternalMap(
+        external_id=external_document_ref.document_ref_id,
+        verified_using=verified_using,
+        location_hint=external_document_ref.document_uri,
+    )

--- a/src/spdx_tools/spdx3/bump_from_spdx2/file.py
+++ b/src/spdx_tools/spdx3/bump_from_spdx2/file.py
@@ -13,7 +13,6 @@ def bump_file(
     spdx2_file: Spdx2_File, payload: Payload, creation_information: CreationInformation, document_namespace: str
 ):
     spdx_id = "#".join([document_namespace, spdx2_file.spdx_id])
-    name = spdx2_file.name
     integrity_methods = [bump_checksum(checksum) for checksum in spdx2_file.checksums]
     # file.checksums -> file.verifiedUsing
     # file.file_types -> file.content_type (MediaType with Cardinality 1)
@@ -24,11 +23,16 @@ def bump_file(
         "missing definition for license profile",
     )
 
-    comment = spdx2_file.comment
     print_missing_conversion(
         "file.notice, file.contributors, file.attribution_texts", 0, "missing definition for license profile"
     )
 
     payload.add_element(
-        File(spdx_id, creation_info=creation_information, name=name, comment=comment, verified_using=integrity_methods)
+        File(
+            spdx_id,
+            creation_info=creation_information,
+            name=spdx2_file.name,
+            comment=spdx2_file.comment,
+            verified_using=integrity_methods,
+        )
     )

--- a/src/spdx_tools/spdx3/bump_from_spdx2/package.py
+++ b/src/spdx_tools/spdx3/bump_from_spdx2/package.py
@@ -24,9 +24,7 @@ def bump_package(
     spdx2_package: Spdx2_Package, payload: Payload, creation_information: CreationInformation, document_namespace: str
 ):
     spdx_id = "#".join([document_namespace, spdx2_package.spdx_id])
-    name = spdx2_package.name
     download_location = handle_no_assertion_or_none(spdx2_package.download_location, "package.download_location")
-    package_version = spdx2_package.version
     # package.file_name -> ?
     print_missing_conversion("package2.file_name", 0)
     # package.supplier -> Relationship, suppliedBy?
@@ -38,20 +36,12 @@ def bump_package(
     print_missing_conversion("package2.verification_code", 1, "of IntegrityMethod")
     # package.checksums -> package.verified_using
     integrity_methods = [bump_checksum(checksum) for checksum in spdx2_package.checksums]
-    homepage = spdx2_package.homepage
-    source_info = spdx2_package.source_info
     print_missing_conversion(
         "package2.license_concluded, package2.license_info_from_files, package2.license_declared, "
         "package2.license_comment, package2.copyright_text",
         0,
         "and missing definition of license profile",
     )
-    summary = spdx2_package.summary
-    description = spdx2_package.description
-    comment = spdx2_package.comment
-    built_time = spdx2_package.built_date
-    release_time = spdx2_package.release_date
-    valid_until_time = spdx2_package.valid_until_date
 
     external_references = []
     external_identifiers = []
@@ -80,23 +70,23 @@ def bump_package(
         Package(
             spdx_id,
             creation_information,
-            name,
-            summary=summary,
-            description=description,
-            comment=comment,
+            spdx2_package.name,
+            summary=spdx2_package.summary,
+            description=spdx2_package.description,
+            comment=spdx2_package.comment,
             verified_using=integrity_methods,
             external_references=external_references,
             external_identifier=external_identifiers,
             originated_by=originated_by_spdx_id,
-            built_time=built_time,
-            release_time=release_time,
-            valid_until_time=valid_until_time,
+            built_time=spdx2_package.built_date,
+            release_time=spdx2_package.release_date,
+            valid_until_time=spdx2_package.valid_until_date,
             package_purpose=package_purpose,
-            package_version=package_version,
+            package_version=spdx2_package.version,
             download_location=download_location,
             package_url=package_url,
-            homepage=homepage,
-            source_info=source_info,
+            homepage=spdx2_package.homepage,
+            source_info=spdx2_package.source_info,
         )
     )
 

--- a/src/spdx_tools/spdx3/bump_from_spdx2/relationship.py
+++ b/src/spdx_tools/spdx3/bump_from_spdx2/relationship.py
@@ -37,7 +37,6 @@ def bump_relationship(
     else:
         from_element = spdx2_relationship.spdx_element_id
         to = [spdx2_relationship.related_spdx_element_id]
-    comment = spdx2_relationship.comment
 
     payload.add_element(
         Relationship(
@@ -46,7 +45,7 @@ def bump_relationship(
             from_element,
             to,
             relationship_type,
-            comment=comment,
+            comment=spdx2_relationship.comment,
             completeness=completeness,
         )
     )

--- a/src/spdx_tools/spdx3/bump_from_spdx2/snippet.py
+++ b/src/spdx_tools/spdx3/bump_from_spdx2/snippet.py
@@ -13,16 +13,12 @@ def bump_snippet(
 ):
     spdx_id = "#".join([document_namespace, spdx2_snippet.spdx_id])
     print_missing_conversion("snippet.file_spdx_id", 0)
-    byte_range = spdx2_snippet.byte_range
-    line_range = spdx2_snippet.line_range
     print_missing_conversion(
         "snippet.concluded_license, snippet.license_info_in_snippet, snippet.license_comment,"
         "snippet.copyright_text",
         0,
         "missing definitions for license profile",
     )
-    comment = spdx2_snippet.comment
-    name = spdx2_snippet.name
 
     print_missing_conversion("snippet.attribution_texts", 0, "missing definitions for license profile")
 
@@ -30,9 +26,9 @@ def bump_snippet(
         Snippet(
             spdx_id=spdx_id,
             creation_info=creation_information,
-            name=name,
-            comment=comment,
-            byte_range=byte_range,
-            line_range=line_range,
+            name=spdx2_snippet.name,
+            comment=spdx2_snippet.comment,
+            byte_range=spdx2_snippet.byte_range,
+            line_range=spdx2_snippet.line_range,
         )
     )


### PR DESCRIPTION
While going through the bumping modules, I had the urge to utilize the new black formatting a bit more and make the assignment of SPDX 2 to 3 properties a bit more comprehensible (hopefully). Now, for properties that just carry over 1-to-1, you don't have to look around in the module anymore to find the initialization of these variables.