### PR TITLE
[issue-771] fix license expression error handling in tag-value parser

### DIFF
--- a/src/spdx_tools/spdx/parser/tagvalue/parser.py
+++ b/src/spdx_tools/spdx/parser/tagvalue/parser.py
@@ -14,7 +14,7 @@
 import re
 
 from beartype.typing import Any, Dict, List
-from license_expression import get_spdx_licensing
+from license_expression import ExpressionError, get_spdx_licensing
 from ply import yacc
 from ply.yacc import LRParser
 
@@ -233,7 +233,13 @@ class Parser:
 
     @grammar_rule("license_or_no_assertion_or_none : LINE")
     def p_license(self, p):
-        p[0] = get_spdx_licensing().parse(p[1])
+        try:
+            p[0] = get_spdx_licensing().parse(p[1])
+        except ExpressionError as err:
+            error_message = f"Error while parsing license expression: {p[1]}"
+            if err.args:
+                error_message += f": {err.args[0]}"
+            self.current_element["logger"].append(error_message)
 
     @grammar_rule("actor_or_no_assertion : PERSON_VALUE\n | ORGANIZATION_VALUE")
     def p_actor_values(self, p):

--- a/tests/spdx/parser/tagvalue/test_tag_value_parser.py
+++ b/tests/spdx/parser/tagvalue/test_tag_value_parser.py
@@ -98,3 +98,41 @@ def test_document_with_mixed_values():
         "Element Package is not the current element in scope, probably the expected "
         "tag to start the element (PackageName) is missing. Line: 4"
     ]
+
+
+def test_faulty_license_expression():
+    parser = Parser()
+    document_str = "\n".join(
+        [
+            f"SPDXID:{DOCUMENT_SPDX_ID}",
+            "FileName: File with faulty license expression",
+            "SPDXID: SPDXRef-File",
+            "FileChecksum: SHA1: d6a770ba38583ed4bb4525bd96e50461655d2759",
+            "LicenseConcluded: LicenseRef-foo/bar",
+            "PackageName: Package with faulty license expression",
+            "SPDXID: SPDXRef-Package",
+            "PackageDownloadLocation: www.download.com",
+            "PackageLicenseConcluded: LicenseRef-bar/foo",
+            "SnippetSPDXID: SPDXRef-Snippet",
+            "SnippetName: Snippet with faulty license expression",
+            "SnippetLicenseConcluded: LicenseRef-foo/foo",
+        ]
+    )
+
+    with pytest.raises(SPDXParsingError) as err:
+        parser.parse(document_str)
+
+    assert err.value.get_messages() == [
+        'Error while parsing File: ["Error while parsing license expression: '
+        "LicenseRef-foo/bar: Invalid license key: the valid characters are: letters "
+        "and numbers, underscore, dot, colon or hyphen signs and spaces: "
+        "'LicenseRef-foo/bar'\"]",
+        'Error while parsing Package: ["Error while parsing license expression: '
+        "LicenseRef-bar/foo: Invalid license key: the valid characters are: letters "
+        "and numbers, underscore, dot, colon or hyphen signs and spaces: "
+        "'LicenseRef-bar/foo'\"]",
+        'Error while parsing Snippet: ["Error while parsing license expression: '
+        "LicenseRef-foo/foo: Invalid license key: the valid characters are: letters "
+        "and numbers, underscore, dot, colon or hyphen signs and spaces: "
+        "'LicenseRef-foo/foo'\"]",
+    ]


### PR DESCRIPTION
fixes #771