### PR TITLE
Update typeguard

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 ]
 urls = { Homepage = "https://github.com/spdx/tools-python" }
 requires-python = ">=3.7"
-dependencies = ["click", "pyyaml", "xmltodict", "rdflib", "typeguard==2.13.3", "uritools", "license_expression", "ply"]
+dependencies = ["click", "pyyaml", "xmltodict", "rdflib", "typeguard==4.0.0", "uritools", "license_expression", "ply"]
 dynamic = ["version"]
 
 [project.optional-dependencies]

--- a/src/spdx_tools/common/typing/dataclass_with_properties.py
+++ b/src/spdx_tools/common/typing/dataclass_with_properties.py
@@ -1,6 +1,8 @@
 from dataclasses import dataclass
 
-from typeguard import typechecked
+from typeguard import CollectionCheckStrategy, TypeCheckError, config, typechecked
+
+config.collection_check_strategy = CollectionCheckStrategy.ALL_ITEMS
 
 
 def dataclass_with_properties(cls):
@@ -26,11 +28,11 @@ def make_setter(field_name, field_type):
     def set_field_with_better_error_message(self, value: field_type):
         try:
             set_field(self, value)
-        except TypeError as err:
-            error_message: str = f"SetterError {self.__class__.__name__}: {err.args[0]}"
+        except TypeCheckError as err:
+            error_message: str = f"SetterError {self.__class__.__name__}: {err}"
             # As setters are created dynamically, their argument name is always "value". We replace it by the
             # actual name so the error message is more helpful.
-            raise TypeError(error_message.replace("value", field_name, 1) + f": {value}")
+            raise TypeError(error_message.replace("value", field_name, 1))
 
     return set_field_with_better_error_message
 
@@ -45,8 +47,8 @@ def make_getter(field_name, field_type):
     def get_field_with_better_error_message(self) -> field_type:
         try:
             return get_field(self)
