### PR TITLE
Add missing license headers in source files

### DIFF
--- a/src/spdx_tools/common/typing/constructor_type_errors.py
+++ b/src/spdx_tools/common/typing/constructor_type_errors.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2023 spdx contributors
+#
+# SPDX-License-Identifier: Apache-2.0
 from beartype.typing import List
 
 

--- a/src/spdx_tools/spdx/parser/parse_anything.py
+++ b/src/spdx_tools/spdx/parser/parse_anything.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 # Copyright (c) spdx contributors
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/spdx_tools/spdx/writer/tagvalue/annotation_writer.py
+++ b/src/spdx_tools/spdx/writer/tagvalue/annotation_writer.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 #  Copyright (c) 2022 spdx contributors
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/src/spdx_tools/spdx/writer/tagvalue/checksum_writer.py
+++ b/src/spdx_tools/spdx/writer/tagvalue/checksum_writer.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 #  Copyright (c) 2022 spdx contributors
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/src/spdx_tools/spdx/writer/tagvalue/creation_info_writer.py
+++ b/src/spdx_tools/spdx/writer/tagvalue/creation_info_writer.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 #  Copyright (c) 2022 spdx contributors
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/src/spdx_tools/spdx/writer/tagvalue/extracted_licensing_info_writer.py
+++ b/src/spdx_tools/spdx/writer/tagvalue/extracted_licensing_info_writer.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 #  Copyright (c) 2022 spdx contributors
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/src/spdx_tools/spdx/writer/tagvalue/file_writer.py
+++ b/src/spdx_tools/spdx/writer/tagvalue/file_writer.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 #  Copyright (c) 2022 spdx contributors
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/src/spdx_tools/spdx/writer/tagvalue/package_writer.py
+++ b/src/spdx_tools/spdx/writer/tagvalue/package_writer.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 #  Copyright (c) 2022 spdx contributors
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/src/spdx_tools/spdx/writer/tagvalue/relationship_writer.py
+++ b/src/spdx_tools/spdx/writer/tagvalue/relationship_writer.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 #  Copyright (c) 2022 spdx contributors
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/src/spdx_tools/spdx/writer/tagvalue/snippet_writer.py
+++ b/src/spdx_tools/spdx/writer/tagvalue/snippet_writer.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 #  Copyright (c) 2022 spdx contributors
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/src/spdx_tools/spdx/writer/tagvalue/tagvalue_writer.py
+++ b/src/spdx_tools/spdx/writer/tagvalue/tagvalue_writer.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 #  Copyright (c) 2022 spdx contributors
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/src/spdx_tools/spdx/writer/tagvalue/tagvalue_writer_helper_functions.py
+++ b/src/spdx_tools/spdx/writer/tagvalue/tagvalue_writer_helper_functions.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 #  Copyright (c) 2022 spdx contributors
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/src/spdx_tools/spdx3/model/__init__.py
+++ b/src/spdx_tools/spdx3/model/__init__.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2023 spdx contributors
+#
+# SPDX-License-Identifier: Apache-2.0
 from spdx_tools.spdx3.model.profile_identifier import ProfileIdentifier
 from spdx_tools.spdx3.model.creation_info import CreationInfo
 from spdx_tools.spdx3.model.integrity_method import IntegrityMethod

--- a/src/spdx_tools/spdx3/model/dataset/__init__.py
+++ b/src/spdx_tools/spdx3/model/dataset/__init__.py
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: 2023 spdx contributors
+#
+# SPDX-License-Identifier: Apache-2.0
 from spdx_tools.spdx3.model.dataset.dataset import Dataset, DatasetAvailabilityType, ConfidentialityLevelType

--- a/src/spdx_tools/spdx3/model/software/__init__.py
+++ b/src/spdx_tools/spdx3/model/software/__init__.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2023 spdx contributors
+#
+# SPDX-License-Identifier: Apache-2.0
 from spdx_tools.spdx3.model.software.software_purpose import SoftwarePurpose
 from spdx_tools.spdx3.model.software.file import File
 from spdx_tools.spdx3.model.software.package import Package

--- a/src/spdx_tools/spdx3/writer/console/__init__.py
+++ b/src/spdx_tools/spdx3/writer/console/__init__.py
@@ -1,2 +1,5 @@
+# SPDX-FileCopyrightText: 2023 spdx contributors
+#
+# SPDX-License-Identifier: Apache-2.0
 """ This is a temporary package to write the implemented model of spdx_tools.spdx3.0 to console. As soon as
     serialization formats are properly defined this package can be deleted."""

--- a/src/spdx_tools/spdx3/writer/console/tool_writer.py
+++ b/src/spdx_tools/spdx3/writer/console/tool_writer.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 #  Copyright (c) 2023 spdx contributors
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/tests/spdx/test_cli.py
+++ b/tests/spdx/test_cli.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2023 spdx contributors
+#
+# SPDX-License-Identifier: Apache-2.0
 import os
 
 import pytest


### PR DESCRIPTION
Inspired by #689 I ran the reuse tool on the code base. It reported a number of missing license and/or copyright headers in our Python source files, which this PR addresses.

Note that reuse also complains about a number of auxiliary files, so this PR does not achieve full compliance on its own.