### PR TITLE
[issue_602] update relationship bump

### DIFF
--- a/src/spdx_tools/spdx3/bump_from_spdx2/relationship.py
+++ b/src/spdx_tools/spdx3/bump_from_spdx2/relationship.py
@@ -1,45 +1,221 @@
 # SPDX-FileCopyrightText: 2023 spdx contributors
 #
 # SPDX-License-Identifier: Apache-2.0
-from typing import Optional, Tuple
+from typing import Dict, List, Optional, Tuple, Union
 
-from spdx_tools.spdx3.model import CreationInformation, Relationship, RelationshipCompleteness, RelationshipType
+from spdx_tools.spdx3.bump_from_spdx2.message import print_missing_conversion
+from spdx_tools.spdx3.model import (
+    CreationInformation,
+    LifecycleScopeType,
+    Relationship,
+    RelationshipCompleteness,
+    RelationshipType,
+)
+from spdx_tools.spdx3.model.software import (
+    DependencyConditionalityType,
+    SoftwareDependencyLinkType,
+    SoftwareDependencyRelationship,
+)
 from spdx_tools.spdx3.payload import Payload
 from spdx_tools.spdx.model.relationship import Relationship as Spdx2_Relationship
 from spdx_tools.spdx.model.relationship import RelationshipType as Spdx2_RelationshipType
 from spdx_tools.spdx.model.spdx_no_assertion import SpdxNoAssertion
 from spdx_tools.spdx.model.spdx_none import SpdxNone
 
