### PR TITLE
Remove top level 'sbom' embedding

### DIFF
--- a/src/spdx_tools/spdx/parser/json/json_parser.py
+++ b/src/spdx_tools/spdx/parser/json/json_parser.py
@@ -13,4 +13,7 @@ def parse_from_file(file_name: str, encoding: str = "utf-8") -> Document:
     with open(file_name, encoding=encoding) as file:
         input_doc_as_dict: Dict = json.load(file)
 
+    if 'sbom' in input_doc_as_dict.keys():
+        input_doc_as_dict = input_doc_as_dict.get("sbom", {})
+
     return JsonLikeDictParser().parse(input_doc_as_dict)

--- a/src/spdx_tools/spdx/parser/json/json_parser.py
+++ b/src/spdx_tools/spdx/parser/json/json_parser.py
@@ -13,7 +13,7 @@ def parse_from_file(file_name: str, encoding: str = "utf-8") -> Document:
     with open(file_name, encoding=encoding) as file:
         input_doc_as_dict: Dict = json.load(file)
 
-    if 'sbom' in input_doc_as_dict.keys():
+    if "sbom" in input_doc_as_dict.keys():
         input_doc_as_dict = input_doc_as_dict.get("sbom", {})
 
     return JsonLikeDictParser().parse(input_doc_as_dict)


### PR DESCRIPTION
The Github spdx JSON file I got looked like this:

![CleanShot 2024-06-29 at 23 18 17@2x](https://github.com/spdx/tools-python/assets/72429/dbc6b363-5ebb-4263-841a-02c45ef78077)

The nesting trips up the parser entirely but is easily fixed.