### PR TITLE
implement recommended UTF-8 encoding for reading and writing SPDX files

### DIFF
--- a/src/spdx_tools/spdx/parser/json/json_parser.py
+++ b/src/spdx_tools/spdx/parser/json/json_parser.py
@@ -2,7 +2,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 import json
-from typing import Optional
 
 from beartype.typing import Dict
 
@@ -10,7 +9,7 @@ from spdx_tools.spdx.model import Document
 from spdx_tools.spdx.parser.jsonlikedict.json_like_dict_parser import JsonLikeDictParser
 
 
-def parse_from_file(file_name: str, encoding: Optional[str] = None) -> Document:
+def parse_from_file(file_name: str, encoding: str = "utf-8") -> Document:
     with open(file_name, encoding=encoding) as file:
         input_doc_as_dict: Dict = json.load(file)
 

--- a/src/spdx_tools/spdx/parser/parse_anything.py
+++ b/src/spdx_tools/spdx/parser/parse_anything.py
@@ -9,7 +9,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Optional
+import logging
 
 from spdx_tools.spdx.formats import FileFormat, file_name_to_format
 from spdx_tools.spdx.parser.json import json_parser
@@ -19,7 +19,12 @@ from spdx_tools.spdx.parser.xml import xml_parser
 from spdx_tools.spdx.parser.yaml import yaml_parser
 
 
-def parse_file(file_name: str, encoding: Optional[str] = None):
+def parse_file(file_name: str, encoding: str = "utf-8"):
+    if encoding != "utf-8":
+        logging.warning(
+            "It's recommended to use the UTF-8 encoding for any SPDX file. Consider changing the encoding of the file."
+        )
+
     input_format = file_name_to_format(file_name)
     if input_format == FileFormat.RDF_XML:
         return rdf_parser.parse_from_file(file_name, encoding)

--- a/src/spdx_tools/spdx/parser/rdf/rdf_parser.py
+++ b/src/spdx_tools/spdx/parser/rdf/rdf_parser.py
@@ -1,8 +1,6 @@
 # SPDX-FileCopyrightText: 2023 spdx contributors
 #
 # SPDX-License-Identifier: Apache-2.0
-from typing import Optional
-
 from beartype.typing import Any, Dict
 from rdflib import RDF, Graph
 
@@ -24,7 +22,7 @@ from spdx_tools.spdx.parser.rdf.snippet_parser import parse_snippet
 from spdx_tools.spdx.rdfschema.namespace import SPDX_NAMESPACE
 
 
-def parse_from_file(file_name: str, encoding: Optional[str] = None) -> Document:
+def parse_from_file(file_name: str, encoding: str = "utf-8") -> Document:
     graph = Graph()
     with open(file_name, encoding=encoding) as file:
         graph.parse(file, format="xml")

--- a/src/spdx_tools/spdx/parser/tagvalue/tagvalue_parser.py
+++ b/src/spdx_tools/spdx/parser/tagvalue/tagvalue_parser.py
@@ -1,13 +1,11 @@
 # SPDX-FileCopyrightText: 2023 spdx contributors
 #
 # SPDX-License-Identifier: Apache-2.0
-from typing import Optional
-
 from spdx_tools.spdx.model import Document
 from spdx_tools.spdx.parser.tagvalue.parser import Parser
 
 
-def parse_from_file(file_name: str, encoding: Optional[str] = None) -> Document:
+def parse_from_file(file_name: str, encoding: str = "utf-8") -> Document:
     parser = Parser()
     with open(file_name, encoding=encoding) as file:
         data = file.read()

--- a/src/spdx_tools/spdx/parser/xml/xml_parser.py
+++ b/src/spdx_tools/spdx/parser/xml/xml_parser.py
@@ -1,8 +1,6 @@
 # SPDX-FileCopyrightText: 2023 spdx contributors
 #
 # SPDX-License-Identifier: Apache-2.0
-from typing import Optional
-
 import xmltodict
 from beartype.typing import Any, Dict
 
@@ -38,7 +36,7 @@ LIST_LIKE_FIELDS = [
 ]
 
 