-        except TypeError as err:
-            error_message: str = f"GetterError {self.__class__.__name__}: {err.args[0]}"
+        except TypeCheckError as err:
+            error_message: str = f"GetterError {self.__class__.__name__}: {err}"
             # As getters are created dynamically, their argument name is always "the return value".
             # We replace it by the actual name so the error message is more helpful.
             raise TypeError(

--- a/tests/spdx/parser/jsonlikedict/test_annotation_parser.py
+++ b/tests/spdx/parser/jsonlikedict/test_annotation_parser.py
@@ -119,40 +119,14 @@ def test_parse_all_annotations():
 
 
 @pytest.mark.parametrize(
-    "incomplete_annotation_dict,expected_message",
+    "incomplete_annotation_dict",
     [
-        (
-            {"annotator": "Person: Jane Doe ()"},
-            [
-                "Error while constructing Annotation: ['SetterError Annotation: type of "
-                'argument "spdx_id" must be str; got NoneType instead: None\', '
-                '\'SetterError Annotation: type of argument "annotation_type" must be '
-                "spdx_tools.spdx.model.annotation.AnnotationType; got NoneType instead: None', "
-                '\'SetterError Annotation: type of argument "annotation_date" must be '
-                "datetime.datetime; got NoneType instead: None', 'SetterError Annotation: "
-                'type of argument "annotation_comment" must be str; got NoneType instead: '
-                "None']"
-            ],
-        ),
-        (
-            {"annotationDate": "2010-01-29T18:30:22Z"},
-            [
-                "Error while constructing Annotation: ['SetterError Annotation: type of "
-                'argument "spdx_id" must be str; got NoneType instead: None\', '
-                '\'SetterError Annotation: type of argument "annotation_type" must be '
-                "spdx_tools.spdx.model.annotation.AnnotationType; got NoneType instead: None', "
-                '\'SetterError Annotation: type of argument "annotator" must be '
-                "spdx_tools.spdx.model.actor.Actor; got NoneType instead: None', 'SetterError Annotation: "
-                'type of argument "annotation_comment" must be str; got NoneType instead: '
-                "None']"
-            ],
-        ),
+        {"annotator": "Person: Jane Doe ()"},
+        {"annotationDate": "2010-01-29T18:30:22Z"},
     ],
 )
-def test_parse_incomplete_annotation(incomplete_annotation_dict, expected_message):
+def test_parse_incomplete_annotation(incomplete_annotation_dict):
     annotation_parser = AnnotationParser()
 
-    with pytest.raises(SPDXParsingError) as err:
+    with pytest.raises(SPDXParsingError):
         annotation_parser.parse_annotation(incomplete_annotation_dict)
-
-    TestCase().assertCountEqual(err.value.get_messages(), expected_message)

--- a/tests/spdx/parser/jsonlikedict/test_checksum_parser.py
+++ b/tests/spdx/parser/jsonlikedict/test_checksum_parser.py
@@ -36,13 +36,5 @@ def test_parse_incomplete_checksum():
     checksum_parser = ChecksumParser()
     checksum_dict = {"algorithm": "SHA1"}
 
-    with pytest.raises(SPDXParsingError) as err:
+    with pytest.raises(SPDXParsingError):
         checksum_parser.parse_checksum(checksum_dict)
-
-    TestCase().assertCountEqual(
-        err.value.get_messages(),
-        [
-            'Error while constructing Checksum: [\'SetterError Checksum: type of argument "value" must be str; '
-            "got NoneType instead: None']"
-        ],
-    )

--- a/tests/spdx/parser/jsonlikedict/test_creation_info_parser.py
+++ b/tests/spdx/parser/jsonlikedict/test_creation_info_parser.py
@@ -60,36 +60,17 @@ def test_parse_creation_info():
 
 
 @pytest.mark.parametrize(
-    "incomplete_dict,expected_message",
+    "incomplete_dict",
     [
-        (
-            {"spdxVersion": "2.3", "SPDXID": DOCUMENT_SPDX_ID, "name": "Example Document"},
-            ["Error while parsing document Example Document: ['CreationInfo does not exist.']"],
-        ),
-        (
-            {"creationInfo": {"created": "2019-02-01T11:30:40Z"}},
-            [
-                "Error while constructing CreationInfo: ['SetterError CreationInfo: type of "
-                'argument "spdx_version" must be str; got NoneType instead: None\', '
-                '\'SetterError CreationInfo: type of argument "spdx_id" must be str; got '
-                "NoneType instead: None', 'SetterError CreationInfo: type of argument "
-                "\"name\" must be str; got NoneType instead: None', 'SetterError "
-                'CreationInfo: type of argument "document_namespace" must be str; got '
-                "NoneType instead: None', 'SetterError CreationInfo: type of argument "
-                "\"creators\" must be a list; got NoneType instead: None', 'SetterError "
-                'CreationInfo: type of argument "data_license" must be str; got NoneType '
-                "instead: None']"
-            ],
-        ),
+        {"spdxVersion": "2.3", "SPDXID": DOCUMENT_SPDX_ID, "name": "Example Document"},
+        {"creationInfo": {"created": "2019-02-01T11:30:40Z"}},
     ],
 )
-def test_parse_incomplete_document_info(incomplete_dict, expected_message):
+def test_parse_incomplete_document_info(incomplete_dict):
     creation_info_parser = CreationInfoParser()
 
-    with pytest.raises(SPDXParsingError) as err:
+    with pytest.raises(SPDXParsingError):
         creation_info_parser.parse_creation_info(incomplete_dict)
-
-    TestCase().assertCountEqual(err.value.get_messages(), expected_message)
 
 
 def test_parse_invalid_creation_info():
@@ -105,15 +86,5 @@ def test_parse_invalid_creation_info():
         "dataLicense": None,
     }
 
-    with pytest.raises(SPDXParsingError) as err:
+    with pytest.raises(SPDXParsingError):
         creation_info_parser.parse_creation_info(doc_dict)
-
-    TestCase().assertCountEqual(
-        err.value.get_messages(),
-        [
-            "Error while constructing CreationInfo: ['SetterError CreationInfo: type of "
-            'argument "document_namespace" must be str; got NoneType instead: None\', '
-            '\'SetterError CreationInfo: type of argument "data_license" must be str; got '
-            "NoneType instead: None']"
-        ],
-    )

