### PR TITLE
fix tests after typeguard update

### DIFF
--- a/tests/spdx3/model/ai/test_ai_package.py
+++ b/tests/spdx3/model/ai/test_ai_package.py
@@ -76,9 +76,6 @@ def test_invalid_initialization(creation_information):
             metric={"metric1": "value", "metric2": 250},
         )
 
-    assert err.value.args[0] == [
-        (
-            "SetterError AIPackage: type of argument \"metric\"['metric2'] must be one of "
-            "(str, NoneType); got int instead: {'metric1': 'value', 'metric2': 250}"
-        )
-    ]
+    assert len(err.value.args[0]) == 1
+    for error in err.value.args[0]:
+        assert error.startswith("SetterError AIPackage:")

--- a/tests/spdx3/model/build/test_build.py
+++ b/tests/spdx3/model/build/test_build.py
@@ -47,9 +47,6 @@ def test_invalid_initialization(creation_information):
             config_source_digest=["hash_value"],
         )
 
-    assert err.value.args[0] == [
-        (
-            "SetterError Build: type of argument \"config_source_digest\"[0] must be spdx_tools.spdx3.model.hash.Hash;"
-            " got str instead: ['hash_value']"
-        )
-    ]
+    assert len(err.value.args[0]) == 1
+    for error in err.value.args[0]:
+        assert error.startswith("SetterError Build:")

--- a/tests/spdx3/model/dataset/test_dataset.py
+++ b/tests/spdx3/model/dataset/test_dataset.py
@@ -72,9 +72,6 @@ def test_invalid_initialization(creation_information):
             sensor={"sensor1": "value", "sensor2": 250},
         )
 
-    assert err.value.args[0] == [
-        (
-            "SetterError Dataset: type of argument \"sensor\"['sensor2'] must be one of "
-            "(str, NoneType); got int instead: {'sensor1': 'value', 'sensor2': 250}"
-        )
-    ]
+    assert len(err.value.args[0]) == 1
+    for error in err.value.args[0]:
+        assert error.startswith("SetterError Dataset:")

--- a/tests/spdx3/model/software/test_file.py
+++ b/tests/spdx3/model/software/test_file.py
@@ -40,14 +40,6 @@ def test_invalid_initialization(creation_information):
             content_type=SoftwarePurpose.ARCHIVE,
         )
 
-    assert err.value.args[0] == [
-        'SetterError File: type of argument "spdx_id" must be str; got int instead: 1',
-        'SetterError File: type of argument "content_identifier" must be one of (str, '
-        "NoneType); got int instead: 3",
-        'SetterError File: type of argument "purpose" must be a list; got '
-        "spdx_tools.spdx3.model.software.software_purpose.SoftwarePurpose instead: "
-        "SoftwarePurpose.FILE",
-        'SetterError File: type of argument "content_type" must be one of (str, '
-        "NoneType); got spdx_tools.spdx3.model.software.software_purpose.SoftwarePurpose "
-        "instead: SoftwarePurpose.ARCHIVE",
-    ]
+    assert len(err.value.args[0]) == 4
+    for error in err.value.args[0]:
+        assert error.startswith("SetterError File:")

--- a/tests/spdx3/model/software/test_package.py
+++ b/tests/spdx3/model/software/test_package.py
@@ -65,21 +65,6 @@ def test_invalid_initialization(creation_information):
             source_info=["some info"],
         )
 
-    assert err.value.args[0] == [
-        'SetterError Package: type of argument "built_time" must be one of '
-        "(datetime.datetime, NoneType); got str instead: 2022-03-04T00:00:00Z",
-        'SetterError Package: type of argument "content_identifier" must be one of '
-        "(str, NoneType); got int instead: 3",
-        'SetterError Package: type of argument "purpose" must be a list; got '
-        "spdx_tools.spdx3.model.software.software_purpose.SoftwarePurpose instead: "
-        "SoftwarePurpose.FILE",
-        'SetterError Package: type of argument "package_version" must be one of '
-        "(str, NoneType); got int instead: 42",
-        'SetterError Package: type of argument "download_location" must be one of '
-        "(str, NoneType); got int instead: 4",
-        'SetterError Package: type of argument "package_url" must be one of (str, '
-        "NoneType); got list instead: ['uris']",
-        'SetterError Package: type of argument "homepage" must be one of (str, ' "NoneType); got bool instead: True",
-        'SetterError Package: type of argument "source_info" must be one of (str, '
-        "NoneType); got list instead: ['some info']",
-    ]
+    assert len(err.value.args[0]) == 8
+    for error in err.value.args[0]:
+        assert error.startswith("SetterError Package:")

