### PR TITLE
fix: allow underscores in git PackageDownloadLocation validation

### DIFF
--- a/src/spdx_tools/spdx/validation/uri_validators.py
+++ b/src/spdx_tools/spdx/validation/uri_validators.py
@@ -15,7 +15,7 @@ url_pattern = (
 url_pattern_ignore_case = re.compile(url_pattern, re.IGNORECASE)
 
 supported_download_repos: str = "(git|hg|svn|bzr)"
-git_pattern = "(git\\+git@[a-zA-Z0-9\\.\\-]+:[a-zA-Z0-9/\\\\.@\\-]+)"
+git_pattern = "(git\\+git@[a-zA-Z0-9\\.\\-]+:[a-zA-Z0-9/\\\\.@\\-_]+)"
 bazaar_pattern = "(bzr\\+lp:[a-zA-Z0-9\\.\\-]+)"
 download_location_pattern = (
     "^(((" + supported_download_repos + "\\+)?" + url_pattern + ")|" + git_pattern + "|" + bazaar_pattern + ")$"

--- a/tests/spdx/validation/test_uri_validators.py
+++ b/tests/spdx/validation/test_uri_validators.py
@@ -4,7 +4,11 @@
 
 import pytest
 
-from spdx_tools.spdx.validation.uri_validators import validate_download_location, validate_uri, validate_url
+from spdx_tools.spdx.validation.uri_validators import (
+    validate_download_location,
+    validate_uri,
+    validate_url,
+)
 
 
 @pytest.mark.parametrize(
@@ -81,6 +85,7 @@ def test_invalid_url(input_value):
         "bzr+http://bzr.myproject.org/MyProject/trunk@v1.0",
         "bzr+https://bzr.myproject.org/MyProject/trunk@2019#src/somefile.c",
         "BZR+HTTPS://BZR.MYPROJECT.ORG/MYPROJECT/TRUNK@2019#SRC/SOMEFILE.C",
+        "git+git@github.com:zephyrproject-rtos/CMSIS_6@06d952b6713a2ca41c9224a62075e4059402a151-off",
     ],
 )
 def test_valid_package_download_location(input_value):
@@ -118,7 +123,8 @@ def test_valid_uri(input_value):
 
 
 @pytest.mark.parametrize(
-    "input_value", ["/invalid/uri", "http//uri", "http://some#uri", "some/uri", "some weird test"]
+    "input_value",
+    ["/invalid/uri", "http//uri", "http://some#uri", "some/uri", "some weird test"],
 )
 def test_invalid_uri(input_value):
     message = validate_uri(input_value)
@@ -128,7 +134,10 @@ def test_invalid_uri(input_value):
     ]
 
 
-@pytest.mark.parametrize("input_value", ["://spdx.org/spdxdocs/spdx-tools-v1.2-3F2504E0-4F89-41D3-9A0C-0305E82..."])
+@pytest.mark.parametrize(
+    "input_value",
+    ["://spdx.org/spdxdocs/spdx-tools-v1.2-3F2504E0-4F89-41D3-9A0C-0305E82..."],
+)
 @pytest.mark.skip(
     "validate_uri() seems to invalidate URIs without scheme, so it does not run into this case. But I'm not sure yet "
     "if this covers all scheme-less examples."


### PR DESCRIPTION
## Summary
- allow underscores in the repository path segment of `git+git@` download locations
- the `git_pattern` regex in `uri_validators.py` was missing `_` in its allowed character class, causing valid URLs like `git+git@github.com:zephyrproject-rtos/CMSIS_6@...` to fail validation
- consistent with the identical fix applied in the Java counterpart (`spdx-java-model-2_X#33`)

## Testing
- added a regression test using the exact example from the issue
- `pytest -vvs` passes all 69 URI validator tests
- `isort`, `black`, `flake8` all clean

Closes #860