### PR TITLE
SPDX3: rename ProfileIdentifier to ProfileIdentifierType

### DIFF
--- a/src/spdx_tools/spdx3/bump_from_spdx2/creation_info.py
+++ b/src/spdx_tools/spdx3/bump_from_spdx2/creation_info.py
@@ -7,7 +7,7 @@ from semantic_version import Version
 from spdx_tools.spdx3.bump_from_spdx2.actor import bump_actor
 from spdx_tools.spdx3.bump_from_spdx2.external_document_ref import bump_external_document_ref
 from spdx_tools.spdx3.bump_from_spdx2.message import print_missing_conversion
-from spdx_tools.spdx3.model import CreationInfo, ProfileIdentifier, SpdxDocument
+from spdx_tools.spdx3.model import CreationInfo, ProfileIdentifierType, SpdxDocument
 from spdx_tools.spdx3.payload import Payload
 from spdx_tools.spdx.model.actor import ActorType
 from spdx_tools.spdx.model.document import CreationInfo as Spdx2_CreationInfo
@@ -40,7 +40,7 @@ def bump_creation_info(spdx2_creation_info: Spdx2_CreationInfo, payload: Payload
         spec_version=Version("3.0.0"),
         created=spdx2_creation_info.created,
         created_by=[],
-        profile=[ProfileIdentifier.CORE, ProfileIdentifier.SOFTWARE, ProfileIdentifier.LICENSING],
+        profile=[ProfileIdentifierType.CORE, ProfileIdentifierType.SOFTWARE, ProfileIdentifierType.LICENSING],
         data_license="https://spdx.org/licenses/" + spdx2_creation_info.data_license,
     )
 

--- a/src/spdx_tools/spdx3/model/__init__.py
+++ b/src/spdx_tools/spdx3/model/__init__.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2023 spdx contributors
 #
 # SPDX-License-Identifier: Apache-2.0
-from spdx_tools.spdx3.model.profile_identifier import ProfileIdentifier
+from spdx_tools.spdx3.model.profile_identifier import ProfileIdentifierType
 from spdx_tools.spdx3.model.creation_info import CreationInfo
 from spdx_tools.spdx3.model.integrity_method import IntegrityMethod
 from spdx_tools.spdx3.model.hash import Hash, HashAlgorithm

--- a/src/spdx_tools/spdx3/model/creation_info.py
+++ b/src/spdx_tools/spdx3/model/creation_info.py
@@ -9,7 +9,7 @@ from semantic_version import Version
 
 from spdx_tools.common.typing.dataclass_with_properties import dataclass_with_properties
 from spdx_tools.common.typing.type_checks import check_types_and_set_values
-from spdx_tools.spdx3.model import ProfileIdentifier
+from spdx_tools.spdx3.model import ProfileIdentifierType
 
 
 @dataclass_with_properties
@@ -17,7 +17,7 @@ class CreationInfo:
     spec_version: Version
     created: datetime
     created_by: List[str]  # SPDXID of Agents
-    profile: List[ProfileIdentifier]
+    profile: List[ProfileIdentifierType]
     data_license: Optional[str] = "CC0-1.0"
     created_using: List[str] = field(default_factory=list)  # SPDXID of Tools
     comment: Optional[str] = None
@@ -27,7 +27,7 @@ class CreationInfo:
         spec_version: Version,
         created: datetime,
         created_by: List[str],
-        profile: List[ProfileIdentifier],
+        profile: List[ProfileIdentifierType],
         data_license: Optional[str] = "CC0-1.0",
         created_using: List[str] = None,
         comment: Optional[str] = None,

--- a/src/spdx_tools/spdx3/model/profile_identifier.py
+++ b/src/spdx_tools/spdx3/model/profile_identifier.py
@@ -4,7 +4,7 @@
 from enum import Enum, auto
 
 
-class ProfileIdentifier(Enum):
+class ProfileIdentifierType(Enum):
     CORE = auto()
     SOFTWARE = auto()
     LICENSING = auto()