--- a/tests/spdx3/model/software/test_sbom.py
+++ b/tests/spdx3/model/software/test_sbom.py
@@ -29,9 +29,6 @@ def test_invalid_initialization():
     with pytest.raises(TypeError) as err:
         Sbom(2, {"creation_info": [3, 4, 5]}, element=[], root_element=[])
 
-    assert err.value.args[0] == [
-        'SetterError Sbom: type of argument "spdx_id" must be str; got int instead: 2',
-        'SetterError Sbom: type of argument "creation_info" must be '
-        "spdx_tools.spdx3.model.creation_information.CreationInformation; got dict "
-        "instead: {'creation_info': [3, 4, 5]}",
-    ]
+    assert len(err.value.args[0]) == 2
+    for error in err.value.args[0]:
+        assert error.startswith("SetterError Sbom:")

--- a/tests/spdx3/model/software/test_snippet.py
+++ b/tests/spdx3/model/software/test_snippet.py
@@ -32,9 +32,6 @@ def test_invalid_initialization(creation_information):
     with pytest.raises(TypeError) as err:
         Snippet(2, creation_information, originated_by=34, byte_range="34:45")
 
-    assert err.value.args[0] == [
-        'SetterError Snippet: type of argument "spdx_id" must be str; got int ' "instead: 2",
-        'SetterError Snippet: type of argument "originated_by" must be a list; got ' "int instead: 34",
-        'SetterError Snippet: type of argument "byte_range" must be one of '
-        "(Tuple[int, int], NoneType); got str instead: 34:45",
-    ]
+    assert len(err.value.args[0]) == 3
+    for error in err.value.args[0]:
+        assert error.startswith("SetterError Snippet:")

--- a/tests/spdx3/model/software/test_software_dependency_relationship.py
+++ b/tests/spdx3/model/software/test_software_dependency_relationship.py
@@ -54,6 +54,6 @@ def test_invalid_initialization(creation_information):
             42,
         )
 
-    assert err.value.args[0] == [
-        'SetterError SoftwareDependencyRelationship: type of argument "to" must be a ' "list; got int instead: 42"
-    ]
+    assert len(err.value.args[0]) == 1
+    for error in err.value.args[0]:
+        assert error.startswith("SetterError SoftwareDependencyRelationship:")

--- a/tests/spdx3/model/test_creation_information.py
+++ b/tests/spdx3/model/test_creation_information.py
@@ -33,16 +33,9 @@ def test_invalid_initialization():
     with pytest.raises(TypeError) as err:
         CreationInformation("2.3", "2012-01-01", [], [], "core", 3, [])
 
-    assert err.value.args[0] == [
-        'SetterError CreationInformation: type of argument "spec_version" must be '
-        "semantic_version.base.Version; got str instead: 2.3",
-        'SetterError CreationInformation: type of argument "created" must be '
-        "datetime.datetime; got str instead: 2012-01-01",
-        'SetterError CreationInformation: type of argument "profile" must be a list; ' "got str instead: core",
-        'SetterError CreationInformation: type of argument "data_license" must be ' "str; got int instead: 3",
-        'SetterError CreationInformation: type of argument "comment" must be'
-        " one of (str, NoneType); got list instead: []",
-    ]
+    assert len(err.value.args[0]) == 5
+    for error in err.value.args[0]:
+        assert error.startswith("SetterError CreationInformation:")
 
 
 def test_incomplete_initialization():

--- a/tests/spdx3/model/test_external_identifier.py
+++ b/tests/spdx3/model/test_external_identifier.py
@@ -27,16 +27,6 @@ def test_invalid_initialization():
     with pytest.raises(TypeError) as err:
         ExternalIdentifier("CPE22", ["identifier", "another_identifier"], 34, "locator", True)
 
