### PR TITLE
spdx3: element_writer: switch from tab characters to two spaces

### DIFF
--- a/src/spdx_tools/spdx3/writer/console/console.py
+++ b/src/spdx_tools/spdx3/writer/console/console.py
@@ -22,6 +22,6 @@ def write_value(tag: str, value: Optional[Union[bool, str, dict, list, Enum]], o
 
 def write_and_possibly_indent(text: str, indent: bool, out: TextIO):
     if indent:
-        out.write(f"\t{text}\n")
+        out.write(f"  {text}\n")
     else:
         out.write(f"{text}\n")

--- a/tests/spdx3/writer/tag_value/test_write_document.py
+++ b/tests/spdx3/writer/tag_value/test_write_document.py
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: 2024 spdx contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+import io
+from datetime import datetime
+
+from semantic_version import Version
+
+from spdx_tools.spdx3.model import CreationInfo, ProfileIdentifierType, SpdxDocument
+from spdx_tools.spdx3.writer.console.spdx_document_writer import write_spdx_document
+
+
+def test_render_creation_info():
+    fake_datetime = datetime(year=2024, month=1, day=1)
+    spec_version = Version("3.0.0")
+    creation_info = CreationInfo(
+        spec_version=spec_version,
+        created=fake_datetime,
+        created_by=[],
+        profile=[ProfileIdentifierType.SOFTWARE],
+    )
+    spdx_document = SpdxDocument(
+        spdx_id="SPDXRef-FOO",
+        name="BAR",
+        element=[],
+        root_element=[],
+        creation_info=creation_info,
+    )
+    output_str = io.StringIO()
+    write_spdx_document(spdx_document, text_output=output_str)
+
+    assert (
+        output_str.getvalue()
+        == """\
+## SPDX Document
+SPDXID: SPDXRef-FOO
+name: BAR
+# Creation Information
+  specVersion: 3.0.0
+  created: 2024-01-01T00:00:00Z
+  profile: SOFTWARE
+  data license: CC0-1.0
+elements: 
+"""  # noqa: W291 # elements: are printed with a space
+    )


### PR DESCRIPTION
Hello everyone,

This is my first issue to this repository. I am new to SPDX and apologize for possible misunderstanding of the intentions behind the code I am modifying.

I am integrating the SPDX 3.0 export to the StrictDoc tool, see https://github.com/strictdoc-project/strictdoc/issues/1541.

The starting point for this issue is the fact that the `Creation Information` block is suddenly nested with a tab character when I try to populate an `spdx3.*.SpdxDocument` and write to a string buffer. My IDE is set up to ignore tab characters, so the output is displayed as if the indentation level was 1 character wide.

<img width="590" alt="Bildschirmfoto 2024-01-09 um 21 07 31" src="https://github.com/spdx/tools-python/assets/452547/705660f8-1624-46e7-9e77-57fb19737fe7">

In this MR, the creation info is unindented, and a test is added to demonstrate the behavior I would expect to see.