--- a/tests/spdx3/bump/test_actor_bump.py
+++ b/tests/spdx3/bump/test_actor_bump.py
@@ -13,7 +13,7 @@ from spdx_tools.spdx3.model import (
     ExternalIdentifierType,
     Organization,
     Person,
-    ProfileIdentifier,
+    ProfileIdentifierType,
     Tool,
 )
 from spdx_tools.spdx3.payload import Payload
@@ -37,7 +37,7 @@ from spdx_tools.spdx.model.actor import Actor, ActorType
 def test_bump_actor(actor_type, actor_name, actor_mail, element_type, new_spdx_id):
     payload = Payload()
     document_namespace = "https://doc.namespace"
-    creation_info = CreationInfo(Version("3.0.0"), datetime(2022, 1, 1), ["Creator"], [ProfileIdentifier.CORE])
+    creation_info = CreationInfo(Version("3.0.0"), datetime(2022, 1, 1), ["Creator"], [ProfileIdentifierType.CORE])
     actor = Actor(actor_type, actor_name, actor_mail)
 
     agent_or_tool_id = bump_actor(actor, payload, document_namespace, creation_info)
@@ -54,8 +54,8 @@ def test_bump_actor(actor_type, actor_name, actor_mail, element_type, new_spdx_i
 
 
 def test_bump_actor_that_already_exists():
-    creation_info_old = CreationInfo(Version("3.0.0"), datetime(2022, 1, 1), ["Creator"], [ProfileIdentifier.CORE])
-    creation_info_new = CreationInfo(Version("3.0.0"), datetime(2023, 2, 2), ["Creator"], [ProfileIdentifier.CORE])
+    creation_info_old = CreationInfo(Version("3.0.0"), datetime(2022, 1, 1), ["Creator"], [ProfileIdentifierType.CORE])
+    creation_info_new = CreationInfo(Version("3.0.0"), datetime(2023, 2, 2), ["Creator"], [ProfileIdentifierType.CORE])
 
     name = "some name"
     document_namespace = "https://doc.namespace"

--- a/tests/spdx3/fixtures.py
+++ b/tests/spdx3/fixtures.py
@@ -25,7 +25,7 @@ from spdx_tools.spdx3.model import (
     NamespaceMap,
     Organization,
     Person,
-    ProfileIdentifier,
+    ProfileIdentifierType,
     Relationship,
     RelationshipCompleteness,
     RelationshipType,
@@ -93,7 +93,7 @@ def creation_info_fixture(
         ["https://spdx.test/tools-python/creation_info_created_using"] if created_using is None else created_using
     )
     profile = (
-        [ProfileIdentifier.CORE, ProfileIdentifier.SOFTWARE, ProfileIdentifier.LICENSING]
+        [ProfileIdentifierType.CORE, ProfileIdentifierType.SOFTWARE, ProfileIdentifierType.LICENSING]
         if profile is None
         else profile
     )

--- a/tests/spdx3/model/test_creation_info.py
+++ b/tests/spdx3/model/test_creation_info.py
@@ -6,7 +6,7 @@ from datetime import datetime
 import pytest
 from semantic_version import Version
 
-from spdx_tools.spdx3.model import CreationInfo, ProfileIdentifier
+from spdx_tools.spdx3.model import CreationInfo, ProfileIdentifierType
 from tests.spdx3.fixtures import creation_info_fixture
 from tests.spdx3.model.model_test_utils import get_property_names
 
@@ -22,9 +22,9 @@ def test_correct_initialization():
     assert creation_info.created_by == ["https://spdx.test/tools-python/creation_info_created_by"]
     assert creation_info.created_using == ["https://spdx.test/tools-python/creation_info_created_using"]
     assert creation_info.profile == [
-        ProfileIdentifier.CORE,
-        ProfileIdentifier.SOFTWARE,
-        ProfileIdentifier.LICENSING,
+        ProfileIdentifierType.CORE,
+        ProfileIdentifierType.SOFTWARE,
+        ProfileIdentifierType.LICENSING,
     ]
     assert creation_info.data_license == "CC0-1.0"
     assert creation_info.comment == "creationInfoComment"


### PR DESCRIPTION
... to be consistent with the naming in the spec. This makes it easier to generate code working with our model as the naming is deterministic.