### PR TITLE
[issue-718] ignore microseconds during datetime conversion to ISO string

### DIFF
--- a/src/spdx_tools/spdx/datetime_conversions.py
+++ b/src/spdx_tools/spdx/datetime_conversions.py
@@ -16,4 +16,7 @@ def datetime_to_iso_string(date: datetime) -> str:
     """
     Return an ISO-8601 representation of a datetime object.
     """
+    if date.microsecond != 0:
+        date = date.replace(microsecond=0)  # SPDX does not support microseconds
+
     return date.isoformat() + "Z"

--- a/tests/spdx/test_datetime_conversions.py
+++ b/tests/spdx/test_datetime_conversions.py
@@ -12,6 +12,10 @@ def test_datetime_to_iso_string():
     assert datetime_to_iso_string(datetime(2022, 12, 13, 1, 2, 3)) == "2022-12-13T01:02:03Z"
 
 
+def test_datetime_to_iso_string_with_microseconds():
+    assert datetime_to_iso_string(datetime(2022, 12, 13, 1, 2, 3, 666666)) == "2022-12-13T01:02:03Z"
+
+
 def test_datetime_from_str():
     date_str = "2010-03-04T05:45:11Z"
 


### PR DESCRIPTION
fixes #718