### PR TITLE
fix wrapper methods for parsing the rdf graph

### DIFF
--- a/src/spdx_tools/spdx/parser/rdf/graph_parsing_functions.py
+++ b/src/spdx_tools/spdx/parser/rdf/graph_parsing_functions.py
@@ -140,7 +140,7 @@ def get_value_from_graph(
     # this is a helper method to cast some rdf types from graph.value() to be compatible with the
     # code that follows
     value = graph.value(subject=subject, predicate=predicate, object=_object, default=default, any=_any)
-    if value and not isinstance(value, (URIRef, Literal, BNode)):
+    if value != default and value is not None and not isinstance(value, (URIRef, Literal, BNode)):
         logger.append(
             f"Warning: Node {value} should be of type BNode, Literal or URIRef, but is {type(value).__name__}. "
             f"This might lead to a failure."

--- a/src/spdx_tools/spdx/parser/rdf/package_parser.py
+++ b/src/spdx_tools/spdx/parser/rdf/package_parser.py
@@ -108,7 +108,9 @@ def parse_package(package_node: URIRef, graph: Graph, doc_namespace: str) -> Pac
     )
     homepage = parse_literal(logger, graph, package_node, DOAP.homepage)
     attribution_texts = []
-    for _, _, attribution_text_literal in graph.triples((package_node, SPDX_NAMESPACE.attributionText, None)):
+    for _, _, attribution_text_literal in get_correctly_typed_triples(
+        logger, graph, package_node, SPDX_NAMESPACE.attributionText, None
+    ):
         attribution_texts.append(attribution_text_literal.toPython())
 
     release_date = parse_literal(


### PR DESCRIPTION
This PR fixes two minor issues concerning the wrapper methods introduced in #563.
- If the default value is used in `get_value_from_graph` the value doesn't need to be a `URIRef, BNode` or `Literal`, so we shouldn't log an error.
- When parsing the `attribution_texts` in a package we should use the wrapper methods to prevent a warning concerning type mismatches. 