### PR TITLE
expand url regex to allow for userinfo

### DIFF
--- a/src/spdx_tools/spdx/validation/uri_validators.py
+++ b/src/spdx_tools/spdx/validation/uri_validators.py
@@ -9,7 +9,8 @@ from uritools import isabsuri, urisplit
 
 url_pattern = (
     "(http:\\/\\/www\\.|https:\\/\\/www\\.|http:\\/\\/|https:\\/\\/|ssh:\\/\\/|git:\\/\\/|svn:\\/\\/|sftp:"
-    "\\/\\/|ftp:\\/\\/)?[a-z0-9]+([\\-\\.]{1}[a-z0-9]+){0,100}\\.[a-z]{2,5}(:[0-9]{1,5})?(\\/.*)?"
+    "\\/\\/|ftp:\\/\\/)?([\\w\\-.!~*'()%;:&=+$,]+@)?[a-z0-9]+([\\-\\.]{1}[a-z0-9]+){0,100}\\.[a-z]{2,5}"
+    "(:[0-9]{1,5})?(\\/.*)?"
 )
 supported_download_repos: str = "(git|hg|svn|bzr)"
 git_pattern = "(git\\+git@[a-zA-Z0-9\\.\\-]+:[a-zA-Z0-9/\\\\.@\\-]+)"

--- a/tests/spdx/validation/test_uri_validators.py
+++ b/tests/spdx/validation/test_uri_validators.py
@@ -34,6 +34,7 @@ def test_invalid_url(input_value):
         "git+https://git.myproject.org/MyProject.git",
         "git+http://git.myproject.org/MyProject",
         "git+ssh://git.myproject.org/MyProject.git",
+        "git+ssh://git@git.myproject.org/MyProject.git",
         "git+git://git.myproject.org/MyProject",
         "git+git@git.myproject.org:MyProject",
         "git://git.myproject.org/MyProject#src/somefile.c",


### PR DESCRIPTION
Closes #745 

Expands the URL regex used in `validate_download_location` to allow for a [`userinfo`](https://datatracker.ietf.org/doc/html/rfc2396#section-3.2.2) specifier to appear before the hostname. Previously, a value like `git+ssh://git@git.myproject.org/MyProject.git` would fail validation due to the inclusion of the `git@` portion of the URL.

In the URI spec ([RFC2396](https://datatracker.ietf.org/doc/html/rfc2396)), the `userinfo` portion of the server component is defined as follow:

```
userinfo      = *( unreserved | escaped | ";" | ":" | "&" | "=" | "+" | "$" | "," )
unreserved    = alphanum | mark
alphanum      = alpha | digit
alpha         = lowalpha | upalpha

lowalpha      = "a" | "b" | "c" | "d" | "e" | "f" | "g" | "h" | "i" |
                "j" | "k" | "l" | "m" | "n" | "o" | "p" | "q" | "r" |
                "s" | "t" | "u" | "v" | "w" | "x" | "y" | "z"
upalpha       = "A" | "B" | "C" | "D" | "E" | "F" | "G" | "H" | "I" |
                "J" | "K" | "L" | "M" | "N" | "O" | "P" | "Q" | "R" |
                "S" | "T" | "U" | "V" | "W" | "X" | "Y" | "Z"
digit         = "0" | "1" | "2" | "3" | "4" | "5" | "6" | "7" |
                "8" | "9"
mark          = "-" | "_" | "." | "!" | "~" | "*" | "'" |
                "(" | ")"
escaped       = "%" hex hex
hex           = digit | "A" | "B" | "C" | "D" | "E" | "F" |
                        "a" | "b" | "c" | "d" | "e" | "f"
```

I translated this into the following regex:

```regex
[\w\-.!~*'()%;:&=+$,]+
```

and then placed it as an optional prefix to the hostname (with a trailing `@` character)

```regex
([\w\-.!~*'()%;:&=+$,]+@)?
```