### PR TITLE
make relationship parsing to be more efficient through precomputation

### DIFF
--- a/src/spdx_tools/spdx/parser/jsonlikedict/relationship_parser.py
+++ b/src/spdx_tools/spdx/parser/jsonlikedict/relationship_parser.py
@@ -125,6 +125,7 @@ class RelationshipParser:
     def parse_has_files(
         self, package_dicts: List[Dict], existing_relationships: List[Relationship]
     ) -> List[Relationship]:
+        # assume existing relationships are stripped of comments
         logger = Logger()
         contains_relationships = []
         for package in package_dicts:

--- a/src/spdx_tools/spdx/parser/jsonlikedict/relationship_parser.py
+++ b/src/spdx_tools/spdx/parser/jsonlikedict/relationship_parser.py
@@ -35,26 +35,34 @@ class RelationshipParser:
         document_describes: List[str] = delete_duplicates_from_list(input_doc_dict.get("documentDescribes", []))
         doc_spdx_id: Optional[str] = input_doc_dict.get("SPDXID")
 
-        existing_relationships_without_comments: List[Relationship] = self.get_all_relationships_without_comments(relationships)
+        existing_relationships_without_comments: List[Relationship] = self.get_all_relationships_without_comments(
+            relationships
+        )
         relationships.extend(
             parse_field_or_log_error(
                 self.logger,
                 document_describes,
                 lambda x: self.parse_document_describes(
-                    doc_spdx_id=doc_spdx_id, described_spdx_ids=x, existing_relationships=existing_relationships_without_comments
+                    doc_spdx_id=doc_spdx_id,
+                    described_spdx_ids=x,
+                    existing_relationships=existing_relationships_without_comments,
                 ),
                 [],
             )
         )
 
         package_dicts: List[Dict] = input_doc_dict.get("packages", [])
-        existing_relationships_without_comments: List[Relationship] = self.get_all_relationships_without_comments(relationships)
+        existing_relationships_without_comments: List[Relationship] = self.get_all_relationships_without_comments(
+            relationships
+        )
 
         relationships.extend(
             parse_field_or_log_error(
                 self.logger,
                 package_dicts,
-                lambda x: self.parse_has_files(package_dicts=x, existing_relationships=existing_relationships_without_comments),
+                lambda x: self.parse_has_files(
+                    package_dicts=x, existing_relationships=existing_relationships_without_comments
+                ),
                 [],
             )
         )

--- a/tests/spdx/parser/all_formats/test_parse_from_file.py
+++ b/tests/spdx/parser/all_formats/test_parse_from_file.py
@@ -36,7 +36,7 @@ class TestParseFromFile:
         doc = parser.parse_from_file(
             os.path.join(os.path.dirname(__file__), f"../../data/SPDX{format_name}Example-v2.3.spdx{extension}")
         )
-        assert type(doc) == Document
+        assert isinstance(doc, Document)
         assert len(doc.annotations) == 5
         assert len(doc.files) == 5
         assert len(doc.packages) == 4
@@ -48,7 +48,7 @@ class TestParseFromFile:
         doc = parser.parse_from_file(
             os.path.join(os.path.dirname(__file__), f"../../data/SPDX{format_name}Example-v2.2.spdx{extension}")
         )
-        assert type(doc) == Document
+        assert isinstance(doc, Document)
         assert len(doc.annotations) == 5
         assert len(doc.files) == 4
         assert len(doc.packages) == 4

--- a/tests/spdx/parser/jsonlikedict/test_dict_parsing_functions.py
+++ b/tests/spdx/parser/jsonlikedict/test_dict_parsing_functions.py
@@ -34,7 +34,7 @@ def test_invalid_json_str_to_enum(invalid_json_str, expected_message):
 def test_parse_field_or_no_assertion(input_str, expected_type):
     resulting_value = parse_field_or_no_assertion(input_str, lambda x: x)
 
-    assert type(resulting_value) == expected_type
+    assert isinstance(resulting_value, expected_type)
 
 
 @pytest.mark.parametrize(
@@ -43,4 +43,4 @@ def test_parse_field_or_no_assertion(input_str, expected_type):
 def test_parse_field_or_no_assertion_or_none(input_str, expected_type):
     resulting_value = parse_field_or_no_assertion_or_none(input_str, lambda x: x)
 
-    assert type(resulting_value) == expected_type
+    assert isinstance(resulting_value, expected_type)

--- a/tests/spdx/parser/jsonlikedict/test_relationship_parser.py
+++ b/tests/spdx/parser/jsonlikedict/test_relationship_parser.py
@@ -169,6 +169,7 @@ def test_parse_has_files():
 @pytest.mark.parametrize(
     "has_files,existing_relationships,contains_relationships",
     [
+        # pre-requisite for parse_has_files requires that comments in relationships are stripped
         (
             ["SPDXRef-File1", "SPDXRef-File2"],
             [
@@ -176,7 +177,6 @@ def test_parse_has_files():
                     spdx_element_id="SPDXRef-Package",
                     relationship_type=RelationshipType.CONTAINS,
                     related_spdx_element_id="SPDXRef-File1",
-                    comment="This relationship has a comment.",
                 ),
                 Relationship(
                     spdx_element_id="SPDXRef-File2",


### PR DESCRIPTION
I ran into long times parsing big SPDX documents that use the `hasFiles` shortcut fields. 

Handling of `hasFiles` field results in the list of all relationships being iterated through for each package. This change moves the creation of `existing_relationships_without_comments` to the top level in `parse_all_relationships`. 

Ideally, it would be nice to use a set for more optimal look-up (but that requires Relationship to be hashable, and probably would like a bit more input on how'd you think that would be better implemented). 

```
before:
python3 src/spdx_tools/spdx/clitools/pyspdxtools.py -i   617.18s user 0.53s system 99% cpu 10:17.96 total
after:
python3 spdx_tools/spdx/clitools/pyspdxtools.py -i  2> /dev/null  316.08s user 0.46s system 99% cpu 5:17.73 total
```