### PR TITLE
[issue-820] Support patch version numbers in Version class

### DIFF
--- a/src/spdx_tools/spdx/model/version.py
+++ b/src/spdx_tools/spdx/model/version.py
@@ -8,10 +8,11 @@ from re import Pattern
 
 
 class Version:
-    VERSION_REGEX: Pattern = re.compile(r"^(\d+)\.(\d+)$")
+    VERSION_REGEX: Pattern = re.compile(r"^(\d+)\.(\d+)(?:\.(\d+))?$")
 
     major: int
     minor: int
+    patch: int | None
 
     @classmethod
     def is_valid_version_string(cls, value: str) -> bool:
@@ -25,16 +26,21 @@ class Version:
             raise ValueError(f"{value} is not a valid version string")
 
         match = cls.VERSION_REGEX.match(value)
-        return cls(int(match.group(1)), int(match.group(2)))
+        major = int(match.group(1))
+        minor = int(match.group(2))
+        patch = int(match.group(3)) if match.group(3) else None
+        return cls(major, minor, patch)
 
-    def __init__(self, major: int, minor: int):
+    def __init__(self, major: int, minor: int, patch: int | None = None):
         self.major = major
         self.minor = minor
+        self.patch = patch
 
     def __str__(self):
-        return f"{self.major}.{self.minor}"
+        patch_suffix = f".{self.patch}" if self.patch is not None else ""
+        return f"{self.major}.{self.minor}{patch_suffix}"
 
     def __eq__(self, other):
         if not isinstance(other, Version):
             return False
-        return self.major == other.major and self.minor == other.minor
+        return self.major == other.major and self.minor == other.minor and self.patch == other.patch

--- a/tests/spdx/model/test_version.py
+++ b/tests/spdx/model/test_version.py
@@ -7,7 +7,15 @@ import pytest
 from spdx_tools.spdx.model import Version
 
 
-@pytest.mark.parametrize("input_string,expected", [("1.2", Version(1, 2)), ("12.345", Version(12, 345))])
+@pytest.mark.parametrize(
+    "input_string,expected",
+    [
+        ("1.2", Version(1, 2)),
+        ("12.345", Version(12, 345)),
+        ("3.24.0", Version(3, 24, 0)),
+        ("1.2.3", Version(1, 2, 3)),
+    ],
+)
 def test_version_from_string(input_string, expected):
     assert Version.is_valid_version_string(input_string)
     version: Version = Version.from_string(input_string)


### PR DESCRIPTION
Since v3.24.0, https://github.com/spdx/license-list-data has a "patch-level" in the version (version before was "v3.23").

To parse that, allow an optional patch level in version. (and update tests)

Fixes: #820