+# bump relationship type, map each relationship type to the corresponding class in 3.0,
+# the relationship type, other arguments and if swapped
+relationship_mapping: Dict[
+    Spdx2_RelationshipType,
+    Tuple[
+        bool,
+        RelationshipType,
+        Union[bool, LifecycleScopeType, None],
+        Optional[SoftwareDependencyLinkType],
+        Optional[DependencyConditionalityType],
+    ],
+] = {
+    Spdx2_RelationshipType.AMENDS: (True, RelationshipType.AMENDS),
+    Spdx2_RelationshipType.ANCESTOR_OF: (True, RelationshipType.ANCESTOR),
+    Spdx2_RelationshipType.BUILD_DEPENDENCY_OF: (
+        False,
+        RelationshipType.DEPENDS_ON,
+        LifecycleScopeType.BUILD,
+        SoftwareDependencyLinkType.TOOL,
+        None,
+    ),
+    Spdx2_RelationshipType.BUILD_TOOL_OF: (
+        False,
+        RelationshipType.DEPENDS_ON,
+        LifecycleScopeType.BUILD,
+        SoftwareDependencyLinkType.TOOL,
+        None,
+    ),
+    Spdx2_RelationshipType.CONTAINED_BY: (True, RelationshipType.CONTAINS, True),
+    Spdx2_RelationshipType.CONTAINS: (
+        True,
+        RelationshipType.CONTAINS,
+    ),  # might be deleted in favor of depends on
+    Spdx2_RelationshipType.COPY_OF: (True, RelationshipType.COPY),
+    Spdx2_RelationshipType.DATA_FILE_OF: None,  # not defined, probably input/ output
+    Spdx2_RelationshipType.DEPENDENCY_MANIFEST_OF: (
+        False,
+        RelationshipType.DEPENDS_ON,
+        None,
+        None,
+        None,
+    ),  # "expect purpose has been set to manifest"
+    Spdx2_RelationshipType.DEPENDENCY_OF: (False, RelationshipType.DEPENDS_ON, True),
+    Spdx2_RelationshipType.DEPENDS_ON: (
+        False,
+        RelationshipType.DEPENDS_ON,
+    ),
+    Spdx2_RelationshipType.DESCENDANT_OF: (True, RelationshipType.ANCESTOR, True),
+    Spdx2_RelationshipType.DESCRIBED_BY: (True, RelationshipType.DESCRIBES, True),
+    Spdx2_RelationshipType.DESCRIBES: (True, RelationshipType.DESCRIBES),  # might be deleted in favor of root
+    # property
+    Spdx2_RelationshipType.DEV_DEPENDENCY_OF: (
+        False,
+        RelationshipType.DEPENDS_ON,
+        LifecycleScopeType.DEVELOPMENT,
+        None,
+        None,
+    ),
+    Spdx2_RelationshipType.DEV_TOOL_OF: (
+        False,
+        RelationshipType.DEPENDS_ON,
+        LifecycleScopeType.DEVELOPMENT,
+        SoftwareDependencyLinkType.TOOL,
+        None,
+    ),
+    Spdx2_RelationshipType.DISTRIBUTION_ARTIFACT: None,  # not defined yet, purpose?
+    Spdx2_RelationshipType.DOCUMENTATION_OF: (True, RelationshipType.DOCUMENTATION),
+    Spdx2_RelationshipType.DYNAMIC_LINK: (
+        False,
+        RelationshipType.DEPENDS_ON,
+        None,
+        SoftwareDependencyLinkType.DYNAMIC,
+        None,
+    ),
+    Spdx2_RelationshipType.EXAMPLE_OF: (True, RelationshipType.EXAMPLE),
+    Spdx2_RelationshipType.EXPANDED_FROM_ARCHIVE: (True, RelationshipType.EXPANDED_FROM_ARCHIVE),
+    Spdx2_RelationshipType.FILE_ADDED: (True, RelationshipType.FILE_ADDED),
+    Spdx2_RelationshipType.FILE_DELETED: (True, RelationshipType.FILE_DELETED),
+    Spdx2_RelationshipType.FILE_MODIFIED: (True, RelationshipType.FILE_MODIFIED),
+    Spdx2_RelationshipType.GENERATED_FROM: (True, RelationshipType.GENERATES, True),
+    Spdx2_RelationshipType.GENERATES: (True, RelationshipType.GENERATES),
+    Spdx2_RelationshipType.HAS_PREREQUISITE: (
+        False,
+        RelationshipType.DEPENDS_ON,
+        None,
+        None,
+        DependencyConditionalityType.PREREQUISITE,
+    ),
+    Spdx2_RelationshipType.METAFILE_OF: (True, RelationshipType.METAFILE),
+    Spdx2_RelationshipType.OPTIONAL_COMPONENT_OF: None,  # converted to depends on and purpose? not clear
+    Spdx2_RelationshipType.OPTIONAL_DEPENDENCY_OF: (
+        False,
+        RelationshipType.DEPENDS_ON,
+        None,
+        None,
+        DependencyConditionalityType.OPTIONAL,
+    ),
+    Spdx2_RelationshipType.OTHER: (True, RelationshipType.OTHER),
+    Spdx2_RelationshipType.PACKAGE_OF: (False, RelationshipType.DEPENDS_ON),
+    Spdx2_RelationshipType.PATCH_APPLIED: (True, RelationshipType.PATCH, True),
+    Spdx2_RelationshipType.PATCH_FOR: (True, RelationshipType.PATCH),
+    Spdx2_RelationshipType.PREREQUISITE_FOR: (
+        False,
+        RelationshipType.DEPENDS_ON,
+        None,
+        None,
+        DependencyConditionalityType.PREREQUISITE,
+    ),
+    Spdx2_RelationshipType.PROVIDED_DEPENDENCY_OF: (
+        False,
+        RelationshipType.DEPENDS_ON,
+        LifecycleScopeType.BUILD,
+        None,
+        DependencyConditionalityType.PROVIDED,
+    ),
+    Spdx2_RelationshipType.RUNTIME_DEPENDENCY_OF: (
+        False,
+        RelationshipType.DEPENDS_ON,
+        LifecycleScopeType.RUNTIME,
+        None,
+        None,
+    ),
+    Spdx2_RelationshipType.STATIC_LINK: (
+        False,
+        RelationshipType.DEPENDS_ON,
+        None,
+        SoftwareDependencyLinkType.STATIC,
+        None,
+    ),
+    Spdx2_RelationshipType.TEST_CASE_OF: (True, RelationshipType.TEST_CASE),
+    Spdx2_RelationshipType.TEST_DEPENDENCY_OF: (
+        False,
+        RelationshipType.DEPENDS_ON,
+        LifecycleScopeType.TEST,
+        None,
+        None,
+    ),
+    Spdx2_RelationshipType.TEST_OF: (True, RelationshipType.TEST),
+    Spdx2_RelationshipType.TEST_TOOL_OF: (
+        False,
+        RelationshipType.DEPENDS_ON,
+        LifecycleScopeType.TEST,
+        SoftwareDependencyLinkType.TOOL,
+        None,
+    ),
+    Spdx2_RelationshipType.VARIANT_OF: (True, RelationshipType.VARIANT),
+    Spdx2_RelationshipType.REQUIREMENT_DESCRIPTION_FOR: (True, RelationshipType.REQUIREMENT_FOR),
+    Spdx2_RelationshipType.SPECIFICATION_FOR: (True, RelationshipType.SPECIFICATION_FOR),
+}
 