--- a/tests/spdx/parser/jsonlikedict/test_error_message.py
+++ b/tests/spdx/parser/jsonlikedict/test_error_message.py
@@ -1,0 +1,31 @@
+from unittest import TestCase
+
+import pytest
+
+from spdx_tools.spdx.parser.error import SPDXParsingError
+from spdx_tools.spdx.parser.jsonlikedict.package_parser import PackageParser
+
+
+# To avoid duplication we use this invalid package as a proxy for the exact comparison of the generated error message.
+# For all other classes we only check that a TypeError is raised if an incorrect type is specified.
+def test_error_message():
+    package_parser = PackageParser()
+    package = {"SPDXID": "SPDXRef-Package", "downloadLocation": 5, "attributionTexts": ["text", 5, {"test": "data"}]}
+
+    with pytest.raises(SPDXParsingError) as err:
+        package_parser.parse_package(package)
+
+    TestCase().assertCountEqual(
+        err.value.get_messages(),
+        [
+            'Error while constructing Package: [\'SetterError Package: argument "name" '
+            "(None) is not an instance of str', 'SetterError Package: argument "
+            '"download_location" (int) did not match any element in the union:\\n  str: '
+            "is not an instance of str\\n  "
+            "spdx_tools.spdx.model.spdx_no_assertion.SpdxNoAssertion: is not an instance "
+            "of spdx_tools.spdx.model.spdx_no_assertion.SpdxNoAssertion\\n  "
+            "spdx_tools.spdx.model.spdx_none.SpdxNone: is not an instance of "
+            "spdx_tools.spdx.model.spdx_none.SpdxNone', 'SetterError Package: item 1 of "
+            'argument "attribution_texts" (list) is not an instance of str\']'
+        ],
+    )

--- a/tests/spdx/parser/jsonlikedict/test_extracted_licensing_info_parser.py
+++ b/tests/spdx/parser/jsonlikedict/test_extracted_licensing_info_parser.py
@@ -1,8 +1,6 @@
 # SPDX-FileCopyrightText: 2022 spdx contributors
 #
 # SPDX-License-Identifier: Apache-2.0
-from unittest import TestCase
-
 import pytest
 
 from spdx_tools.spdx.parser.error import SPDXParsingError
@@ -51,14 +49,5 @@ def test_parse_invalid_extracted_licensing_info():
         "seeAlsos": ["http://people.freebsd.org/~phk/"],
     }
 
-    with pytest.raises(SPDXParsingError) as err:
+    with pytest.raises(SPDXParsingError):
         extracted_licensing_info_parser.parse_extracted_licensing_info(extracted_licensing_infos_dict)
-
-    TestCase().assertCountEqual(
-        err.value.get_messages(),
-        [
-            "Error while constructing ExtractedLicensingInfo: ['SetterError "
-            'ExtractedLicensingInfo: type of argument "comment" must be one of (str, '
-            "NoneType); got int instead: 56']"
-        ],
-    )

--- a/tests/spdx/parser/jsonlikedict/test_file_parser.py
+++ b/tests/spdx/parser/jsonlikedict/test_file_parser.py
@@ -93,22 +93,6 @@ def test_parse_file(copyright_text, expected_copyright_text):
     assert file.attribution_texts == ["Some attribution text."]
 
 
-def test_parse_incomplete_file():
-    file_parser = FileParser()
-    file_dict = {"SPDXID": "SPDXRef-File", "fileName": "Incomplete File"}
-
-    with pytest.raises(SPDXParsingError) as err:
-        file_parser.parse_file(file_dict)
-
-    TestCase().assertCountEqual(
-        err.value.get_messages(),
-        [
-            "Error while constructing File: ['SetterError File: type of argument "
-            '"checksums" must be a list; got NoneType instead: None\']'
-        ],
-    )
-
-
 def test_parse_invalid_files():
     file_parser = FileParser()
     files = [
@@ -129,20 +113,11 @@ def test_parse_invalid_files():
                 {"algorithm": "MD", "checksumValue": "624c1abb3664f4b35547e7c73864ad24"},
             ],
         },
+        {"SPDXID": "SPDXRef-File", "fileName": "Incomplete File"},
     ]
 
-    with pytest.raises(SPDXParsingError) as err:
+    with pytest.raises(SPDXParsingError):
         parse_list_of_elements(files, file_parser.parse_file)
-    TestCase().assertCountEqual(
-        err.value.get_messages(),
-        [
-            "Error while constructing File: ['SetterError File: type of argument "
-            '"checksums" must be a list; got NoneType instead: None\']',
-            'Error while constructing File: [\'SetterError File: type of argument "name" '
-            "must be str; got NoneType instead: None']",
-            "Error while parsing File: [\"Error while parsing Checksum: ['Invalid ChecksumAlgorithm: MD']\"]",
-        ],
-    )
 
 
 def test_parse_file_types():

