### PR TITLE
make example files valid

### DIFF
--- a/tests/spdx/data/SPDXXMLExample-v2.3.spdx.xml
+++ b/tests/spdx/data/SPDXXMLExample-v2.3.spdx.xml
@@ -267,7 +267,7 @@ EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.</extractedText>
     <externalRefs>
       <referenceCategory>PACKAGE-MANAGER</referenceCategory>
       <referenceLocator>pkg:maven/org.apache.jena/apache-jena@3.12.0</referenceLocator>
-      <referenceType>http://spdx.org/spdxdocs/spdx-example-444504E0-4F89-41D3-9A0C-0305E82C3301#purl</referenceType>
+      <referenceType>purl</referenceType>
     </externalRefs>
     <filesAnalyzed>false</filesAnalyzed>
     <homepage>http://www.openjena.org/</homepage>

--- a/tests/spdx/data/SPDXYAMLExample-v2.3.spdx.yaml
+++ b/tests/spdx/data/SPDXYAMLExample-v2.3.spdx.yaml
@@ -232,7 +232,7 @@ packages:
   externalRefs:
   - referenceCategory: "PACKAGE-MANAGER"
     referenceLocator: "pkg:maven/org.apache.jena/apache-jena@3.12.0"
-    referenceType: "http://spdx.org/spdxdocs/spdx-example-444504E0-4F89-41D3-9A0C-0305E82C3301#purl"
+    referenceType: "purl"
   filesAnalyzed: false
   homepage: "http://www.openjena.org/"
   name: "Jena"


### PR DESCRIPTION
I noticed that these two example files are marked as invalid. The changed files align with the examples given in the spdx-spec repo. As far as I understand the spec we only add the documents namespace to `referenceType` in `RDF` format, not in any other. So I think the examples were simply incorrect and there is no need to adapt the code to accept these kind of `referenceType`.