### PR TITLE
Generate API docs with pdoc

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,47 @@
+# SPDX-FileCopyrightText: 2023 spdx contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+name: Generate API docs
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          sudo apt-get install graphviz-dev
+          pip install -e ".[test,graph_generation]"
+          pip install pdoc
+      - name: Generate docs
+        run: pdoc spdx_tools -o docs/
+      - name: Upload docs as artifact
+        uses: actions/upload-pages-artifact@v1
+        with:
+          path: docs/
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        name: Deploy docs to GitHub pages
+        uses: actions/deploy-pages@v2


### PR DESCRIPTION
This PR adds a workflow to auto-generate API docs with [pdoc](https://pdoc.dev/docs/pdoc.html) and publish them to GitHub pages.

Actions run: https://github.com/fholger/tools-python/actions/runs/5409859727
Preview: https://frydrych.org/tools-python/spdx_tools.html

While the generated docs do not offer much benefit over browsing the actual code in your IDE, they do provide a searchable and easily navigable web interface to look at the library structure. Given that it costs us virtually nothing to provide it, I believe we might as well have it.

Note: the GitHub pages configuration in the repository settings needs to be updated once to have the GH Pages deployed from a GitHub action instead of branch.