### PR TITLE
Update Debian stdeb.cfg - Targets Bookworm

### DIFF
--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -1,4 +1,15 @@
 [DEFAULT]
-Depends = python-rdflib (>= 4.1.2), python-ply (>= 3.4)
-Copyright-File = LICENSE 
-
+# beartype is not packaged in Debian Trixie/Bookworm; install via pip.
+# semantic_version is not packaged in Debian Trixie; install via pip.
+Depends3 =
+    # python3-beartype, # Trixie
+    python3-click,
+    python3-license-expression,
+    python3-ply,
+    python3-rdflib,
+    # python3-semantic-version, # Sid
+    python3-uritools,
+    python3-xmltodict,
+    python3-yaml
+X-Python3-Version = >= 3.10
+Copyright-File = LICENSE

--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -1,13 +1,13 @@
 [DEFAULT]
-# beartype is not packaged in Debian Trixie/Bookworm; install via pip.
-# semantic_version is not packaged in Debian Trixie; install via pip.
+# beartype is not packaged in Debian 13; install via pip.
+# semantic-version is not packaged in Debian 12 and 13; install via pip.
 Depends3 =
-    # python3-beartype, # Trixie
+    # python3-beartype, # Available in Debian 13
     python3-click,
     python3-license-expression,
     python3-ply,
     python3-rdflib,
-    # python3-semantic-version, # Sid
+    # python3-semantic-version, # Avaiable in Debian Sid
     python3-uritools,
     python3-xmltodict,
     python3-yaml


### PR DESCRIPTION
Update stdeb.cfg file to use Debian Python 3 package names.

This stdeb.cfg should work with Debian 12 (Bookworm) which End of Life is 10 June 2026.

From https://www.debian.org/releases/

| Version | Code Name | Release Date | End of Life (EOL) | End of LTS | End of ELTS | Status |
|-|-|-|-|-|-|-|
| 13 | [Trixie](https://www.debian.org/releases/trixie/) | 2025-08-09 | 2028-08-09 | 2030-06-30 | 2035-06-30 | Current "stable" release |
| 12 | [Bookworm](https://www.debian.org/releases/bookworm/) | 2023-06-10 | 2026-06-10 | 2028-06-30 | 2033-06-30 | Current "oldstable" release |
| 11 | [Bullseye](https://www.debian.org/releases/bullseye/) | 2021-08-14 | 2024-08-14 | 2026-08-31 | 2031-06-30 | Current "oldoldstable" release, under [LTS support](https://wiki.debian.org/LTS) |