### PR TITLE
Make pytest not skip 'test_build' folders

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,3 +62,6 @@ include = "(^/src/.*.py|^/tests/.*.py)"
 profile = "black"
 line_length = 119
 skip = ["__init__.py"]
+
+[tool.pytest.ini_options]
+norecursedirs = []  # overwrite the default to not skip tests/build folder which is needed in spdx3


### PR DESCRIPTION
Per default, pytest skips over folder containing "build". This overwrites that default.