### PR TITLE
Create new Github workflow to build a release when a tag is pushed

### DIFF
--- a/.github/workflows/check_codestyle.yml
+++ b/.github/workflows/check_codestyle.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2023 spdx contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 name: Run Linter
 
 on:

--- a/.github/workflows/install_and_test.yml
+++ b/.github/workflows/install_and_test.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2023 spdx contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 name: Install and Test
 
 on:

--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2023 spdx contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 name: Prepare release
 
 on:

--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -1,0 +1,40 @@
+name: Prepare release
+
+on:
+  push:
+    tags: [ 'v*.*.*']
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.7'
+      - name: Set up dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install --upgrade setuptools wheel setuptools_scm build twine
+          python -m pip install -e .
+        shell: bash
+      - name: Build wheel
+        run: python -m build
+      - name: Verify build
+        run: twine check dist/*
+      - name: Create build archive
+        uses: a7ul/tar-action@v1.1.0
+        with:
+          command: c
+          files: dist
+          outPath: spdx_tools_dist.tar.gz
+      - name: Create GitHub release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: spdx_tools_dist.tar.gz
+          generate_release_notes: true
+          draft: true


### PR DESCRIPTION
Whenever a versioned tag (vX.Y.Z) is pushed, this workflow will build the python wheel, create a new GitHub release for the pushed tag and attach the build output to the release.
This is a first step towards automating our release process. In the future, we may want to directly upload the release to PyPI.

Sample run: https://github.com/fholger/tools-python/actions/runs/5332473607/jobs/9661695249
Sample created release: https://github.com/fholger/tools-python/releases/tag/v0.8.1a4