-    assert err.value.args[0] == [
-        'SetterError ExternalIdentifier: type of argument "external_identifier_type" '
-        "must be spdx_tools.spdx3.model.external_identifier.ExternalIdentifierType; got str "
-        "instead: CPE22",
-        'SetterError ExternalIdentifier: type of argument "identifier" must be str; '
-        "got list instead: ['identifier', 'another_identifier']",
-        'SetterError ExternalIdentifier: type of argument "comment" must be one of '
-        "(str, NoneType); got int instead: 34",
-        'SetterError ExternalIdentifier: type of argument "identifier_locator" must '
-        "be a list; got str instead: locator",
-        'SetterError ExternalIdentifier: type of argument "issuing_authority" must be '
-        "one of (str, NoneType); got bool instead: True",
-    ]
+    assert len(err.value.args[0]) == 5
+    for error in err.value.args[0]:
+        assert error.startswith("SetterError ExternalIdentifier:")

--- a/tests/spdx3/model/test_external_map.py
+++ b/tests/spdx3/model/test_external_map.py
@@ -21,8 +21,6 @@ def test_invalid_initialization():
     with pytest.raises(TypeError) as err:
         ExternalMap(234, None, ["location  hints"])
 
-    assert err.value.args[0] == [
-        'SetterError ExternalMap: type of argument "external_id" must be str; got int ' "instead: 234",
-        'SetterError ExternalMap: type of argument "location_hint" must be one of '
-        "(str, NoneType); got list instead: ['location  hints']",
-    ]
+    assert len(err.value.args[0]) == 2
+    for error in err.value.args[0]:
+        assert error.startswith("SetterError ExternalMap:")

--- a/tests/spdx3/model/test_external_reference.py
+++ b/tests/spdx3/model/test_external_reference.py
@@ -20,13 +20,6 @@ def test_invalid_initialization():
     with pytest.raises(TypeError) as err:
         ExternalReference("OTHER", "a URI", 34, True)
 
-    assert err.value.args[0] == [
-        'SetterError ExternalReference: type of argument "external_reference_type" '
-        "must be one of (spdx_tools.spdx3.model.external_reference.ExternalReferenceType, "
-        "NoneType); got str instead: OTHER",
-        'SetterError ExternalReference: type of argument "locator" must be a list; ' "got str instead: a URI",
-        'SetterError ExternalReference: type of argument "content_type" must be one '
-        "of (str, NoneType); got int instead: 34",
-        'SetterError ExternalReference: type of argument "comment" must be one of '
-        "(str, NoneType); got bool instead: True",
-    ]
+    assert len(err.value.args[0]) == 4
+    for error in err.value.args[0]:
+        assert error.startswith("SetterError ExternalReference:")

--- a/tests/spdx3/model/test_hash.py
+++ b/tests/spdx3/model/test_hash.py
@@ -17,8 +17,6 @@ def test_invalid_initialization():
     with pytest.raises(TypeError) as err:
         Hash("SHA1", 345)
 
-    assert err.value.args[0] == [
-        'SetterError Hash: type of argument "algorithm" must be '
-        "spdx_tools.spdx3.model.hash.HashAlgorithm; got str instead: SHA1",
-        'SetterError Hash: type of argument "hash_value" must be str; got int ' "instead: 345",
-    ]
+    assert len(err.value.args[0]) == 2
+    for error in err.value.args[0]:
+        assert error.startswith("SetterError Hash:")

--- a/tests/spdx3/model/test_namespace_map.py
+++ b/tests/spdx3/model/test_namespace_map.py
@@ -17,8 +17,6 @@ def test_invalid_initialization():
     with pytest.raises(TypeError) as err:
         NamespaceMap(34, ["list of namespaces"])
 
-    assert err.value.args[0] == [
-        'SetterError NamespaceMap: type of argument "prefix" must be one of (str, ' "NoneType); got int instead: 34",
-        'SetterError NamespaceMap: type of argument "namespace" must be one of (str, '
-        "NoneType); got list instead: ['list of namespaces']",
-    ]
+    assert len(err.value.args[0]) == 2
+    for error in err.value.args[0]:
+        assert error.startswith("SetterError NamespaceMap:")


### PR DESCRIPTION
The last typeguard update changed the error message text; to ensure this will not break again in the future, this will now not be tested anymore.

Some of the negative tests might look a little pointless right now because in a next step, I will change these to test all properties just like it is already done in [test_element_and_licensing_subclasses.py](https://github.com/spdx/tools-python/blob/6b56465a934fa2ba5b7d04f55e82f6971cb51671/tests/spdx3/model/test_element_and_licensing_subclasses.py).