### PR TITLE
Add return type Document for parse_file()

### DIFF
--- a/src/spdx_tools/spdx/parser/parse_anything.py
+++ b/src/spdx_tools/spdx/parser/parse_anything.py
@@ -12,6 +12,7 @@
 import logging
 
 from spdx_tools.spdx.formats import FileFormat, file_name_to_format
+from spdx_tools.spdx.model import Document
 from spdx_tools.spdx.parser.json import json_parser
 from spdx_tools.spdx.parser.rdf import rdf_parser
 from spdx_tools.spdx.parser.tagvalue import tagvalue_parser
@@ -19,7 +20,7 @@ from spdx_tools.spdx.parser.xml import xml_parser
 from spdx_tools.spdx.parser.yaml import yaml_parser
 
 
-def parse_file(file_name: str, encoding: str = "utf-8"):
+def parse_file(file_name: str, encoding: str = "utf-8") -> Document:
     if encoding != "utf-8":
         logging.warning(
             "It's recommended to use the UTF-8 encoding for any SPDX file. Consider changing the encoding of the file."


### PR DESCRIPTION
Add a return type to `spdx.parser.parse_anything.parse_file` function.

Since all `parse_from_file()` functions from
- `rdf_parser`
- `tagvalue_parser`
- `json_parser`
- `xml_parser` and
- `yaml_parser`

that `parse_file()` is calling, are returning `Document`,
it should be safe to declare that `parse_file()` return `Document` as well.

This will assist type checking.