-def parse_from_file(file_name: str, encoding: Optional[str] = None) -> Document:
+def parse_from_file(file_name: str, encoding: str = "utf-8") -> Document:
     with open(file_name, encoding=encoding) as file:
         parsed_xml: Dict = xmltodict.parse(file.read(), encoding="utf-8")
 

--- a/src/spdx_tools/spdx/parser/yaml/yaml_parser.py
+++ b/src/spdx_tools/spdx/parser/yaml/yaml_parser.py
@@ -1,8 +1,6 @@
 # SPDX-FileCopyrightText: 2023 spdx contributors
 #
 # SPDX-License-Identifier: Apache-2.0
-from typing import Optional
-
 import yaml
 from beartype.typing import Dict
 
@@ -10,7 +8,7 @@ from spdx_tools.spdx.model import Document
 from spdx_tools.spdx.parser.jsonlikedict.json_like_dict_parser import JsonLikeDictParser
 
 
-def parse_from_file(file_name: str, encoding: Optional[str] = None) -> Document:
+def parse_from_file(file_name: str, encoding: str = "utf-8") -> Document:
     with open(file_name, encoding=encoding) as file:
         input_doc_as_dict: Dict = yaml.safe_load(file)
 

--- a/src/spdx_tools/spdx/writer/json/json_writer.py
+++ b/src/spdx_tools/spdx/writer/json/json_writer.py
@@ -34,5 +34,5 @@ def write_document_to_file(
     converter: DocumentConverter = None,
     drop_duplicates: bool = True,
 ):
-    with open(file_name, "w") as out:
+    with open(file_name, "w", encoding="utf-8") as out:
         write_document_to_stream(document, out, validate, converter, drop_duplicates)

--- a/src/spdx_tools/spdx/writer/tagvalue/tagvalue_writer.py
+++ b/src/spdx_tools/spdx/writer/tagvalue/tagvalue_writer.py
@@ -35,7 +35,7 @@ def write_document_to_stream(document: Document, stream: TextIO, validate: bool 
 
 
 def write_document_to_file(document: Document, file_name: str, validate: bool = True, drop_duplicates: bool = True):
-    with open(file_name, "w") as out:
+    with open(file_name, "w", encoding="utf-8") as out:
         write_document_to_stream(document, out, validate, drop_duplicates)
 
 

--- a/src/spdx_tools/spdx/writer/xml/xml_writer.py
+++ b/src/spdx_tools/spdx/writer/xml/xml_writer.py
@@ -33,5 +33,5 @@ def write_document_to_file(
     converter: DocumentConverter = None,
     drop_duplicates: bool = True,
 ):
-    with open(file_name, "w") as out:
+    with open(file_name, "w", encoding="utf-8") as out:
         write_document_to_stream(document, out, validate, converter, drop_duplicates)

--- a/src/spdx_tools/spdx/writer/yaml/yaml_writer.py
+++ b/src/spdx_tools/spdx/writer/yaml/yaml_writer.py
@@ -33,5 +33,5 @@ def write_document_to_file(
     converter: DocumentConverter = None,
     drop_duplicates: bool = True,
 ):
-    with open(file_name, "w") as out:
+    with open(file_name, "w", encoding="utf-8") as out:
         write_document_to_stream(document, out, validate, converter, drop_duplicates)

--- a/tests/spdx/writer/json/test_json_writer.py
+++ b/tests/spdx/writer/json/test_json_writer.py
@@ -21,10 +21,12 @@ def test_write_json(temporary_file_path: str):
     document = document_fixture()
     write_document_to_file(document, temporary_file_path, validate=True)
 
-    with open(temporary_file_path) as written_file:
+    with open(temporary_file_path, encoding="utf-8") as written_file:
         written_json = json.load(written_file)
 
-    with open(os.path.join(os.path.dirname(__file__), "expected_results", "expected.json")) as expected_file:
+    with open(
+        os.path.join(os.path.dirname(__file__), "expected_results", "expected.json"), encoding="utf-8"
+    ) as expected_file:
         expected_json = json.load(expected_file)
 
     assert written_json == expected_json


### PR DESCRIPTION
#755

The `rdf_writer` open the file with "wb" and therefore does not support encoding.