-def bump_relationship(
-    spdx2_relationship: Spdx2_Relationship,
+
+def bump_relationships(
+    spdx2_relationships: List[Spdx2_Relationship],
     payload: Payload,
     creation_information: CreationInformation,
     document_namespace: str,
-    counter: int,
 ):
-    relationship_type, swap_direction = bump_relationship_type(spdx2_relationship.relationship_type)
+    generated_relationships: Dict[Tuple[str, str], List[Relationship]] = {}
+    for counter, spdx2_relationship in enumerate(spdx2_relationships):
+        relationship = bump_relationship(spdx2_relationship, creation_information, document_namespace, counter)
+        if relationship:
+            generated_relationships.setdefault(
+                (relationship.from_element, relationship.relationship_type.name), []
+            ).append(relationship)
 
+    for key, relationships in generated_relationships.items():
+        if len(relationships) > 1:
+            merge_relationships_and_add_to_payload(payload, relationships)
+        else:
+            payload.add_element(relationships[0])
+
+
+def bump_relationship(
+    spdx2_relationship: Spdx2_Relationship,
+    creation_information: CreationInformation,
+    document_namespace: str,
+    counter: int,
+) -> Optional[Union[Relationship, SoftwareDependencyRelationship]]:
+    swap_direction = False
+    completeness, to = determine_completeness(spdx2_relationship.related_spdx_element_id)
     spdx_id = "#".join([document_namespace, f"SPDXRef-Relationship-{counter}"])
-
-    if isinstance(
-        spdx2_relationship.related_spdx_element_id, SpdxNoAssertion
-    ):  # how to translate none/ no assertion to element?
-        completeness = RelationshipCompleteness.UNKNOWN
-    elif isinstance(spdx2_relationship.related_spdx_element_id, SpdxNone):
-        completeness = RelationshipCompleteness.KNOWN
-    else:
-        completeness = None
-
-    if swap_direction:
-        from_element = spdx2_relationship.related_spdx_element_id
-        to = [spdx2_relationship.spdx_element_id]
-    else:
+    parameters_for_bump = relationship_mapping[spdx2_relationship.relationship_type]
+    if parameters_for_bump is None:
+        print_missing_conversion(spdx2_relationship.relationship_type.name, 0)
+        return
+    base_relationship = parameters_for_bump[0]
+    relationship_type = parameters_for_bump[1]
+    if not base_relationship:
+        scope = parameters_for_bump[2]
+        software_linkage = parameters_for_bump[3]
+        conditionality = parameters_for_bump[4]
         from_element = spdx2_relationship.spdx_element_id
-        to = [spdx2_relationship.related_spdx_element_id]
 
-    payload.add_element(
-        Relationship(
+        return SoftwareDependencyRelationship(
             spdx_id,
             creation_information,
             from_element,
@@ -47,28 +223,55 @@ def bump_relationship(
             relationship_type,
             comment=spdx2_relationship.comment,
             completeness=completeness,
+            scope=scope,
+            software_linkage=software_linkage,
+            conditionality=conditionality,
         )
+
+    if base_relationship and (len(parameters_for_bump) == 3):
+        swap_direction = parameters_for_bump[2]
+    if swap_direction:
+        if not to:
+            print_missing_conversion("Swapped Relationship to NoAssertion/ None", 0)
+            return
+        from_element = to[0]
+        to = [spdx2_relationship.spdx_element_id]
+    else:
+        from_element = spdx2_relationship.spdx_element_id
+
+    return Relationship(
+        spdx_id,
+        creation_information,
+        from_element,
+        to,
+        relationship_type,
+        comment=spdx2_relationship.comment,
+        completeness=completeness,
     )
 
 
-def bump_relationship_type(spdx2_relationship_type: Spdx2_RelationshipType) -> Optional[Tuple[RelationshipType, bool]]:
-    if spdx2_relationship_type == Spdx2_RelationshipType.DESCRIBED_BY:
-        return RelationshipType.DESCRIBES, True
-    if spdx2_relationship_type == Spdx2_RelationshipType.CONTAINED_BY:
-        return RelationshipType.CONTAINS, True
-    if spdx2_relationship_type == Spdx2_RelationshipType.DEPENDENCY_OF:
-        return RelationshipType.DEPENDS_ON, True
-    if spdx2_relationship_type == Spdx2_RelationshipType.GENERATED_FROM:
-        return RelationshipType.GENERATES, True
-    if spdx2_relationship_type == Spdx2_RelationshipType.HAS_PREREQUISITE:
-        return RelationshipType.PREREQUISITE, True
-    if spdx2_relationship_type.name.endswith("_OF"):
-        relationship_type = spdx2_relationship_type.name.replace("_OF", "")
-        return RelationshipType[relationship_type], False
-    if spdx2_relationship_type.name.endswith("_FOR"):
-        relationship_type = spdx2_relationship_type.name.replace("_FOR", "")
-        return RelationshipType[relationship_type], False
-    return RelationshipType[spdx2_relationship_type.name], False
-    # if spdx2_relationship_type == Spdx2_RelationshipType.PATCH_APPLIED:
-    #     print_missing_conversion("RelationshipType.PATCH_APPLIED", 0)
-    #     return None
+def determine_completeness(
+    related_spdx_element_id: Union[str, SpdxNone, SpdxNoAssertion]
+) -> Tuple[Optional[RelationshipCompleteness], List[str]]:
+    if isinstance(related_spdx_element_id, SpdxNoAssertion):
+        completeness = RelationshipCompleteness.NOASSERTION
+        to = []
+    elif isinstance(related_spdx_element_id, SpdxNone):
+        completeness = RelationshipCompleteness.COMPLETE
+        to = []
+    else:
+        completeness = None
+        to = [related_spdx_element_id]
+    return completeness, to
+
+
+def merge_relationships_and_add_to_payload(payload: Payload, relationships: List[Relationship]):
+    merged_relationship = relationships[0]
+    for relationship in relationships[1:]:
+        merged_relationship.to += relationship.to
+        if merged_relationship.comment and relationship.comment:
+            merged_relationship.comment += ", " + relationship.comment
+        if not merged_relationship.comment and relationship.comment:
+            merged_relationship.comment = relationship.comment
+
+    payload.add_element(merged_relationship)

--- a/src/spdx_tools/spdx3/bump_from_spdx2/spdx_document.py
+++ b/src/spdx_tools/spdx3/bump_from_spdx2/spdx_document.py
@@ -5,7 +5,7 @@ from spdx_tools.spdx3.bump_from_spdx2.annotation import bump_annotation
 from spdx_tools.spdx3.bump_from_spdx2.creation_information import bump_creation_information
 from spdx_tools.spdx3.bump_from_spdx2.file import bump_file
 from spdx_tools.spdx3.bump_from_spdx2.package import bump_package
-from spdx_tools.spdx3.bump_from_spdx2.relationship import bump_relationship
+from spdx_tools.spdx3.bump_from_spdx2.relationship import bump_relationships
 from spdx_tools.spdx3.bump_from_spdx2.snippet import bump_snippet
 from spdx_tools.spdx3.model import CreationInformation, SpdxDocument
 from spdx_tools.spdx3.payload import Payload
@@ -33,8 +33,7 @@ def bump_spdx_document(document: Spdx2_Document) -> Payload:
     for spdx2_snippet in document.snippets:
         bump_snippet(spdx2_snippet, payload, creation_info, document_namespace)
 
-    for counter, spdx2_relationship in enumerate(document.relationships):
-        bump_relationship(spdx2_relationship, payload, creation_info, document_namespace, counter)
+    bump_relationships(document.relationships, payload, creation_info, document_namespace)
 
     for counter, spdx2_annotation in enumerate(document.annotations):
         bump_annotation(spdx2_annotation, payload, creation_info, document_namespace, counter)

--- a/src/spdx_tools/spdx3/writer/console/payload_writer.py
+++ b/src/spdx_tools/spdx3/writer/console/payload_writer.py
@@ -31,13 +31,16 @@ from spdx_tools.spdx3.writer.console.software.file_writer import write_file
 from spdx_tools.spdx3.writer.console.software.package_writer import write_package
 from spdx_tools.spdx3.writer.console.software.sbom_writer import write_sbom
 from spdx_tools.spdx3.writer.console.software.snippet_writer import write_snippet
+from spdx_tools.spdx3.writer.console.software.software_dependency_relationship_writer import (
+    write_software_dependency_relationship,
+)
 from spdx_tools.spdx3.writer.console.spdx_document_writer import write_spdx_document
 from spdx_tools.spdx3.writer.console.tool_writer import write_tool
 
 MAP_CLASS_TO_WRITE_METHOD = {
     Annotation: write_annotation,
     Relationship: write_relationship,
-    SoftwareDependencyRelationship: write_relationship, # needs to be adapted as soon as base PR is changed
+    SoftwareDependencyRelationship: write_software_dependency_relationship,
     Bundle: write_bundle,
     SpdxDocument: write_spdx_document,
     Bom: write_bom,

--- a/src/spdx_tools/spdx3/writer/console/payload_writer.py
+++ b/src/spdx_tools/spdx3/writer/console/payload_writer.py
@@ -17,7 +17,7 @@ from spdx_tools.spdx3.model import (
 from spdx_tools.spdx3.model.ai import AIPackage
 from spdx_tools.spdx3.model.build import Build
 from spdx_tools.spdx3.model.dataset import Dataset
-from spdx_tools.spdx3.model.software import File, Package, Sbom, Snippet
+from spdx_tools.spdx3.model.software import File, Package, Sbom, Snippet, SoftwareDependencyRelationship
 from spdx_tools.spdx3.payload import Payload
 from spdx_tools.spdx3.writer.console.agent_writer import write_agent
 from spdx_tools.spdx3.writer.console.ai.ai_package_writer import write_ai_package
@@ -37,6 +37,7 @@ from spdx_tools.spdx3.writer.console.tool_writer import write_tool
 MAP_CLASS_TO_WRITE_METHOD = {
     Annotation: write_annotation,
     Relationship: write_relationship,
+    SoftwareDependencyRelationship: write_relationship, # needs to be adapted as soon as base PR is changed
     Bundle: write_bundle,
     SpdxDocument: write_spdx_document,
     Bom: write_bom,

--- a/tests/spdx3/bump/test_relationship_bump.py
+++ b/tests/spdx3/bump/test_relationship_bump.py
@@ -1,0 +1,97 @@
+# SPDX-FileCopyrightText: 2023 spdx contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+from unittest import mock
+
+from spdx_tools.spdx3.bump_from_spdx2.relationship import bump_relationship, bump_relationships
+from spdx_tools.spdx3.model import Relationship, RelationshipCompleteness, RelationshipType
+from spdx_tools.spdx3.payload import Payload
+from spdx_tools.spdx.model import RelationshipType as Spdx2_RelationshipType
+from spdx_tools.spdx.model import SpdxNoAssertion, SpdxNone
+from tests.spdx.fixtures import relationship_fixture
+
+
+@mock.patch("spdx_tools.spdx3.model.CreationInformation", autospec=True)
+def test_relationship_bump(creation_info):
+    spdx2_relationship = relationship_fixture()
+    document_namespace = "https://doc.namespace"
+    relationship = bump_relationship(spdx2_relationship, creation_info, document_namespace, 1)
+
+    assert relationship == Relationship(
+        f"{document_namespace}#SPDXRef-Relationship-1",
+        creation_info,
+        spdx2_relationship.spdx_element_id,
+        [spdx2_relationship.related_spdx_element_id],
+        RelationshipType.DESCRIBES,
+        comment=spdx2_relationship.comment,
+    )
+
+
+@mock.patch("spdx_tools.spdx3.model.CreationInformation", autospec=True)
+def test_relationships_bump(creation_info):
+    relationships = [relationship_fixture(), relationship_fixture(related_spdx_element_id="SPDXRef-Package")]
+    payload = Payload()
+    document_namespace = "https://doc.namespace"
+    bump_relationships(relationships, payload, creation_info, document_namespace)
+
+    assert payload.get_element(f"{document_namespace}#SPDXRef-Relationship-0") == Relationship(
+        f"{document_namespace}#SPDXRef-Relationship-0",
+        creation_info,
+        relationships[0].spdx_element_id,
+        [relationships[0].related_spdx_element_id, relationships[1].related_spdx_element_id],
+        RelationshipType.DESCRIBES,
+        comment=relationships[0].comment + ", " + relationships[1].comment,
+    )
+
+
+@mock.patch("spdx_tools.spdx3.model.CreationInformation", autospec=True)
+def test_relationships_bump_with_setting_completeness(creation_info):
+    relationships = [
+        relationship_fixture(related_spdx_element_id=SpdxNoAssertion()),
+        relationship_fixture(related_spdx_element_id="SPDXRef-Package"),
+        relationship_fixture(
+            relationship_type=Spdx2_RelationshipType.SPECIFICATION_FOR,
+            related_spdx_element_id=SpdxNone(),
+            comment=None,
+        ),
+    ]
+    payload = Payload()
+    document_namespace = "https://doc.namespace"
+    bump_relationships(relationships, payload, creation_info, document_namespace)
+
+    assert payload.get_element(f"{document_namespace}#SPDXRef-Relationship-0") == Relationship(
+        f"{document_namespace}#SPDXRef-Relationship-0",
+        creation_info,
+        relationships[0].spdx_element_id,
+        [relationships[1].related_spdx_element_id],
+        RelationshipType.DESCRIBES,
+        comment=relationships[0].comment + ", " + relationships[1].comment,
+        completeness=RelationshipCompleteness.NOASSERTION,
+    )
+    assert payload.get_element(f"{document_namespace}#SPDXRef-Relationship-2") == Relationship(
+        f"{document_namespace}#SPDXRef-Relationship-2",
+        creation_info,
+        relationships[2].spdx_element_id,
+        [],
+        RelationshipType.SPECIFICATION_FOR,
+        completeness=RelationshipCompleteness.COMPLETE,
+    )
+
+
+@mock.patch("spdx_tools.spdx3.model.CreationInformation", autospec=True)
+def test_undefined_relationship_bump(creation_info, capsys):
+    relationships = [
+        relationship_fixture(
+            related_spdx_element_id=SpdxNoAssertion(), relationship_type=Spdx2_RelationshipType.CONTAINED_BY
+        ),
+        relationship_fixture(relationship_type=Spdx2_RelationshipType.OPTIONAL_COMPONENT_OF),
+    ]
+    payload = Payload()
+    document_namespace = "https://doc.namespace"
+    bump_relationships(relationships, payload, creation_info, document_namespace)
+
+    captured = capsys.readouterr()
+    assert (
+        captured.err == "Swapped Relationship to NoAssertion/ None not converted: missing conversion rule \n"
+        "OPTIONAL_COMPONENT_OF not converted: missing conversion rule \n"
+    )

--- a/tests/spdx3/bump/test_relationship_bump.py
+++ b/tests/spdx3/bump/test_relationship_bump.py
@@ -29,18 +29,20 @@ def test_relationship_bump(creation_info):
 
 @mock.patch("spdx_tools.spdx3.model.CreationInformation", autospec=True)
 def test_relationships_bump(creation_info):
-    relationships = [relationship_fixture(), relationship_fixture(related_spdx_element_id="SPDXRef-Package")]
+    relationships = [
+        relationship_fixture(comment=None),
+        relationship_fixture(related_spdx_element_id="SPDXRef-Package", comment=None),
+    ]
     payload = Payload()
     document_namespace = "https://doc.namespace"
     bump_relationships(relationships, payload, creation_info, document_namespace)
 
-    assert payload.get_element(f"{document_namespace}#SPDXRef-Relationship-0") == Relationship(
-        f"{document_namespace}#SPDXRef-Relationship-0",
+    assert payload.get_element(f"{document_namespace}#SPDXRef-Relationship-1") == Relationship(
+        f"{document_namespace}#SPDXRef-Relationship-1",
         creation_info,
         relationships[0].spdx_element_id,
         [relationships[0].related_spdx_element_id, relationships[1].related_spdx_element_id],
         RelationshipType.DESCRIBES,
-        comment=relationships[0].comment + ", " + relationships[1].comment,
     )
 
 
@@ -63,10 +65,18 @@ def test_relationships_bump_with_setting_completeness(creation_info):
         f"{document_namespace}#SPDXRef-Relationship-0",
         creation_info,
         relationships[0].spdx_element_id,
+        [],
+        RelationshipType.DESCRIBES,
+        comment=relationships[0].comment,
+        completeness=RelationshipCompleteness.NOASSERTION,
+    )
+    assert payload.get_element(f"{document_namespace}#SPDXRef-Relationship-1") == Relationship(
+        f"{document_namespace}#SPDXRef-Relationship-1",
+        creation_info,
+        relationships[1].spdx_element_id,
         [relationships[1].related_spdx_element_id],
         RelationshipType.DESCRIBES,
-        comment=relationships[0].comment + ", " + relationships[1].comment,
-        completeness=RelationshipCompleteness.NOASSERTION,
+        comment=relationships[1].comment,
     )
     assert payload.get_element(f"{document_namespace}#SPDXRef-Relationship-2") == Relationship(
         f"{document_namespace}#SPDXRef-Relationship-2",
@@ -92,6 +102,6 @@ def test_undefined_relationship_bump(creation_info, capsys):
 
     captured = capsys.readouterr()
     assert (
-        captured.err == "Swapped Relationship to NoAssertion/ None not converted: missing conversion rule \n"
+        captured.err == "Swapped Relationship to NoAssertion/None not converted: missing conversion rule \n"
         "OPTIONAL_COMPONENT_OF not converted: missing conversion rule \n"
     )


### PR DESCRIPTION
This PR is based on #609.  

I assumed that relationships with the same "from spdx_id"  and relationship_type should be merged. Sone conversions are not yet defined or the RelatoinshipType doesn't exist yet in the spdx-3-model and the prototype, I decided to print an info about missing conversions here and added a comment at the corresponding relationshiptypes. 

fixes #602