### PR TITLE
fix(validation): also allow URLs in download locations

### DIFF
--- a/src/spdx_tools/spdx/validation/uri_validators.py
+++ b/src/spdx_tools/spdx/validation/uri_validators.py
@@ -28,8 +28,8 @@ def validate_url(url: str) -> List[str]:
 
 
 def validate_download_location(location: str) -> List[str]:
-    if not re.match(download_location_pattern, location):
-        return [f"must be a valid download location according to the specification, but is: {location}"]
+    if not (validate_url(location) == [] or re.match(download_location_pattern, location)):
+        return [f"must be a valid URL or download location according to the specification, but is: {location}"]
 
     return []
 

--- a/tests/spdx/validation/test_uri_validators.py
+++ b/tests/spdx/validation/test_uri_validators.py
@@ -18,6 +18,8 @@ from spdx_tools.spdx.validation.uri_validators import validate_download_location
 )
 def test_valid_url(input_value):
     assert validate_url(input_value) == []
+    # URLs are also valid download locations:
+    assert validate_download_location(input_value) == []
 
 
 # TODO: more negative examples: https://github.com/spdx/tools-python/issues/377
@@ -92,7 +94,7 @@ def test_valid_package_download_location(input_value):
 )
 def test_invalid_package_download_location(input_value):
     assert validate_download_location(input_value) == [
-        f"must be a valid download location according to the specification, but is: {input_value}"
+        f"must be a valid URL or download location according to the specification, but is: {input_value}"
     ]
 
 


### PR DESCRIPTION
All URLs are valid download locations.

This closes  #761 and #762.