### PR TITLE
Remove MANIFEST.in; Migrate to pyproject.toml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ __pycache__/
 *.out
 
 # Virtual environments
+.python-version
 .tox
 venv*
 /bin

--- a/.gitignore
+++ b/.gitignore
@@ -1,43 +1,44 @@
+# Build outputs
+/build/
+/dist*/
+*.egg-info/
+/.eggs/
+src/spdx_tools/spdx/parser/tagvalue/parsetab.py
+
+# Python cache
 __pycache__/
 *.py[cod]
 *.out
-/build/
-/dist*/
-/tmp/
-src/spdx_tools/spdx/parser/tagvalue/parsetab.py
-/.cache/
 
+# Virtual environments
 .tox
 venv*
-
-# virtualenv
 /bin
+/include
+/Include
 /lib
 /Lib
 /local
 /local/
-/.eggs/
-*.egg-info/
-/Include
-/include
-/pip-selfcheck.json
-.Python
 /share/
 
 # IDEs
+.idea
 .project
 .pydevproject
-.idea
-org.eclipse.core.resources.prefs
 .vscode
-.pytest_cache
+org.eclipse.core.resources.prefs
 
-# Installer logs
-pip-log.txt
-
-# Unit test / coverage reports
+# Testing and type checking
 .cache
 .coverage
 .coverage.*
-nosetests.xml
+.mypy_cache
+.pytest_cache
 htmlcov
+
+# OS temporary files
+*.*~
+._*
+.DS_Store
+/tmp/

--- a/.python-version
+++ b/.python-version
@@ -1,0 +1,1 @@
+tools-python

--- a/.python-version
+++ b/.python-version
@@ -1,1 +1,0 @@
-tools-python

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,16 +1,1 @@
-graft examples
-graft src
-graft tests
-
 prune src/spdx_tools.egg-info
-
-include .gitignore
-include README.md
-include CHANGELOG.md
-include CONTRIBUTING.md
-include DOCUMENTATION.md
-include LICENSE
-include setup.py
-include pyproject.toml
-
-global-exclude *.py[co] __pycache__ *.*~ .DS_Store .pytest_cache .mypy_cache


### PR DESCRIPTION
Remove MANIFEST.in and migrate to pyproject.toml

- Consolidate config files for maintainability
- With the use of setuptools_scm, all files that are tracked with the version control system will be included in the distribution anyway -- so there's no need to declared "graft/include" in the MANIFEST.in.
- The side effect of completely remove MANIFEST.in is the egg-info will be included. As setuptools can't be configured to prune src/spdx_tools.egg-info via pyproject.toml config.
  - However, the inclusion of egg-info is actually a standard practice (setuptools itself also include this information).
  - The additional size of sdist when include the egg-info is 5.6 kbytes (704,357 vs 698,744 bytes).
  - If needed, we can also include a minimal MANIFEST.in with one line:
    ```
    prune src/spdx_tools.egg-info
    ```
    to exclude the egg-info from sdist

Modernize .gitignore

- Remove .Python, /pip-selfcheck.json, pip-log.txt -- from Python 2 era and obsoleted pip (that is no longer supported the minimum Python 3.10 requirement of current spdx-tools library)
- Group by category and sort alphabetically