--- a/tests/spdx/parser/jsonlikedict/test_package_parser.py
+++ b/tests/spdx/parser/jsonlikedict/test_package_parser.py
@@ -228,52 +228,23 @@ def test_parse_package(
 
 
 @pytest.mark.parametrize(
-    "incomplete_package_dict,expected_message",
+    "incomplete_package_dict",
     [
-        (
-            {"SPDXID": "SPDXRef-Package"},
-            [
-                "Error while constructing Package: ['SetterError Package: type of "
-                "argument \"name\" must be str; got NoneType instead: None', 'SetterError Package: type of argument "
-                '"download_location" must be one of (str, spdx_tools.spdx.model.spdx_no_assertion.SpdxNoAssertion, '
-                "spdx_tools.spdx.model.spdx_none.SpdxNone); "
-                "got NoneType instead: None']"
-            ],
-        ),
-        (
-            {"SPDXID": "SPDXRef-Package", "name": 5, "downloadLocation": "NONE"},
-            [
-                "Error while constructing Package: ['SetterError Package: type of argument "
-                '"name" must be str; got int instead: 5\']'
-            ],
-        ),
+        {"SPDXID": "SPDXRef-Package"},
+        {"SPDXID": "SPDXRef-Package", "name": 5, "downloadLocation": "NONE"},
+        {
+            "SPDXID": "SPDXRef-Package",
+            "name": "Example Package",
+            "downloadLocation": "NONE",
+            "checksums": [{"algorithm": "SHA", "value": "1234"}],
+        },
     ],
 )
-def test_parse_incomplete_package(incomplete_package_dict, expected_message):
+def test_parse_invalid_package(incomplete_package_dict):
     package_parser = PackageParser()
 
-    with pytest.raises(SPDXParsingError) as err:
+    with pytest.raises(SPDXParsingError):
         package_parser.parse_package(incomplete_package_dict)
-
-    TestCase().assertCountEqual(err.value.get_messages(), expected_message)
-
-
-def test_parse_invalid_package():
-    package_parser = PackageParser()
-    package_dict = {
-        "SPDXID": "SPDXRef-Package",
-        "name": "Example Package",
-        "downloadLocation": "NONE",
-        "checksums": [{"algorithm": "SHA", "value": "1234"}],
-    }
-
-    with pytest.raises(SPDXParsingError) as err:
-        package_parser.parse_package(package_dict)
-
-    TestCase().assertCountEqual(
-        err.value.get_messages(),
-        ["Error while parsing Package: [\"Error while parsing Checksum: ['Invalid ChecksumAlgorithm: SHA']\"]"],
-    )
 
 
 def test_parse_packages():
@@ -289,36 +260,16 @@ def test_parse_packages():
         {"SPDXID": "SPDXRef-Package", "name": "Example Package", "downloadLocation": "NONE"},
     ]
 
-    with pytest.raises(SPDXParsingError) as err:
+    with pytest.raises(SPDXParsingError):
         parse_list_of_elements(packages_list, package_parser.parse_package)
-
-    TestCase().assertCountEqual(
-        err.value.get_messages(),
-        [
-            'Error while parsing Package: ["Error while parsing Checksum: ' "['Invalid ChecksumAlgorithm: SHA']\"]",
-            "Error while constructing Package: ['SetterError Package: type of argument "
-            '"name" must be str; got int instead: 5\']',
-        ],
-    )
 
 
 def test_parse_external_ref():
     package_parser = PackageParser()
     external_ref = {"referenceType": "fix"}
 
-    with pytest.raises(SPDXParsingError) as err:
+    with pytest.raises(SPDXParsingError):
         package_parser.parse_external_ref(external_ref)
-
-    TestCase().assertCountEqual(
-        err.value.get_messages(),
-        [
-            "Error while constructing ExternalPackageRef: ['SetterError "
-            'ExternalPackageRef: type of argument "category" must be '
-            "spdx_tools.spdx.model.package.ExternalPackageRefCategory; got NoneType instead: None', "
-            '\'SetterError ExternalPackageRef: type of argument "locator" must be str; '
-            "got NoneType instead: None']"
-        ],
-    )
 
 
 def test_parse_invalid_external_package_ref_category():

--- a/tests/spdx/parser/jsonlikedict/test_relationship_parser.py
+++ b/tests/spdx/parser/jsonlikedict/test_relationship_parser.py
@@ -37,17 +37,8 @@ def test_parse_incomplete_relationship():
         "comment": "Comment.",
     }
 
-    with pytest.raises(SPDXParsingError) as err:
+    with pytest.raises(SPDXParsingError):
         relationship_parser.parse_relationship(relationship_dict)
-
-    TestCase().assertCountEqual(
-        err.value.get_messages(),
-        [
-            "Error while constructing Relationship: ['SetterError Relationship: type of "
-            'argument "relationship_type" must be '
-            "spdx_tools.spdx.model.relationship.RelationshipType; got NoneType instead: None']"
-        ],
-    )
 
 
 def test_parse_relationship_type():

