### PR TITLE
spdx3: software_purpose: add REQUIREMENT type

### DIFF
--- a/src/spdx_tools/spdx3/model/software/software_purpose.py
+++ b/src/spdx_tools/spdx3/model/software/software_purpose.py
@@ -24,5 +24,6 @@ class SoftwarePurpose(Enum):
     OPERATING_SYSTEM = auto()
     OTHER = auto()
     PATCH = auto()
+    REQUIREMENT = auto()
     SOURCE = auto()
     TEST = auto()


### PR DESCRIPTION
This suggestion is an outcome of a recent discussion in the SPDX FuSa working group where @kestewart suggested that I should report it here directly.

I am implementing SPDX export in the StrictDoc which is a text-based requirements tool. The requirements are stored in text files, and it looks like a new software purpose `REQUIREMENT` would best match the nature of the requirements that I am modelling with SPDX snippets.

<img width="685" alt="Bildschirmfoto 2024-01-09 um 21 45 02" src="https://github.com/spdx/tools-python/assets/452547/9fb9f15c-fa48-482a-b1cd-67dd9f2779b6">

