### PR TITLE
[issue-774] fix tag-value output when related_spdx_element_id is "NONE" or "NOASSERTION"

### DIFF
--- a/src/spdx_tools/spdx/writer/tagvalue/tagvalue_writer_helper_functions.py
+++ b/src/spdx_tools/spdx/writer/tagvalue/tagvalue_writer_helper_functions.py
@@ -83,7 +83,9 @@ def scan_relationships(
     files_by_spdx_id = {file.spdx_id: file for file in files}
     packages_spdx_ids = [package.spdx_id for package in packages]
     for relationship in relationships:
-        if (
+        if relationship.related_spdx_element_id in [SpdxNoAssertion(), SpdxNone()]:
+            relationships_to_write.append(relationship)
+        elif (
             relationship.relationship_type == RelationshipType.CONTAINS
             and relationship.spdx_element_id in packages_spdx_ids
             and relationship.related_spdx_element_id in files_by_spdx_id.keys()

--- a/tests/spdx/writer/tagvalue/test_tagvalue_writer_helper_functions.py
+++ b/tests/spdx/writer/tagvalue/test_tagvalue_writer_helper_functions.py
@@ -5,7 +5,7 @@ from unittest.mock import MagicMock, call, mock_open, patch
 
 import pytest
 
-from spdx_tools.spdx.model import ActorType, RelationshipType, SpdxNoAssertion
+from spdx_tools.spdx.model import ActorType, RelationshipType, SpdxNoAssertion, SpdxNone
 from spdx_tools.spdx.writer.tagvalue.tagvalue_writer_helper_functions import scan_relationships, write_actor
 from tests.spdx.fixtures import actor_fixture, file_fixture, package_fixture, relationship_fixture
 
@@ -16,6 +16,18 @@ def test_scan_relationships():
     packages = [package_fixture(spdx_id=first_package_spdx_id), package_fixture(spdx_id=second_package_spdx_id)]
     file_spdx_id = "SPDXRef-File"
     files = [file_fixture(spdx_id=file_spdx_id)]
+    no_assertion_relationship = relationship_fixture(
+        spdx_element_id=second_package_spdx_id,
+        relationship_type=RelationshipType.CONTAINS,
+        related_spdx_element_id=SpdxNoAssertion(),
+        comment=None,
+    )
+    none_relationship = relationship_fixture(
+        spdx_element_id=second_package_spdx_id,
+        relationship_type=RelationshipType.CONTAINS,
+        related_spdx_element_id=SpdxNone(),
+        comment=None,
+    )
     relationships = [
         relationship_fixture(
             spdx_element_id=first_package_spdx_id,
@@ -29,11 +41,13 @@ def test_scan_relationships():
             related_spdx_element_id=file_spdx_id,
             comment=None,
         ),
+        no_assertion_relationship,
+        none_relationship,
     ]
 
     relationships_to_write, contained_files_by_package_id = scan_relationships(relationships, packages, files)
 
-    assert relationships_to_write == []
+    assert relationships_to_write == [no_assertion_relationship, none_relationship]
     assert contained_files_by_package_id == {first_package_spdx_id: files, second_package_spdx_id: files}
 
 


### PR DESCRIPTION
fixes #774