### PR TITLE
Issue 615 fix rdf parser

### DIFF
--- a/src/spdx_tools/spdx/parser/rdf/creation_info_parser.py
+++ b/src/spdx_tools/spdx/parser/rdf/creation_info_parser.py
@@ -61,6 +61,8 @@ def parse_creation_info(graph: Graph) -> Tuple[CreationInfo, URIRef]:
         logger, graph, creation_info_node, SPDX_NAMESPACE.creator
     ):
         creators.append(ActorParser.parse_actor(creator_literal.toPython()))
+    if not creators:
+        logger.append("No creators provided.")
     external_document_refs = []
     for _, _, external_document_node in get_correctly_typed_triples(
         logger, graph, doc_node, SPDX_NAMESPACE.externalDocumentRef

--- a/src/spdx_tools/spdx/parser/rdf/rdf_parser.py
+++ b/src/spdx_tools/spdx/parser/rdf/rdf_parser.py
@@ -35,11 +35,7 @@ def parse_from_file(file_name: str) -> Document:
 def translate_graph_to_document(graph: Graph) -> Document:
     parsed_fields: Dict[str, Any] = dict()
     logger = Logger()
-    try:
-        creation_info, doc_node = parse_creation_info(graph)
-    except SPDXParsingError as err:
-        logger.extend(err.get_messages())
-        creation_info = None
+    creation_info, doc_node = parse_creation_info(graph)
 
     parsed_fields["creation_info"] = creation_info
 

--- a/tests/spdx/parser/rdf/data/invalid_documents/invalid_creation_info.rdf.xml
+++ b/tests/spdx/parser/rdf/data/invalid_documents/invalid_creation_info.rdf.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rdf:RDF
+    xmlns:spdx="http://spdx.org/rdf/terms#"
+    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+    xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+>
+    <spdx:SpdxDocument rdf:about="https://some.namespace#SPDXRef-DOCUMENT">
+        <rdfs:comment>documentComment</rdfs:comment>
+        <spdx:name>documentName</spdx:name>
+        <spdx:dataLicense rdf:resource="http://spdx.org/licenses/CC0-1.0"/>
+        <spdx:creationInfo>
+            <spdx:CreationInfo rdf:nodeID="N80af30c2c55b44afb3a7cf4124ed9aff">
+                <spdx:licenseListVersion>3.19</spdx:licenseListVersion>
+                <spdx:created></spdx:created>
+            </spdx:CreationInfo>
+        </spdx:creationInfo>
+    </spdx:SpdxDocument>
+</rdf:RDF>

--- a/tests/spdx/parser/rdf/data/invalid_documents/invalid_creation_info_with_snippet.rdf.xml
+++ b/tests/spdx/parser/rdf/data/invalid_documents/invalid_creation_info_with_snippet.rdf.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rdf:RDF
+    xmlns:spdx="http://spdx.org/rdf/terms#"
+    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+    xmlns:ptr="http://www.w3.org/2009/pointers#"
+    xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+>
+    <spdx:SpdxDocument rdf:about="https://some.namespace#SPDXRef-DOCUMENT">
+        <spdx:specVersion>SPDX-2.3</spdx:specVersion>
+        <spdx:hasExtractedLicensingInfo>
+            <spdx:ExtractedLicensingInfo rdf:about="https://some.namespace#LicenseRef-1">
+                <rdfs:seeAlso>https://see.also</rdfs:seeAlso>
+                <spdx:extractedText>extractedText</spdx:extractedText>
+                <spdx:licenseId>LicenseRef-1</spdx:licenseId>
+                <rdfs:comment>licenseComment</rdfs:comment>
+                <spdx:name>licenseName</spdx:name>
+            </spdx:ExtractedLicensingInfo>
+        </spdx:hasExtractedLicensingInfo>
+        <rdfs:comment>documentComment</rdfs:comment>
+        <spdx:name>documentName</spdx:name>
+        <spdx:dataLicense rdf:resource="http://spdx.org/licenses/CC0-1.0"/>
+        <spdx:creationInfo>
+            <spdx:CreationInfo rdf:nodeID="N80af30c2c55b44afb3a7cf4124ed9aff">
+                <rdfs:comment>creatorComment</rdfs:comment>
+                <spdx:licenseListVersion>3.19</spdx:licenseListVersion>
+                <spdx:created></spdx:created>
+            </spdx:CreationInfo>
+        </spdx:creationInfo>
+    </spdx:SpdxDocument>
+        <spdx:Snippet rdf:about="https://some.namespace#SPDXRef-Snippet">
+        <spdx:range>
+            <ptr:StartEndPointer rdf:nodeID="N079962c320a64e15bc1b4f2c01ea04b8">
+                <ptr:startPointer>
+                    <ptr:LineCharPointer rdf:nodeID="N42ab092d6b334333b1a457cf9387cbb8">
+                        <ptr:reference rdf:resource="https://some.namespace#SPDXRef-File"/>
+                        <ptr:lineNumber rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">3</ptr:lineNumber>
+                    </ptr:LineCharPointer>
+                </ptr:startPointer>
+                <ptr:endPointer>
+                    <ptr:LineCharPointer rdf:nodeID="Nbb9c38211e154a9b92f2489289580125">
+                        <ptr:reference rdf:resource="https://some.namespace#SPDXRef-File"/>
+                        <ptr:lineNumber rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">4</ptr:lineNumber>
+                    </ptr:LineCharPointer>
+                </ptr:endPointer>
+            </ptr:StartEndPointer>
+        </spdx:range>
+        <spdx:range>
+            <ptr:StartEndPointer rdf:nodeID="N77e7b08564a0412a9413b90ff9b3ddd9">
+                <ptr:startPointer>
+                    <ptr:ByteOffsetPointer rdf:nodeID="N89d93c1292de424f9aa75ee1e297ede9">
+                        <ptr:offset rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</ptr:offset>
+                        <ptr:reference rdf:resource="https://some.namespace#SPDXRef-File"/>
+                    </ptr:ByteOffsetPointer>
+                </ptr:startPointer>
+                <ptr:endPointer>
+                    <ptr:ByteOffsetPointer rdf:nodeID="N7099800c04534fcc8a998b551fee34ce">
+                        <ptr:reference rdf:resource="https://some.namespace#SPDXRef-File"/>
+                        <ptr:offset rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">2</ptr:offset>
+                    </ptr:ByteOffsetPointer>
+                </ptr:endPointer>
+            </ptr:StartEndPointer>
+        </spdx:range>
+        <spdx:snippetFromFile rdf:resource="https://some.namespace#SPDXRef-File"/>
+        <spdx:licenseInfoInSnippet rdf:resource="http://spdx.org/licenses/MIT"/>
+        <spdx:licenseInfoInSnippet rdf:resource="http://spdx.org/licenses/GPL-2.0-only"/>
+        <spdx:licenseInfoInSnippet rdf:resource="http://spdx.org/rdf/terms#noassertion"/>
+        <spdx:attributionText>snippetAttributionText</spdx:attributionText>
+        <spdx:name>snippetName</spdx:name>
+        <spdx:licenseComments>snippetLicenseComment</spdx:licenseComments>
+        <rdfs:comment>snippetComment</rdfs:comment>
+        <spdx:copyrightText>licenseCopyrightText</spdx:copyrightText>
+        <spdx:licenseConcluded>
+            <spdx:ConjunctiveLicenseSet rdf:nodeID="Ndf36ad77a5c244e5af7928009800aed7">
+                <spdx:member rdf:resource="http://spdx.org/licenses/MIT"/>
+                <spdx:member rdf:resource="http://spdx.org/licenses/GPL-2.0-only"/>
+            </spdx:ConjunctiveLicenseSet>
+        </spdx:licenseConcluded>
+    </spdx:Snippet>
+</rdf:RDF>

--- a/tests/spdx/parser/rdf/test_creation_info_parser.py
+++ b/tests/spdx/parser/rdf/test_creation_info_parser.py
@@ -11,11 +11,13 @@ from rdflib.term import Node
 
 from spdx_tools.spdx.constants import DOCUMENT_SPDX_ID
 from spdx_tools.spdx.model import Actor, ActorType, Checksum, ChecksumAlgorithm, Version
+from spdx_tools.spdx.parser.error import SPDXParsingError
 from spdx_tools.spdx.parser.rdf.creation_info_parser import (
     parse_creation_info,
     parse_external_document_refs,
     parse_namespace_and_spdx_id,
 )
+from spdx_tools.spdx.parser.rdf.rdf_parser import parse_from_file
 from spdx_tools.spdx.rdfschema.namespace import SPDX_NAMESPACE
 
 
@@ -90,3 +92,20 @@ def test_parse_external_document_refs():
         ChecksumAlgorithm.SHA1, "71c4025dd9897b364f3ebbb42c484ff43d00791c"
     )
     assert external_document_ref.document_uri == "https://namespace.com"
+
+
+@pytest.mark.parametrize(
+    "file, error_message",
+    [
+        (
+            "invalid_creation_info.rdf.xml",
+            "Error while parsing CreationInfo: ['No creators provided.']",
+        ),
+        ("invalid_creation_info_with_snippet.rdf.xml", "Error while parsing CreationInfo: ['No creators provided.']"),
+    ],
+)
+def test_parse_invalid_creation_info(file, error_message):
+    with pytest.raises(SPDXParsingError) as err:
+        parse_from_file(os.path.join(os.path.dirname(__file__), f"data/invalid_documents/{file}"))
+
+    assert err.value.get_messages() == [error_message]


### PR DESCRIPTION
This PR fixes two things:
- If there is any error while parsing the creation info  the parsing process will be canceled as the following code tries to access `creation_info.doc_namespace`. This lead to an uncaught `AttributeError`. 
- If there are no creators in the given input file an `SPDXParsingError` will be raised as this is not valid.

I added two negative tests for these cases. They seem to be pretty similar but they test different things. I added the `invalid_creation_info_with_snippet` to verify that there is no uncaught error whereas the other test simply tests that a file without creators will raise an `SPDXParsingError`. 

fixes #615  