### PR TITLE
Add `pre-commit` hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,7 @@
+- id: pyspdxtools
+  name: pyspdxtools
+  entry: pyspdxtools
+  language: python
+  types: [json]
+  require_serial: true
+  args: [--infile]


### PR DESCRIPTION
This is a PR for discussion :).

I was looking for a possibility to introduce some kind of automatically validation of SPDX files inside of a git repository.

I found [`pre-commit`](https://pre-commit.com), which could be a solution for my goal. It will execute the `pyspdxtools --infile` for validation.

Currenty this is working only for one file and only for *.json and not the other possible file-formats, but it's working.

Do you have interest in integrating `pre-commit`? If so, I think I will try to make this possibel.