### PR TITLE
Update spdx2 to 3 conversion

### DIFF
--- a/src/spdx_tools/spdx3/bump_from_spdx2/actor.py
+++ b/src/spdx_tools/spdx3/bump_from_spdx2/actor.py
@@ -1,6 +1,8 @@
 # SPDX-FileCopyrightText: 2023 spdx contributors
 #
 # SPDX-License-Identifier: Apache-2.0
+from typing import Optional
+
 from beartype.typing import List
 
 from spdx_tools.spdx3.model import CreationInfo, ExternalIdentifier, ExternalIdentifierType, Organization, Person, Tool
@@ -10,7 +12,7 @@ from spdx_tools.spdx.model.actor import ActorType
 
 
 def bump_actor(
-    spdx2_actor: Spdx2_Actor, payload: Payload, creation_info: CreationInfo, document_namespace: str
+    spdx2_actor: Spdx2_Actor, payload: Payload, document_namespace: str, creation_info: Optional[CreationInfo] = None
 ) -> str:
     name: str = spdx2_actor.name
     email: str = spdx2_actor.email
@@ -27,20 +29,21 @@ def bump_actor(
     if spdx_id in payload.get_full_map():  # the agent/tool already exists, so we don't need to create a new one
         return spdx_id
 
+    value_dict = {
+        "spdx_id": spdx_id,
+        "creation_info": creation_info,
+        "name": name,
+        "external_identifier": external_identifiers,
+    }
+
     if actor_type == ActorType.PERSON:
-        agent_or_tool = Person(
-            spdx_id=spdx_id, creation_info=creation_info, name=name, external_identifier=external_identifiers
-        )
+        agent_or_tool = Person(**value_dict)
 
     elif actor_type == ActorType.ORGANIZATION:
-        agent_or_tool = Organization(
-            spdx_id=spdx_id, creation_info=creation_info, name=name, external_identifier=external_identifiers
-        )
+        agent_or_tool = Organization(**value_dict)
 
     elif actor_type == ActorType.TOOL:
-        agent_or_tool = Tool(
-            spdx_id=spdx_id, creation_info=creation_info, name=name, external_identifier=external_identifiers
-        )
+        agent_or_tool = Tool(**value_dict)
 
     else:
         raise ValueError(f"no conversion rule defined for ActorType {actor_type}")

--- a/src/spdx_tools/spdx3/bump_from_spdx2/annotation.py
+++ b/src/spdx_tools/spdx3/bump_from_spdx2/annotation.py
@@ -25,7 +25,7 @@ def bump_annotation(
     # caution: the annotator and the annotation will only share the same creation_info if the actor
     #          has not been previously defined
     annotator = spdx2_annotation.annotator
-    creator_id: str = bump_actor(annotator, payload, creation_info, document_namespace)
+    creator_id: str = bump_actor(annotator, payload, document_namespace, creation_info)
     if annotator.actor_type in [ActorType.PERSON, ActorType.ORGANIZATION]:
         creation_info.created_by = [creator_id]
     else:

--- a/src/spdx_tools/spdx3/bump_from_spdx2/creation_info.py
+++ b/src/spdx_tools/spdx3/bump_from_spdx2/creation_info.py
@@ -70,7 +70,7 @@ def bump_creation_info(spdx2_creation_info: Spdx2_CreationInfo, payload: Payload
         name=spdx2_creation_info.name,
         comment=spdx2_creation_info.document_comment,
         element=[],
-        root_element=[spdx_id],
+        root_element=[],
         imports=imports,
         namespaces=namespaces,
     )

--- a/src/spdx_tools/spdx3/bump_from_spdx2/creation_info.py
+++ b/src/spdx_tools/spdx3/bump_from_spdx2/creation_info.py
@@ -38,7 +38,7 @@ def bump_creation_info(spdx2_creation_info: Spdx2_CreationInfo, payload: Payload
         created_by=[],
         created_using=[],
         profile=[ProfileIdentifier.CORE, ProfileIdentifier.SOFTWARE, ProfileIdentifier.LICENSING],
-        data_license=spdx2_creation_info.data_license,
+        data_license="https://spdx.org/licenses/" + spdx2_creation_info.data_license,
     )
 
     # due to creators having a creation_info themselves which inherits from the document's one,

--- a/src/spdx_tools/spdx3/bump_from_spdx2/creation_info.py
+++ b/src/spdx_tools/spdx3/bump_from_spdx2/creation_info.py
@@ -46,7 +46,7 @@ def bump_creation_info(spdx2_creation_info: Spdx2_CreationInfo, payload: Payload
     creator_ids: List[str] = []
     tool_ids: List[str] = []
     for creator in spdx2_creation_info.creators:
-        bumped_actor_id = bump_actor(creator, payload, creation_info, document_namespace)
+        bumped_actor_id = bump_actor(creator, payload, document_namespace, creation_info)
         if creator.actor_type in [ActorType.PERSON, ActorType.ORGANIZATION]:
             creator_ids.append(bumped_actor_id)
         else:

--- a/src/spdx_tools/spdx3/bump_from_spdx2/file.py
+++ b/src/spdx_tools/spdx3/bump_from_spdx2/file.py
@@ -4,12 +4,11 @@
 from beartype.typing import List
 
 from spdx_tools.spdx3.bump_from_spdx2.checksum import bump_checksum
-from spdx_tools.spdx3.bump_from_spdx2.license_expression import bump_license_expression_or_none_or_no_assertion
 from spdx_tools.spdx3.bump_from_spdx2.message import print_missing_conversion
-from spdx_tools.spdx3.model import CreationInfo, ExternalMap
+from spdx_tools.spdx3.model import ExternalMap
 from spdx_tools.spdx3.model.software import File
 from spdx_tools.spdx3.payload import Payload
-from spdx_tools.spdx.model import ExternalDocumentRef, ExtractedLicensingInfo, SpdxNoAssertion
+from spdx_tools.spdx.model import ExternalDocumentRef, SpdxNoAssertion
 from spdx_tools.spdx.model.file import File as Spdx2_File
 from spdx_tools.spdx.spdx_element_utils import get_full_element_spdx_id
 
@@ -17,9 +16,7 @@ from spdx_tools.spdx.spdx_element_utils import get_full_element_spdx_id
 def bump_file(
     spdx2_file: Spdx2_File,
     payload: Payload,
-    creation_info: CreationInfo,
     document_namespace: str,
-    extracted_licensing_info: List[ExtractedLicensingInfo],
     external_document_refs: List[ExternalDocumentRef],
     imports: List[ExternalMap],
 ):
@@ -36,9 +33,6 @@ def bump_file(
     print_missing_conversion(
         "file.file_type", 0, "different cardinalities, " "https://github.com/spdx/spdx-3-model/issues/82"
     )
-    license_concluded = bump_license_expression_or_none_or_no_assertion(
-        spdx2_file.license_concluded, extracted_licensing_info
-    )
     copyright_text = None
     if isinstance(spdx2_file.copyright_text, str):
         copyright_text = spdx2_file.copyright_text
@@ -53,11 +47,9 @@ def bump_file(
     payload.add_element(
         File(
             spdx_id,
-            creation_info=creation_info,
             name=spdx2_file.name,
             comment=spdx2_file.comment,
             verified_using=integrity_methods,
-            concluded_license=license_concluded,
             copyright_text=copyright_text,
             attribution_text=", ".join(spdx2_file.attribution_texts),
         )

--- a/src/spdx_tools/spdx3/bump_from_spdx2/package.py
+++ b/src/spdx_tools/spdx3/bump_from_spdx2/package.py
@@ -6,10 +6,8 @@ from beartype.typing import List, Optional, Union
 from spdx_tools.spdx3.bump_from_spdx2.actor import bump_actor
 from spdx_tools.spdx3.bump_from_spdx2.bump_utils import handle_no_assertion_or_none
 from spdx_tools.spdx3.bump_from_spdx2.checksum import bump_checksum
-from spdx_tools.spdx3.bump_from_spdx2.license_expression import bump_license_expression_or_none_or_no_assertion
 from spdx_tools.spdx3.bump_from_spdx2.message import print_missing_conversion
 from spdx_tools.spdx3.model import (
-    CreationInfo,
     ExternalIdentifier,
     ExternalIdentifierType,
     ExternalMap,
@@ -19,7 +17,7 @@ from spdx_tools.spdx3.model import (
 from spdx_tools.spdx3.model.software import Package, SoftwarePurpose
 from spdx_tools.spdx3.payload import Payload
 from spdx_tools.spdx.model import Actor as Spdx2_Actor
-from spdx_tools.spdx.model import ExternalDocumentRef, ExtractedLicensingInfo, SpdxNoAssertion
+from spdx_tools.spdx.model import ExternalDocumentRef, SpdxNoAssertion
 from spdx_tools.spdx.model.package import ExternalPackageRef
 from spdx_tools.spdx.model.package import Package as Spdx2_Package
 from spdx_tools.spdx.spdx_element_utils import get_full_element_spdx_id
@@ -28,9 +26,7 @@ from spdx_tools.spdx.spdx_element_utils import get_full_element_spdx_id
 def bump_package(
     spdx2_package: Spdx2_Package,
     payload: Payload,
-    creation_info: CreationInfo,
     document_namespace: str,
-    extracted_licensing_info: List[ExtractedLicensingInfo],
     external_document_refs: List[ExternalDocumentRef],
     imports: List[ExternalMap],
 ):
@@ -46,11 +42,11 @@ def bump_package(
     download_location = handle_no_assertion_or_none(spdx2_package.download_location, "package.download_location")
     print_missing_conversion("package2.file_name", 0, "https://github.com/spdx/spdx-3-model/issues/83")
     if isinstance(spdx2_package.supplier, Spdx2_Actor):
-        supplied_by_spdx_id = [bump_actor(spdx2_package.supplier, payload, creation_info, document_namespace)]
+        supplied_by_spdx_id = [bump_actor(spdx2_package.supplier, payload, document_namespace)]
     else:
         supplied_by_spdx_id = None
     if isinstance(spdx2_package.originator, Spdx2_Actor):
-        originated_by_spdx_id = [bump_actor(spdx2_package.originator, payload, creation_info, document_namespace)]
+        originated_by_spdx_id = [bump_actor(spdx2_package.originator, payload, document_namespace)]
     else:
         originated_by_spdx_id = None
     print_missing_conversion("package2.files_analyzed", 0, "https://github.com/spdx/spdx-3-model/issues/84")
@@ -58,12 +54,6 @@ def bump_package(
         "package2.verification_code", 1, "of IntegrityMethod, https://github.com/spdx/spdx-3-model/issues/85"
     )
     integrity_methods = [bump_checksum(checksum) for checksum in spdx2_package.checksums]
-    declared_license = bump_license_expression_or_none_or_no_assertion(
-        spdx2_package.license_declared, extracted_licensing_info
-    )
-    concluded_license = bump_license_expression_or_none_or_no_assertion(
-        spdx2_package.license_concluded, extracted_licensing_info
-    )
     copyright_text = None
     if isinstance(spdx2_package.copyright_text, str):
         copyright_text = spdx2_package.copyright_text
@@ -99,7 +89,6 @@ def bump_package(
         Package(
             spdx_id,
             spdx2_package.name,
-            creation_info=creation_info,
             summary=spdx2_package.summary,
             description=spdx2_package.description,
             comment=spdx2_package.comment,
@@ -119,8 +108,6 @@ def bump_package(
             source_info=spdx2_package.source_info,
             copyright_text=copyright_text,
             attribution_text=", ".join(spdx2_package.attribution_texts),
-            concluded_license=concluded_license,
-            declared_license=declared_license,
         )
     )
 

--- a/src/spdx_tools/spdx3/bump_from_spdx2/relationship.py
+++ b/src/spdx_tools/spdx3/bump_from_spdx2/relationship.py
@@ -7,13 +7,7 @@ import sys
 from beartype.typing import Dict, List, Optional, Tuple, Union
 
 from spdx_tools.spdx3.bump_from_spdx2.message import print_missing_conversion
-from spdx_tools.spdx3.model import (
-    CreationInfo,
-    LifecycleScopeType,
-    Relationship,
-    RelationshipCompleteness,
-    RelationshipType,
-)
+from spdx_tools.spdx3.model import LifecycleScopeType, Relationship, RelationshipCompleteness, RelationshipType
 from spdx_tools.spdx3.model.software import (
     DependencyConditionalityType,
     SoftwareDependencyLinkType,
@@ -158,12 +152,11 @@ relationship_mapping: Dict[
 def bump_relationships(
     spdx2_relationships: List[Spdx2_Relationship],
     payload: Payload,
-    creation_info: CreationInfo,
     document_namespace: str,
 ):
     generated_relationships: Dict[Tuple[str, str], List[Relationship]] = {}
     for counter, spdx2_relationship in enumerate(spdx2_relationships):
-        relationship = bump_relationship(spdx2_relationship, creation_info, document_namespace, counter)
+        relationship = bump_relationship(spdx2_relationship, document_namespace, counter)
         if relationship:
             generated_relationships.setdefault(
                 (relationship.from_element, relationship.relationship_type.name), []
@@ -178,7 +171,6 @@ def bump_relationships(
 
 def bump_relationship(
     spdx2_relationship: Spdx2_Relationship,
-    creation_info: CreationInfo,
     document_namespace: str,
     counter: int,
 ) -> Optional[Union[Relationship, SoftwareDependencyRelationship]]:
@@ -208,7 +200,6 @@ def bump_relationship(
             f"{document_namespace}#{from_element}",
             relationship_type,
             [f"{document_namespace}#{t}" for t in to],
-            creation_info=creation_info,
             comment=spdx2_relationship.comment,
             completeness=completeness,
             scope=parameters.get("scope"),
@@ -221,7 +212,6 @@ def bump_relationship(
         f"{document_namespace}#{from_element}",
         relationship_type,
         [f"{document_namespace}#{t}" for t in to],
-        creation_info=creation_info,
         comment=spdx2_relationship.comment,
         completeness=completeness,
     )

--- a/src/spdx_tools/spdx3/bump_from_spdx2/snippet.py
+++ b/src/spdx_tools/spdx3/bump_from_spdx2/snippet.py
@@ -3,13 +3,12 @@
 # SPDX-License-Identifier: Apache-2.0
 from beartype.typing import List, Optional, Tuple
 
-from spdx_tools.spdx3.bump_from_spdx2.license_expression import bump_license_expression_or_none_or_no_assertion
 from spdx_tools.spdx3.bump_from_spdx2.message import print_missing_conversion
-from spdx_tools.spdx3.model import CreationInfo, ExternalMap
+from spdx_tools.spdx3.model import ExternalMap
 from spdx_tools.spdx3.model.positive_integer_range import PositiveIntegerRange
 from spdx_tools.spdx3.model.software import Snippet
 from spdx_tools.spdx3.payload import Payload
-from spdx_tools.spdx.model import ExternalDocumentRef, ExtractedLicensingInfo, SpdxNoAssertion
+from spdx_tools.spdx.model import ExternalDocumentRef, SpdxNoAssertion
 from spdx_tools.spdx.model.snippet import Snippet as Spdx2_Snippet
 from spdx_tools.spdx.spdx_element_utils import get_full_element_spdx_id
 
@@ -21,9 +20,7 @@ def bump_integer_range(spdx2_range: Optional[Tuple[int, int]]) -> PositiveIntege
 def bump_snippet(
     spdx2_snippet: Spdx2_Snippet,
     payload: Payload,
-    creation_info: CreationInfo,
     document_namespace: str,
-    extracted_licensing_info: List[ExtractedLicensingInfo],
     external_document_refs: List[ExternalDocumentRef],
     imports: List[ExternalMap],
 ):
@@ -37,9 +34,6 @@ def bump_snippet(
         )
 
     print_missing_conversion("snippet.file_spdx_id", 0, "https://github.com/spdx/spdx-3-model/issues/130")
-    concluded_license = bump_license_expression_or_none_or_no_assertion(
-        spdx2_snippet.license_concluded, extracted_licensing_info
-    )
     copyright_text = None
     if isinstance(spdx2_snippet.copyright_text, str):
         copyright_text = spdx2_snippet.copyright_text
@@ -54,13 +48,11 @@ def bump_snippet(
     payload.add_element(
         Snippet(
             spdx_id=spdx_id,
-            creation_info=creation_info,
             name=spdx2_snippet.name,
             comment=spdx2_snippet.comment,
             byte_range=bump_integer_range(spdx2_snippet.byte_range),
             line_range=bump_integer_range(spdx2_snippet.line_range),
             copyright_text=copyright_text,
             attribution_text=", ".join(spdx2_snippet.attribution_texts),
-            concluded_license=concluded_license,
         )
     )

--- a/src/spdx_tools/spdx3/bump_from_spdx2/spdx_document.py
+++ b/src/spdx_tools/spdx3/bump_from_spdx2/spdx_document.py
@@ -37,9 +37,7 @@ def bump_spdx_document(document: Spdx2_Document) -> Payload:
         bump_package(
             spdx2_package,
             payload,
-            creation_info,
             document_namespace,
-            document.extracted_licensing_info,
             document.creation_info.external_document_refs,
             spdx_document.imports,
         )
@@ -48,9 +46,7 @@ def bump_spdx_document(document: Spdx2_Document) -> Payload:
         bump_file(
             spdx2_file,
             payload,
-            creation_info,
             document_namespace,
-            document.extracted_licensing_info,
             document.creation_info.external_document_refs,
             spdx_document.imports,
         )
@@ -59,14 +55,12 @@ def bump_spdx_document(document: Spdx2_Document) -> Payload:
         bump_snippet(
             spdx2_snippet,
             payload,
-            creation_info,
             document_namespace,
-            document.extracted_licensing_info,
             document.creation_info.external_document_refs,
             spdx_document.imports,
         )
 
-    bump_relationships(document.relationships, payload, creation_info, document_namespace)
+    bump_relationships(document.relationships, payload, document_namespace)
 
     for counter, spdx2_annotation in enumerate(document.annotations):
         bump_annotation(spdx2_annotation, payload, creation_info, document_namespace, counter)

--- a/src/spdx_tools/spdx3/bump_from_spdx2/spdx_document.py
+++ b/src/spdx_tools/spdx3/bump_from_spdx2/spdx_document.py
@@ -9,7 +9,9 @@ from spdx_tools.spdx3.bump_from_spdx2.relationship import bump_relationships
 from spdx_tools.spdx3.bump_from_spdx2.snippet import bump_snippet
 from spdx_tools.spdx3.model import CreationInfo, SpdxDocument
 from spdx_tools.spdx3.payload import Payload
+from spdx_tools.spdx.model import RelationshipType
 from spdx_tools.spdx.model.document import Document as Spdx2_Document
+from spdx_tools.spdx.model.relationship_filters import filter_by_type_and_origin
 
 """ We want to implement a bump_from_spdx2 from the data model in src.spdx to the data model in src.spdx3.
     As there are many fundamental differences between these version we want each bump_from_spdx2 method to take
@@ -20,6 +22,13 @@ def bump_spdx_document(document: Spdx2_Document) -> Payload:
     payload = Payload()
     document_namespace: str = document.creation_info.document_namespace
     spdx_document: SpdxDocument = bump_creation_info(document.creation_info, payload)
+    spdx_document.root_element = [
+        f"{document_namespace}#{relationship.related_spdx_element_id}"
+        for relationship in filter_by_type_and_origin(
+            document.relationships, RelationshipType.DESCRIBES, "SPDXRef-DOCUMENT"
+        )
+    ]
+
     creation_info: CreationInfo = spdx_document.creation_info
 
     payload.add_element(spdx_document)

--- a/tests/spdx3/bump/test_actor_bump.py
+++ b/tests/spdx3/bump/test_actor_bump.py
@@ -40,7 +40,7 @@ def test_bump_actor(actor_type, actor_name, actor_mail, element_type, new_spdx_i
     creation_info = CreationInfo(Version("3.0.0"), datetime(2022, 1, 1), ["Creator"], [], [ProfileIdentifier.CORE])
     actor = Actor(actor_type, actor_name, actor_mail)
 
-    agent_or_tool_id = bump_actor(actor, payload, creation_info, document_namespace)
+    agent_or_tool_id = bump_actor(actor, payload, document_namespace, creation_info)
     agent_or_tool = payload.get_element(agent_or_tool_id)
 
     assert isinstance(agent_or_tool, element_type)
@@ -68,7 +68,7 @@ def test_bump_actor_that_already_exists():
     )
 
     actor = Actor(ActorType.PERSON, name, "some@mail.com")
-    agent_spdx_id = bump_actor(actor, payload, creation_info_new, document_namespace)
+    agent_spdx_id = bump_actor(actor, payload, document_namespace, creation_info_new)
 
     # assert that there is only one Person in the payload
     assert (

--- a/tests/spdx3/bump/test_file_bump.py
+++ b/tests/spdx3/bump/test_file_bump.py
@@ -1,33 +1,27 @@
 # SPDX-FileCopyrightText: 2023 spdx contributors
 #
 # SPDX-License-Identifier: Apache-2.0
-from unittest import mock
 
 from spdx_tools.spdx3.bump_from_spdx2.file import bump_file
 from spdx_tools.spdx3.model import Hash, HashAlgorithm
-from spdx_tools.spdx3.model.licensing import ConjunctiveLicenseSet, ListedLicense
 from spdx_tools.spdx3.model.software import File
 from spdx_tools.spdx3.payload import Payload
 from spdx_tools.spdx.model.file import File as Spdx2_File
 from tests.spdx.fixtures import file_fixture
 
 
-@mock.patch("spdx_tools.spdx3.model.CreationInfo", autospec=True)
-def test_bump_file(creation_info):
+def test_bump_file():
     payload = Payload()
     document_namespace = "https://doc.namespace"
     spdx2_file: Spdx2_File = file_fixture()
     integrity_method: Hash = Hash(HashAlgorithm.SHA1, "71c4025dd9897b364f3ebbb42c484ff43d00791c")
     expected_new_file_id = f"{document_namespace}#{spdx2_file.spdx_id}"
 
-    bump_file(spdx2_file, payload, creation_info, document_namespace, [], [], [])
+    bump_file(spdx2_file, payload, document_namespace, [], [])
     file = payload.get_element(expected_new_file_id)
 
     assert isinstance(file, File)
     assert file.spdx_id == expected_new_file_id
     assert file.verified_using == [integrity_method]
-    assert file.concluded_license == ConjunctiveLicenseSet(
-        [ListedLicense("MIT", "MIT", "blank"), ListedLicense("GPL-2.0-only", "GPL-2.0-only", "blank")]
-    )
     assert file.copyright_text == spdx2_file.copyright_text
     assert file.attribution_text == spdx2_file.attribution_texts[0]

--- a/tests/spdx3/bump/test_package_bump.py
+++ b/tests/spdx3/bump/test_package_bump.py
@@ -7,13 +7,11 @@ import pytest
 
 from spdx_tools.spdx3.bump_from_spdx2.package import bump_package
 from spdx_tools.spdx3.model import ExternalIdentifier, ExternalIdentifierType, ExternalReference, ExternalReferenceType
-from spdx_tools.spdx3.model.licensing import ConjunctiveLicenseSet, ListedLicense
 from spdx_tools.spdx3.model.software import Package
 from spdx_tools.spdx3.payload import Payload
 from spdx_tools.spdx.model import SpdxNoAssertion
 from spdx_tools.spdx.model.package import ExternalPackageRef, ExternalPackageRefCategory
 from spdx_tools.spdx.model.package import Package as Spdx2_Package
-from tests.spdx3.fixtures import creation_info_fixture
 from tests.spdx.fixtures import actor_fixture, package_fixture
 
 
@@ -45,7 +43,7 @@ def test_bump_package(originator, expected_originator, supplier, expected_suppli
     )
     expected_new_package_id = f"{document_namespace}#{spdx2_package.spdx_id}"
 
-    bump_package(spdx2_package, payload, creation_info_fixture(), document_namespace, [], [], [])
+    bump_package(spdx2_package, payload, document_namespace, [], [])
     package = payload.get_element(expected_new_package_id)
 
     assert isinstance(package, Package)
@@ -68,12 +66,6 @@ def test_bump_package(originator, expected_originator, supplier, expected_suppli
     assert package.valid_until_time == spdx2_package.valid_until_date
     assert package.copyright_text == spdx2_package.copyright_text
     assert package.attribution_text == spdx2_package.attribution_texts[0]
-    assert package.concluded_license == ConjunctiveLicenseSet(
-        [ListedLicense("MIT", "MIT", "blank"), ListedLicense("GPL-2.0-only", "GPL-2.0-only", "blank")]
-    )
-    assert package.declared_license == ConjunctiveLicenseSet(
-        [ListedLicense("MIT", "MIT", "blank"), ListedLicense("GPL-2.0-only", "GPL-2.0-only", "blank")]
-    )
 
 
 def test_bump_of_single_purl_without_comment():
@@ -86,7 +78,7 @@ def test_bump_of_single_purl_without_comment():
     )
     expected_new_package_id = f"{document_namespace}#{spdx2_package.spdx_id}"
 
-    bump_package(spdx2_package, payload, creation_info_fixture(), document_namespace, [], [], [])
+    bump_package(spdx2_package, payload, document_namespace, [], [])
     package = payload.get_element(expected_new_package_id)
 
     assert package.package_url == "purl_locator"
@@ -104,7 +96,7 @@ def test_bump_of_single_purl_with_comment():
     )
     expected_new_package_id = f"{document_namespace}#{spdx2_package.spdx_id}"
 
-    bump_package(spdx2_package, payload, creation_info_fixture(), document_namespace, [], [], [])
+    bump_package(spdx2_package, payload, document_namespace, [], [])
     package = payload.get_element(expected_new_package_id)
 
     assert package.package_url is None
@@ -125,7 +117,7 @@ def test_bump_of_multiple_purls():
     )
     expected_new_package_id = f"{document_namespace}#{spdx2_package.spdx_id}"
 
-    bump_package(spdx2_package, payload, creation_info_fixture(), document_namespace, [], [], [])
+    bump_package(spdx2_package, payload, document_namespace, [], [])
     package = payload.get_element(expected_new_package_id)
 
     assert package.package_url is None

--- a/tests/spdx3/bump/test_relationship_bump.py
+++ b/tests/spdx3/bump/test_relationship_bump.py
@@ -1,8 +1,6 @@
 # SPDX-FileCopyrightText: 2023 spdx contributors
 #
 # SPDX-License-Identifier: Apache-2.0
-from unittest import mock
-
 from spdx_tools.spdx3.bump_from_spdx2.relationship import bump_relationship, bump_relationships
 from spdx_tools.spdx3.model import Relationship, RelationshipCompleteness, RelationshipType
 from spdx_tools.spdx3.payload import Payload
@@ -11,31 +9,28 @@ from spdx_tools.spdx.model import SpdxNoAssertion, SpdxNone
 from tests.spdx.fixtures import relationship_fixture
 
 
-@mock.patch("spdx_tools.spdx3.model.CreationInfo", autospec=True)
-def test_relationship_bump(creation_info):
+def test_relationship_bump():
     spdx2_relationship = relationship_fixture()
     document_namespace = "https://doc.namespace"
-    relationship = bump_relationship(spdx2_relationship, creation_info, document_namespace, 1)
+    relationship = bump_relationship(spdx2_relationship, document_namespace, 1)
 
     assert relationship == Relationship(
         f"{document_namespace}#SPDXRef-Relationship-1",
         f"{document_namespace}#{spdx2_relationship.spdx_element_id}",
         RelationshipType.DESCRIBES,
         [f"{document_namespace}#{spdx2_relationship.related_spdx_element_id}"],
-        creation_info=creation_info,
         comment=spdx2_relationship.comment,
     )
 
 
-@mock.patch("spdx_tools.spdx3.model.CreationInfo", autospec=True)
-def test_relationships_bump(creation_info):
+def test_relationships_bump():
     relationships = [
         relationship_fixture(comment=None),
         relationship_fixture(related_spdx_element_id="SPDXRef-Package", comment=None),
     ]
     payload = Payload()
     document_namespace = "https://doc.namespace"
-    bump_relationships(relationships, payload, creation_info, document_namespace)
+    bump_relationships(relationships, payload, document_namespace)
 
     assert payload.get_element(f"{document_namespace}#SPDXRef-Relationship-1") == Relationship(
         f"{document_namespace}#SPDXRef-Relationship-1",
@@ -45,12 +40,10 @@ def test_relationships_bump(creation_info):
             f"{document_namespace}#{relationships[0].related_spdx_element_id}",
             f"{document_namespace}#{relationships[1].related_spdx_element_id}",
         ],
-        creation_info=creation_info,
     )
 
 
-@mock.patch("spdx_tools.spdx3.model.CreationInfo", autospec=True)
-def test_relationships_bump_with_setting_completeness(creation_info):
+def test_relationships_bump_with_setting_completeness():
     relationships = [
         relationship_fixture(related_spdx_element_id=SpdxNoAssertion()),
         relationship_fixture(related_spdx_element_id="SPDXRef-Package"),
@@ -62,14 +55,13 @@ def test_relationships_bump_with_setting_completeness(creation_info):
     ]
     payload = Payload()
     document_namespace = "https://doc.namespace"
-    bump_relationships(relationships, payload, creation_info, document_namespace)
+    bump_relationships(relationships, payload, document_namespace)
 
     assert payload.get_element(f"{document_namespace}#SPDXRef-Relationship-0") == Relationship(
         f"{document_namespace}#SPDXRef-Relationship-0",
         f"{document_namespace}#{relationships[0].spdx_element_id}",
         RelationshipType.DESCRIBES,
         [],
-        creation_info=creation_info,
         comment=relationships[0].comment,
         completeness=RelationshipCompleteness.NOASSERTION,
     )
@@ -78,7 +70,6 @@ def test_relationships_bump_with_setting_completeness(creation_info):
         f"{document_namespace}#{relationships[1].spdx_element_id}",
         RelationshipType.DESCRIBES,
         [f"{document_namespace}#{relationships[1].related_spdx_element_id}"],
-        creation_info=creation_info,
         comment=relationships[1].comment,
     )
     assert payload.get_element(f"{document_namespace}#SPDXRef-Relationship-2") == Relationship(
@@ -86,13 +77,11 @@ def test_relationships_bump_with_setting_completeness(creation_info):
         f"{document_namespace}#{relationships[2].spdx_element_id}",
         RelationshipType.SPECIFICATION_FOR,
         [],
-        creation_info=creation_info,
         completeness=RelationshipCompleteness.COMPLETE,
     )
 
 
-@mock.patch("spdx_tools.spdx3.model.CreationInfo", autospec=True)
-def test_undefined_relationship_bump(creation_info, capsys):
+def test_undefined_relationship_bump(capsys):
     relationships = [
         relationship_fixture(
             related_spdx_element_id=SpdxNoAssertion(), relationship_type=Spdx2_RelationshipType.CONTAINED_BY
@@ -101,7 +90,7 @@ def test_undefined_relationship_bump(creation_info, capsys):
     ]
     payload = Payload()
     document_namespace = "https://doc.namespace"
-    bump_relationships(relationships, payload, creation_info, document_namespace)
+    bump_relationships(relationships, payload, document_namespace)
 
     captured = capsys.readouterr()
     assert (

--- a/tests/spdx3/bump/test_snippet_bump.py
+++ b/tests/spdx3/bump/test_snippet_bump.py
@@ -1,30 +1,24 @@
 # SPDX-FileCopyrightText: 2023 spdx contributors
 #
 # SPDX-License-Identifier: Apache-2.0
-from unittest import mock
 
 from spdx_tools.spdx3.bump_from_spdx2.snippet import bump_snippet
-from spdx_tools.spdx3.model.licensing import ConjunctiveLicenseSet, ListedLicense
 from spdx_tools.spdx3.model.software import Snippet
 from spdx_tools.spdx3.payload import Payload
 from spdx_tools.spdx.model.snippet import Snippet as Spdx2_Snippet
 from tests.spdx.fixtures import snippet_fixture
 
 
-@mock.patch("spdx_tools.spdx3.model.CreationInfo", autospec=True)
-def test_bump_snippet(creation_info):
+def test_bump_snippet():
     payload = Payload()
     document_namespace = "https://doc.namespace"
     spdx2_snippet: Spdx2_Snippet = snippet_fixture()
     expected_new_snippet_id = f"{document_namespace}#{spdx2_snippet.spdx_id}"
 
-    bump_snippet(spdx2_snippet, payload, creation_info, document_namespace, [], [], [])
+    bump_snippet(spdx2_snippet, payload, document_namespace, [], [])
     snippet = payload.get_element(expected_new_snippet_id)
 
     assert isinstance(snippet, Snippet)
     assert snippet.spdx_id == expected_new_snippet_id
     assert snippet.copyright_text == spdx2_snippet.copyright_text
     assert snippet.attribution_text == spdx2_snippet.attribution_texts[0]
-    assert snippet.concluded_license == ConjunctiveLicenseSet(
-        [ListedLicense("MIT", "MIT", "blank"), ListedLicense("GPL-2.0-only", "GPL-2.0-only", "blank")]
-    )


### PR DESCRIPTION
This fixes a few things that came up during writing the parser:
- use `rootElement` for DESCRIBED Elements
- add the correct URI prefix before the data license
- don't write `CreationInfo` on all Elements (may have to change in the future depending on how we will treat this)
- don't convert licenses (licensing format has yet to be decided on)