### PR TITLE
[issue-427] fix external document ref bumping

### DIFF
--- a/src/spdx_tools/spdx3/bump_from_spdx2/creation_information.py
+++ b/src/spdx_tools/spdx3/bump_from_spdx2/creation_information.py
@@ -23,10 +23,14 @@ def bump_creation_information(spdx2_creation_info: Spdx2_CreationInfo, payload: 
     print_missing_conversion("creation_info.document_namespace", 0, "https://github.com/spdx/spdx-3-model/issues/87")
 
     # creation_info.external_document_refs -> spdx_document.imports
-    imports = [
-        bump_external_document_ref(external_document_ref)
-        for external_document_ref in spdx2_creation_info.external_document_refs
-    ]
+    namespaces, imports = zip(
+        *[
+            bump_external_document_ref(external_document_ref)
+            for external_document_ref in spdx2_creation_info.external_document_refs
+        ]
+    )
+    namespaces = list(namespaces)
+    imports = list(imports)
     # creation_info.license_list_version -> ?
     print_missing_conversion(
         "creation_info.license_list_version",
@@ -76,4 +80,5 @@ def bump_creation_information(spdx2_creation_info: Spdx2_CreationInfo, payload: 
         element=[],
         root_element=[],
         imports=imports,
+        namespaces=namespaces,
     )

--- a/src/spdx_tools/spdx3/bump_from_spdx2/creation_information.py
+++ b/src/spdx_tools/spdx3/bump_from_spdx2/creation_information.py
@@ -15,14 +15,11 @@ from spdx_tools.spdx.model.document import CreationInfo as Spdx2_CreationInfo
 
 
 def bump_creation_information(spdx2_creation_info: Spdx2_CreationInfo, payload: Payload) -> SpdxDocument:
-    # creation_info.spdx_id -> spdx_document.spdx_id
     document_namespace = spdx2_creation_info.document_namespace
     spdx_id = f"{document_namespace}#{spdx2_creation_info.spdx_id}"
 
-    # creation_info.document_namespace -> ?
     print_missing_conversion("creation_info.document_namespace", 0, "https://github.com/spdx/spdx-3-model/issues/87")
 
-    # creation_info.external_document_refs -> spdx_document.imports
     namespaces, imports = zip(
         *[
             bump_external_document_ref(external_document_ref)
@@ -31,13 +28,11 @@ def bump_creation_information(spdx2_creation_info: Spdx2_CreationInfo, payload: 
     )
     namespaces = list(namespaces)
     imports = list(imports)
-    # creation_info.license_list_version -> ?
     print_missing_conversion(
         "creation_info.license_list_version",
         0,
         "part of licensing profile, " "https://github.com/spdx/spdx-3-model/issues/131",
     )
-    # creation_info.document_comment -> spdx_document.comment
     document_comment = spdx2_creation_info.document_comment
     creation_information = CreationInformation(
         spec_version=Version("3.0.0"),

--- a/src/spdx_tools/spdx3/bump_from_spdx2/external_document_ref.py
+++ b/src/spdx_tools/spdx3/bump_from_spdx2/external_document_ref.py
@@ -1,18 +1,17 @@
 # SPDX-FileCopyrightText: 2023 spdx contributors
 #
 # SPDX-License-Identifier: Apache-2.0
-from typing import List
+from typing import List, Tuple
 
 from spdx_tools.spdx3.bump_from_spdx2.checksum import bump_checksum
-from spdx_tools.spdx3.model import ExternalMap, Hash
+from spdx_tools.spdx3.model import ExternalMap, Hash, NamespaceMap
 from spdx_tools.spdx.model.external_document_ref import ExternalDocumentRef
 
 
-def bump_external_document_ref(external_document_ref: ExternalDocumentRef) -> ExternalMap:
+def bump_external_document_ref(external_document_ref: ExternalDocumentRef) -> Tuple[NamespaceMap, ExternalMap]:
     verified_using: List[Hash] = [bump_checksum(external_document_ref.checksum)]
 
-    return ExternalMap(
-        external_id=external_document_ref.document_ref_id,
+    return NamespaceMap(external_document_ref.document_ref_id, external_document_ref.document_uri + "#"), ExternalMap(
+        external_id=f"{external_document_ref.document_ref_id}:SPDXRef-DOCUMENT",
         verified_using=verified_using,
-        location_hint=external_document_ref.document_uri,
     )

--- a/src/spdx_tools/spdx3/bump_from_spdx2/file.py
+++ b/src/spdx_tools/spdx3/bump_from_spdx2/file.py
@@ -20,8 +20,6 @@ def bump_file(
 ):
     spdx_id = "#".join([document_namespace, spdx2_file.spdx_id])
     integrity_methods = [bump_checksum(checksum) for checksum in spdx2_file.checksums]
-    # file.checksums -> file.verifiedUsing
-    # file.file_types -> file.content_type (MediaType with Cardinality 1)
     print_missing_conversion(
         "file.file_type", 0, "different cardinalities, " "https://github.com/spdx/spdx-3-model/issues/82"
     )

--- a/src/spdx_tools/spdx3/bump_from_spdx2/package.py
+++ b/src/spdx_tools/spdx3/bump_from_spdx2/package.py
@@ -32,7 +32,6 @@ def bump_package(
 ):
     spdx_id = "#".join([document_namespace, spdx2_package.spdx_id])
     download_location = handle_no_assertion_or_none(spdx2_package.download_location, "package.download_location")
-    # package.file_name -> ?
     print_missing_conversion("package2.file_name", 0, "https://github.com/spdx/spdx-3-model/issues/83")
     if isinstance(spdx2_package.supplier, Spdx2_Actor):
         supplied_by_spdx_id = [bump_actor(spdx2_package.supplier, payload, creation_information, document_namespace)]
@@ -44,13 +43,10 @@ def bump_package(
         ]
     else:
         originated_by_spdx_id = None
-    # package.files_analyzed  -> ?
     print_missing_conversion("package2.files_analyzed", 0, "https://github.com/spdx/spdx-3-model/issues/84")
-    # package.verification_code -> package.verified_using
     print_missing_conversion(
         "package2.verification_code", 1, "of IntegrityMethod, https://github.com/spdx/spdx-3-model/issues/85"
     )
-    # package.checksums -> package.verified_using
     integrity_methods = [bump_checksum(checksum) for checksum in spdx2_package.checksums]
     declared_license = bump_license_expression_or_none_or_no_assertion(
         spdx2_package.license_declared, extracted_licensing_info

--- a/tests/spdx3/bump/test_external_document_ref_bump.py
+++ b/tests/spdx3/bump/test_external_document_ref_bump.py
@@ -1,0 +1,36 @@
+# SPDX-FileCopyrightText: 2023 spdx contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from spdx_tools.spdx3.bump_from_spdx2.checksum import bump_checksum
+from spdx_tools.spdx3.bump_from_spdx2.creation_information import bump_creation_information
+from spdx_tools.spdx3.bump_from_spdx2.external_document_ref import bump_external_document_ref
+from spdx_tools.spdx3.payload import Payload
+from spdx_tools.spdx.model import ExternalDocumentRef
+from tests.spdx.fixtures import checksum_fixture, creation_info_fixture, external_document_ref_fixture
+
+
+def test_bump_external_document_ref():
+    checksum = checksum_fixture()
+    external_document_ref = ExternalDocumentRef("DocumentRef-external", "https://external.uri", checksum)
+    namespace_map, imports = bump_external_document_ref(external_document_ref)
+
+    assert namespace_map.prefix == "DocumentRef-external"
+    assert namespace_map.namespace == "https://external.uri#"
+
+    assert imports.external_id == "DocumentRef-external:SPDXRef-DOCUMENT"
+    assert imports.verified_using == [bump_checksum(checksum)]
+
+
+def test_bump_multiple_external_document_refs():
+    payload = Payload()
+    creation_info = creation_info_fixture(
+        external_document_refs=[
+            external_document_ref_fixture("DocumentRef-external1", "https://external.uri1"),
+            external_document_ref_fixture("DocumentRef-external2", "https://external.uri2"),
+        ]
+    )
+    spdx_document = bump_creation_information(creation_info, payload)
+
+    assert len(spdx_document.imports) == 2
+    assert len(spdx_document.namespaces) == 2


### PR DESCRIPTION
The new conversion follows the description provided in the [migration guide](https://docs.google.com/document/d/1-olHRnX1CssUS67Psv_sAq9Vd-pc81HF8MM0hA7M0hg/edit#heading=h.h8bkqwghh9fe).

The test is a little more verbose than necessary because I had some trouble wrapping my head around which field goes where.

Next up is adding external elements to the `imports` list, as also described in the migration guide.

part of #427