### PR TITLE
typing: fix dataclass_with_properties for static type checkers

### DIFF
--- a/src/spdx_tools/common/typing/dataclass_with_properties.py
+++ b/src/spdx_tools/common/typing/dataclass_with_properties.py
@@ -1,12 +1,14 @@
 # SPDX-FileCopyrightText: 2022 spdx contributors
 #
 # SPDX-License-Identifier: Apache-2.0
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+from typing import dataclass_transform
 
 from beartype import beartype
 from beartype.roar import BeartypeCallHintException
 
 
+@dataclass_transform(field_specifiers=(field,))
 def dataclass_with_properties(cls):
     """Decorator to generate a dataclass with properties out of the class' value:type list.
     Their getters and setters will be subjected to the @typechecked decorator to ensure type conformity."""


### PR DESCRIPTION
**Purpose of this PR:**

Currently, all `model` in the codebase are implemented as `dataclass` with additional functionality provided by `dataclass_with_properties`. However, this approach causes static type checkers to fail in recognizing the `dataclass` structure.

To resolve this, I've introduced [typing.dataclass_transform](https://typing.readthedocs.io/en/latest/spec/dataclasses.html), which allows static type checkers to properly recognize and work with the enhanced `dataclasses`. This should improve type safety and make the code more robust from a type-checking perspective.



**Demonstration:** 

Content of `test.py`:
```python

import datetime

from spdx_tools.spdx.model import CreationInfo


def demo() -> CreationInfo:
    return CreationInfo(
        spdx_version="SPDX-2.3",
        spdx_id="SPDXRef-DOCUMENT",
        name="name",
        document_namespace="https://testdomain.com",
        creators=[],
        created=datetime.datetime.now()
    )

if __name__ == "__main__":
    demo()
```

Without this fix:
```shell
tools-python ❯ .venv/bin/pyright test.py
tools-python/test.py
  tools-python/test.py:6:15 - error: Expected class but received "(type[_T@dataclass]) -> type[_T@dataclass]" (reportGeneralTypeIssues)
  tools-python/test.py:8:22 - error: Expected 1 more positional argument (reportCallIssue)
2 errors, 0 warnings, 0 informations 
```

With this fix:
```shell
tools-python ❯ .venv/bin/pyright test.py
0 errors, 0 warnings, 0 informations 
```