--- a/tests/spdx/parser/jsonlikedict/test_snippet_parser.py
+++ b/tests/spdx/parser/jsonlikedict/test_snippet_parser.py
@@ -74,18 +74,8 @@ def test_parse_incomplete_snippet():
     snippet_parser = SnippetParser()
     incomplete_snippet_dict = {"SPDXID": "SPDXRef-Snippet", "file_spdx_id": "SPDXRef-File"}
 
-    with pytest.raises(SPDXParsingError) as err:
+    with pytest.raises(SPDXParsingError):
         snippet_parser.parse_snippet(incomplete_snippet_dict)
-
-    TestCase().assertCountEqual(
-        err.value.get_messages(),
-        [
-            "Error while constructing Snippet: ['SetterError Snippet: type of argument "
-            "\"file_spdx_id\" must be str; got NoneType instead: None', 'SetterError Snippet: type of argument "
-            '"byte_range" must be a tuple; got NoneType '
-            "instead: None']"
-        ],
-    )
 
 
 def test_parse_snippet_with_invalid_snippet_range():
@@ -101,18 +91,8 @@ def test_parse_snippet_with_invalid_snippet_range():
         ],
     }
 
-    with pytest.raises(SPDXParsingError) as err:
+    with pytest.raises(SPDXParsingError):
         snippet_parser.parse_snippet(snippet_with_invalid_ranges_list)
-
-    TestCase().assertCountEqual(
-        err.value.get_messages(),
-        [
-            "Error while constructing Snippet: ['SetterError Snippet: type of argument "
-            "\"file_spdx_id\" must be str; got NoneType instead: None', 'SetterError "
-            'Snippet: type of argument "byte_range"[0] must be int; got str instead: '
-            "(\\'310s\\', 23)']"
-        ],
-    )
 
 
 def test_parse_invalid_snippet_range():

--- a/tests/spdx/parser/rdf/test_file_parser.py
+++ b/tests/spdx/parser/rdf/test_file_parser.py
@@ -45,10 +45,5 @@ def test_parse_invalid_file():
     doc_namespace = "https://some.namespace"
 
     assert isinstance(file_node, BNode)
-    with pytest.raises(SPDXParsingError) as err:
+    with pytest.raises(SPDXParsingError):
         parse_file(file_node, graph, doc_namespace)
-
-    assert err.value.get_messages() == [
-        "Error while constructing File: ['SetterError File: type of argument "
-        '"spdx_id" must be str; got NoneType instead: None\']'
-    ]

--- a/tests/spdx/parser/rdf/test_package_parser.py
+++ b/tests/spdx/parser/rdf/test_package_parser.py
@@ -104,10 +104,5 @@ def test_parse_invalid_package():
     doc_namespace = "https://some.namespace"
 
     assert isinstance(package_node, BNode)
-    with pytest.raises(SPDXParsingError) as err:
+    with pytest.raises(SPDXParsingError):
         parse_package(package_node, graph, doc_namespace)
-
-    assert err.value.get_messages() == [
-        "Error while constructing Package: ['SetterError Package: type of argument "
-        '"spdx_id" must be str; got NoneType instead: None\']'
-    ]

--- a/tests/spdx/parser/rdf/test_snippet_parser.py
+++ b/tests/spdx/parser/rdf/test_snippet_parser.py
@@ -167,11 +167,5 @@ def test_parse_invalid_file():
     doc_namespace = "https://some.namespace"
 
     assert isinstance(snippet_node, BNode)
-    with pytest.raises(SPDXParsingError) as err:
+    with pytest.raises(SPDXParsingError):
         parse_snippet(snippet_node, graph, doc_namespace)
-
-    assert err.value.get_messages() == [
-        "Error while constructing Snippet: ['SetterError Snippet: type of argument "
-        "\"spdx_id\" must be str; got NoneType instead: None', 'SetterError Snippet: "
-        'type of argument "file_spdx_id" must be str; got NoneType instead: None\']'
-    ]


### PR DESCRIPTION
Based on #655

The following adaptions were made to be able to bump typeguard from 2.13.3 to 4.0.0

- the error raised is a `TypeCheckError`
- we need to enable the CollectionCheckStrategy.ALL_ITEMS to check each instance in a collection
- instead of checking the generated error messages for each class we only check that an error is raised for every class and use only one invalid package as a proxy for all other tests to check the generated message

The generated error message changed with the update. In the `test_error_message` module you can see an example for the new message. I think the part for `package.download_location`(so a wrong type where a `Union` of types is possible) takes a bit  of getting used to, but in my opinion the problem becomes clear and we don't need to customize this error. 